### PR TITLE
fbsd/ena: Add missing lock upon initialization of the interface

### DIFF
--- a/kernel/fbsd/ena/ena.c
+++ b/kernel/fbsd/ena/ena.c
@@ -2276,8 +2276,11 @@ ena_init(void *arg)
 {
 	struct ena_adapter *adapter = (struct ena_adapter *)arg;
 
-	if (adapter->up == false)
+	if (adapter->up == false) {
+		sx_xlock(&adapter->ioctl_sx);
 		ena_up(adapter);
+		sx_unlock(&adapter->ioctl_sx);
+	}
 
 	return;
 }


### PR DESCRIPTION
Lack of this lock was causing crash if down was called in
parallel with the initialization routine.