### PR TITLE
fbsd/ena: remove unused statement from platform code

### DIFF
--- a/kernel/fbsd/ena/ena_com/ena_plat.h
+++ b/kernel/fbsd/ena/ena_com/ena_plat.h
@@ -139,21 +139,12 @@ extern struct ena_bus_space ebs;
 #define MAX_ERRNO 4095
 #define IS_ERR_VALUE(x) unlikely((x) <= (unsigned long)MAX_ERRNO)
 
-#define WARN_ON(condition)						\
-	do {								\
-		int __ret_warn_on = !!(condition);			\
-		if (unlikely(__ret_warn_on))				\
-			printf("%s %s", __FUNCTION__, __FILE__);	\
-		unlikely(__ret_warn_on);				\
-	} while (0)
-
 #define ENA_ASSERT(cond, format, arg...)				\
 	do {								\
 		if (unlikely(!(cond))) {				\
 			ena_trc_err(					\
 				"Assert failed on %s:%s:%d:" format,	\
 				__FILE__, __func__, __LINE__, ##arg);	\
-			WARN_ON(cond);					\
 		}							\
 	} while (0)
 


### PR DESCRIPTION
WARN_ON was only called from ENA_ASSERT macro and it was doing
almost the same thing as ENA_ASSERT. Instead of modyfing it, it is
removed.

This fix allows gcc compilation of the driver with standard
warning flags.

Submitted by: Ryan Libby <rlibby@gmail.com>