### PR TITLE
Apply fixes from community review of the ENA FreeBSD

### DIFF
--- a/kernel/fbsd/ena/ena.h
+++ b/kernel/fbsd/ena/ena.h
@@ -70,7 +70,6 @@
 
 #define	ENA_RX_REFILL_THRESH_DIVIDER	8
 
-#define	ENA_NAME_MAX_LEN		20
 #define	ENA_IRQNAME_SIZE		40
 
 #define	ENA_PKT_MAX_BUFS 		19
@@ -240,7 +239,7 @@ struct ena_ring {
 	/* Determines if device will use LLQ or normal mode for TX */
 	enum ena_admin_placement_policy_type tx_mem_queue_type;
 	/* The maximum length the driver can push to the device (For LLQ) */
-	 uint8_t tx_max_header_size;
+	uint8_t tx_max_header_size;
 
 	struct ena_com_rx_buf_info ena_bufs[ENA_PKT_MAX_BUFS];
 

--- a/kernel/fbsd/ena/ena_com/ena_plat.h
+++ b/kernel/fbsd/ena/ena_com/ena_plat.h
@@ -250,7 +250,7 @@ static inline long PTR_ERR(const void *ptr)
 #define u8 		uint8_t
 #define u16 		uint16_t
 #define u32 		uint32_t
-#define u64 		unsigned long long
+#define u64 		uint64_t
 
 typedef struct {
 	bus_addr_t              paddr;


### PR DESCRIPTION
* Remove NULL checks for malloc with M_WAITOK.
* Do not check conditions explicitely for bool variables.
* Remove ENA_NAME_MAX_LEN.
* Remove single extra leading whitespace.
* Expand goto if retrieving RX mbuf fails.
* Fix error handling routine by assigning value to free_rx_ids instead
  of tx.
* Change M_NOWAIT to M_WAITOK on taskqueue_create_fast for alignment.
* Minor style fixes.
* Fix typo in printout.
* Cast field of the mbuf csum_flags to fix compilation error with newest
  FreeBSD kernel (from r325506).