### PR TITLE
Fix build on EL7.4

### DIFF
--- a/kernel/linux/ena/kcompat.h
+++ b/kernel/linux/ena/kcompat.h
@@ -419,7 +419,7 @@ static inline int pci_enable_msix_range(struct pci_dev *dev,
 
 /*****************************************************************************/
 #if (( LINUX_VERSION_CODE < KERNEL_VERSION(3,13,8) ) && \
-     !(RHEL_RELEASE_CODE && RHEL_RELEASE_CODE <= RHEL_RELEASE_VERSION(7,3)) && \
+     !(RHEL_RELEASE_CODE && RHEL_RELEASE_CODE <= RHEL_RELEASE_VERSION(7,4)) && \
      !(SLE_VERSION_CODE && SLE_VERSION_CODE >= SLE_VERSION(12,0,0)))
 enum pkt_hash_types {
 	PKT_HASH_TYPE_NONE,	/* Undefined type */
@@ -441,7 +441,7 @@ static inline void skb_set_hash(struct sk_buff *skb, __u32 hash,
 /* for ndo_dfwd_ ops add_station, del_station and _start_xmit */
 #define HAVE_NDO_SELECT_QUEUE_ACCEL_FALLBACK
 #else
-#if !(RHEL_RELEASE_CODE && ((RHEL_RELEASE_CODE <= RHEL_RELEASE_VERSION(7,3) \
+#if !(RHEL_RELEASE_CODE && ((RHEL_RELEASE_CODE <= RHEL_RELEASE_VERSION(7,4) \
                         && RHEL_RELEASE_CODE >= RHEL_RELEASE_VERSION(7,1)) \
                         || RHEL_RELEASE_CODE < RHEL_RELEASE_VERSION(7,0))) && \
     !(UBUNTU_VERSION_CODE && UBUNTU_VERSION_CODE >= UBUNTU_VERSION(3,13,0,105))
@@ -474,7 +474,7 @@ static inline void ether_addr_copy(u8 *dst, const u8 *src)
 #if ( LINUX_VERSION_CODE >= KERNEL_VERSION(3,15,0) || \
 	(UBUNTU_VERSION_CODE && UBUNTU_VERSION_CODE > UBUNTU_VERSION(3,13,0,24))) || \
 	(SLE_VERSION_CODE && SLE_VERSION_CODE >= SLE_VERSION(12,0,0)) || \
-	(RHEL_RELEASE_CODE && ((RHEL_RELEASE_CODE <= RHEL_RELEASE_VERSION(7,3) \
+	(RHEL_RELEASE_CODE && ((RHEL_RELEASE_CODE <= RHEL_RELEASE_VERSION(7,4) \
 	                     && RHEL_RELEASE_CODE >= RHEL_RELEASE_VERSION(7,2)) \
                            || RHEL_RELEASE_CODE < RHEL_RELEASE_VERSION(7,0)))
 #else
@@ -502,7 +502,7 @@ static inline unsigned int u64_stats_fetch_begin_irq(const struct u64_stats_sync
 
 #if ( LINUX_VERSION_CODE >= KERNEL_VERSION(3,19,0) ) \
 	|| (SLE_VERSION_CODE && SLE_VERSION_CODE >= SLE_VERSION(12,0,0)) \
-	|| (RHEL_RELEASE_CODE && ((RHEL_RELEASE_CODE <= RHEL_RELEASE_VERSION(7,3) \
+	|| (RHEL_RELEASE_CODE && ((RHEL_RELEASE_CODE <= RHEL_RELEASE_VERSION(7,4) \
 	                        && RHEL_RELEASE_CODE >= RHEL_RELEASE_VERSION(7,1)) \
 	                        || RHEL_RELEASE_CODE < RHEL_RELEASE_VERSION(7,0)))
 #else


### PR DESCRIPTION
This fixes the build for EL 7.4 where I was seeing the following error:

DKMS make.log for ena-1.2.0 for kernel 3.10.0-693.el7.x86_64 (x86_64)
Thu Aug 10 23:06:10 UTC 2017
make: Entering directory `/var/lib/dkms/ena/1.2.0/build/kernel/linux/ena'
make -C /lib/modules/3.10.0-693.el7.x86_64/build M=/var/lib/dkms/ena/1.2.0/build/kernel/linux/ena modules
make[1]: Entering directory `/usr/src/kernels/3.10.0-693.el7.x86_64'
make[1]: warning: jobserver unavailable: using -j1.  Add `+' to parent make rule.
  CC [M]  /var/lib/dkms/ena/1.2.0/build/kernel/linux/ena/ena_netdev.o
In file included from /var/lib/dkms/ena/1.2.0/build/kernel/linux/ena/ena_netdev.h:44:0,
                 from /var/lib/dkms/ena/1.2.0/build/kernel/linux/ena/ena_netdev.c:53:
/var/lib/dkms/ena/1.2.0/build/kernel/linux/ena/kcompat.h:424:6: error: nested redefinition of ‘enum pkt_hash_types’
 enum pkt_hash_types {
      ^
compilation terminated due to -Wfatal-errors.
make[2]: *** [/var/lib/dkms/ena/1.2.0/build/kernel/linux/ena/ena_netdev.o] Error 1
make[1]: *** [_module_/var/lib/dkms/ena/1.2.0/build/kernel/linux/ena] Error 2
make[1]: Leaving directory `/usr/src/kernels/3.10.0-693.el7.x86_64'
make: *** [all] Error 2
make: Leaving directory `/var/lib/dkms/ena/1.2.0/build/kernel/linux/ena'
