### PR TITLE
dpdk/ena: fix RX mbuf flags settings

### DIFF
--- a/userspace/dpdk/16.04/0002-net-ena-TX-L4-offload-flags-should-not-be-set-in-RX-.patch
+++ b/userspace/dpdk/16.04/0002-net-ena-TX-L4-offload-flags-should-not-be-set-in-RX-.patch
@@ -1,0 +1,53 @@
+From 25d9cb981fbd57a4a501473eb03cab1f3c7a6795 Mon Sep 17 00:00:00 2001
+From: Rafal Kozik <rk@semihalf.com>
+Date: Tue, 9 Jan 2018 16:19:08 +0100
+Subject: [PATCH 2/2] net/ena: TX L4 offload flags should not be set in RX path
+
+Information about received packet type detected by NIC should be stored
+in packet_type field of rte_mbuf. TX L4 offload flags should not be set
+in RX path.
+Only fields that could be set in of_flags during packet receiving are
+information if L4 and L3 checksum is correct.
+
+Fixes: 1173fca25af9 ("ena: add polling-mode driver")
+---
+ drivers/net/ena/ena_ethdev.c | 10 ++++++----
+ 1 file changed, 6 insertions(+), 4 deletions(-)
+
+diff --git a/drivers/net/ena/ena_ethdev.c b/drivers/net/ena/ena_ethdev.c
+index 8823c51cf..9d677b8d7 100644
+--- a/drivers/net/ena/ena_ethdev.c
++++ b/drivers/net/ena/ena_ethdev.c
+@@ -258,16 +258,17 @@ static inline void ena_rx_mbuf_prepare(struct rte_mbuf *mbuf,
+ 				       struct ena_com_rx_ctx *ena_rx_ctx)
+ {
+ 	uint64_t ol_flags = 0;
++	uint32_t packet_type = 0;
+ 
+ 	if (ena_rx_ctx->l4_proto == ENA_ETH_IO_L4_PROTO_TCP)
+-		ol_flags |= PKT_TX_TCP_CKSUM;
++		packet_type |= RTE_PTYPE_L4_TCP;
+ 	else if (ena_rx_ctx->l4_proto == ENA_ETH_IO_L4_PROTO_UDP)
+-		ol_flags |= PKT_TX_UDP_CKSUM;
++		packet_type |= RTE_PTYPE_L4_UDP;
+ 
+ 	if (ena_rx_ctx->l3_proto == ENA_ETH_IO_L3_PROTO_IPV4)
+-		ol_flags |= PKT_TX_IPV4;
++		packet_type |= RTE_PTYPE_L3_IPV4;
+ 	else if (ena_rx_ctx->l3_proto == ENA_ETH_IO_L3_PROTO_IPV6)
+-		ol_flags |= PKT_TX_IPV6;
++		packet_type |= RTE_PTYPE_L3_IPV6;
+ 
+ 	if (unlikely(ena_rx_ctx->l4_csum_err))
+ 		ol_flags |= PKT_RX_L4_CKSUM_BAD;
+@@ -275,6 +276,7 @@ static inline void ena_rx_mbuf_prepare(struct rte_mbuf *mbuf,
+ 		ol_flags |= PKT_RX_IP_CKSUM_BAD;
+ 
+ 	mbuf->ol_flags = ol_flags;
++	mbuf->packet_type = packet_type;
+ }
+ 
+ static inline void ena_tx_mbuf_prepare(struct rte_mbuf *mbuf,
+-- 
+2.14.1
+

--- a/userspace/dpdk/16.11/0006-net-ena-TX-L4-offload-flags-should-not-be-set-in-RX-.patch
+++ b/userspace/dpdk/16.11/0006-net-ena-TX-L4-offload-flags-should-not-be-set-in-RX-.patch
@@ -1,0 +1,53 @@
+From bae106e07e523acf0c2458b6542e6db025f886ff Mon Sep 17 00:00:00 2001
+From: Rafal Kozik <rk@semihalf.com>
+Date: Tue, 9 Jan 2018 16:19:08 +0100
+Subject: [PATCH 6/6] net/ena: TX L4 offload flags should not be set in RX path
+
+Information about received packet type detected by NIC should be stored
+in packet_type field of rte_mbuf. TX L4 offload flags should not be set
+in RX path.
+Only fields that could be set in of_flags during packet receiving are
+information if L4 and L3 checksum is correct.
+
+Fixes: 1173fca25af9 ("ena: add polling-mode driver")
+---
+ drivers/net/ena/ena_ethdev.c | 10 ++++++----
+ 1 file changed, 6 insertions(+), 4 deletions(-)
+
+diff --git a/drivers/net/ena/ena_ethdev.c b/drivers/net/ena/ena_ethdev.c
+index c832d241f..3e73fe1fb 100644
+--- a/drivers/net/ena/ena_ethdev.c
++++ b/drivers/net/ena/ena_ethdev.c
+@@ -248,16 +248,17 @@ static inline void ena_rx_mbuf_prepare(struct rte_mbuf *mbuf,
+ 				       struct ena_com_rx_ctx *ena_rx_ctx)
+ {
+ 	uint64_t ol_flags = 0;
++	uint32_t packet_type = 0;
+ 
+ 	if (ena_rx_ctx->l4_proto == ENA_ETH_IO_L4_PROTO_TCP)
+-		ol_flags |= PKT_TX_TCP_CKSUM;
++		packet_type |= RTE_PTYPE_L4_TCP;
+ 	else if (ena_rx_ctx->l4_proto == ENA_ETH_IO_L4_PROTO_UDP)
+-		ol_flags |= PKT_TX_UDP_CKSUM;
++		packet_type |= RTE_PTYPE_L4_UDP;
+ 
+ 	if (ena_rx_ctx->l3_proto == ENA_ETH_IO_L3_PROTO_IPV4)
+-		ol_flags |= PKT_TX_IPV4;
++		packet_type |= RTE_PTYPE_L3_IPV4;
+ 	else if (ena_rx_ctx->l3_proto == ENA_ETH_IO_L3_PROTO_IPV6)
+-		ol_flags |= PKT_TX_IPV6;
++		packet_type |= RTE_PTYPE_L3_IPV6;
+ 
+ 	if (unlikely(ena_rx_ctx->l4_csum_err))
+ 		ol_flags |= PKT_RX_L4_CKSUM_BAD;
+@@ -265,6 +266,7 @@ static inline void ena_rx_mbuf_prepare(struct rte_mbuf *mbuf,
+ 		ol_flags |= PKT_RX_IP_CKSUM_BAD;
+ 
+ 	mbuf->ol_flags = ol_flags;
++	mbuf->packet_type = packet_type;
+ }
+ 
+ static inline void ena_tx_mbuf_prepare(struct rte_mbuf *mbuf,
+-- 
+2.14.1
+

--- a/userspace/dpdk/17.02/0007-net-ena-TX-L4-offload-flags-should-not-be-set-in-RX-.patch
+++ b/userspace/dpdk/17.02/0007-net-ena-TX-L4-offload-flags-should-not-be-set-in-RX-.patch
@@ -1,0 +1,53 @@
+From 0793c84c650946f4814086a72075b329e161455c Mon Sep 17 00:00:00 2001
+From: Rafal Kozik <rk@semihalf.com>
+Date: Tue, 9 Jan 2018 16:19:08 +0100
+Subject: [PATCH 7/7] net/ena: TX L4 offload flags should not be set in RX path
+
+Information about received packet type detected by NIC should be stored
+in packet_type field of rte_mbuf. TX L4 offload flags should not be set
+in RX path.
+Only fields that could be set in of_flags during packet receiving are
+information if L4 and L3 checksum is correct.
+
+Fixes: 1173fca25af9 ("ena: add polling-mode driver")
+---
+ drivers/net/ena/ena_ethdev.c | 10 ++++++----
+ 1 file changed, 6 insertions(+), 4 deletions(-)
+
+diff --git a/drivers/net/ena/ena_ethdev.c b/drivers/net/ena/ena_ethdev.c
+index 7fca0278d..b7812c62b 100644
+--- a/drivers/net/ena/ena_ethdev.c
++++ b/drivers/net/ena/ena_ethdev.c
+@@ -259,16 +259,17 @@ static inline void ena_rx_mbuf_prepare(struct rte_mbuf *mbuf,
+ 				       struct ena_com_rx_ctx *ena_rx_ctx)
+ {
+ 	uint64_t ol_flags = 0;
++	uint32_t packet_type = 0;
+ 
+ 	if (ena_rx_ctx->l4_proto == ENA_ETH_IO_L4_PROTO_TCP)
+-		ol_flags |= PKT_TX_TCP_CKSUM;
++		packet_type |= RTE_PTYPE_L4_TCP;
+ 	else if (ena_rx_ctx->l4_proto == ENA_ETH_IO_L4_PROTO_UDP)
+-		ol_flags |= PKT_TX_UDP_CKSUM;
++		packet_type |= RTE_PTYPE_L4_UDP;
+ 
+ 	if (ena_rx_ctx->l3_proto == ENA_ETH_IO_L3_PROTO_IPV4)
+-		ol_flags |= PKT_TX_IPV4;
++		packet_type |= RTE_PTYPE_L3_IPV4;
+ 	else if (ena_rx_ctx->l3_proto == ENA_ETH_IO_L3_PROTO_IPV6)
+-		ol_flags |= PKT_TX_IPV6;
++		packet_type |= RTE_PTYPE_L3_IPV6;
+ 
+ 	if (unlikely(ena_rx_ctx->l4_csum_err))
+ 		ol_flags |= PKT_RX_L4_CKSUM_BAD;
+@@ -276,6 +277,7 @@ static inline void ena_rx_mbuf_prepare(struct rte_mbuf *mbuf,
+ 		ol_flags |= PKT_RX_IP_CKSUM_BAD;
+ 
+ 	mbuf->ol_flags = ol_flags;
++	mbuf->packet_type = packet_type;
+ }
+ 
+ static inline void ena_tx_mbuf_prepare(struct rte_mbuf *mbuf,
+-- 
+2.14.1
+

--- a/userspace/dpdk/17.05/0003-net-ena-TX-L4-offload-flags-should-not-be-set-in-RX-.patch
+++ b/userspace/dpdk/17.05/0003-net-ena-TX-L4-offload-flags-should-not-be-set-in-RX-.patch
@@ -1,0 +1,53 @@
+From 983994bc5959bb40320e748aa90d5367b46f1ec1 Mon Sep 17 00:00:00 2001
+From: Rafal Kozik <rk@semihalf.com>
+Date: Tue, 9 Jan 2018 16:19:08 +0100
+Subject: [PATCH 3/3] net/ena: TX L4 offload flags should not be set in RX path
+
+Information about received packet type detected by NIC should be stored
+in packet_type field of rte_mbuf. TX L4 offload flags should not be set
+in RX path.
+Only fields that could be set in of_flags during packet receiving are
+information if L4 and L3 checksum is correct.
+
+Fixes: 1173fca25af9 ("ena: add polling-mode driver")
+---
+ drivers/net/ena/ena_ethdev.c | 10 ++++++----
+ 1 file changed, 6 insertions(+), 4 deletions(-)
+
+diff --git a/drivers/net/ena/ena_ethdev.c b/drivers/net/ena/ena_ethdev.c
+index ce07a26d0..58b0b6355 100644
+--- a/drivers/net/ena/ena_ethdev.c
++++ b/drivers/net/ena/ena_ethdev.c
+@@ -260,16 +260,17 @@ static inline void ena_rx_mbuf_prepare(struct rte_mbuf *mbuf,
+ 				       struct ena_com_rx_ctx *ena_rx_ctx)
+ {
+ 	uint64_t ol_flags = 0;
++	uint32_t packet_type = 0;
+ 
+ 	if (ena_rx_ctx->l4_proto == ENA_ETH_IO_L4_PROTO_TCP)
+-		ol_flags |= PKT_TX_TCP_CKSUM;
++		packet_type |= RTE_PTYPE_L4_TCP;
+ 	else if (ena_rx_ctx->l4_proto == ENA_ETH_IO_L4_PROTO_UDP)
+-		ol_flags |= PKT_TX_UDP_CKSUM;
++		packet_type |= RTE_PTYPE_L4_UDP;
+ 
+ 	if (ena_rx_ctx->l3_proto == ENA_ETH_IO_L3_PROTO_IPV4)
+-		ol_flags |= PKT_TX_IPV4;
++		packet_type |= RTE_PTYPE_L3_IPV4;
+ 	else if (ena_rx_ctx->l3_proto == ENA_ETH_IO_L3_PROTO_IPV6)
+-		ol_flags |= PKT_TX_IPV6;
++		packet_type |= RTE_PTYPE_L3_IPV6;
+ 
+ 	if (unlikely(ena_rx_ctx->l4_csum_err))
+ 		ol_flags |= PKT_RX_L4_CKSUM_BAD;
+@@ -277,6 +278,7 @@ static inline void ena_rx_mbuf_prepare(struct rte_mbuf *mbuf,
+ 		ol_flags |= PKT_RX_IP_CKSUM_BAD;
+ 
+ 	mbuf->ol_flags = ol_flags;
++	mbuf->packet_type = packet_type;
+ }
+ 
+ static inline void ena_tx_mbuf_prepare(struct rte_mbuf *mbuf,
+-- 
+2.14.1
+

--- a/userspace/dpdk/17.08/0001-net-ena-TX-L4-offload-flags-should-not-be-set-in-RX-.patch
+++ b/userspace/dpdk/17.08/0001-net-ena-TX-L4-offload-flags-should-not-be-set-in-RX-.patch
@@ -1,0 +1,53 @@
+From 1b7a4729eb1f069850f5b08f9f00057dac2aa33d Mon Sep 17 00:00:00 2001
+From: Rafal Kozik <rk@semihalf.com>
+Date: Tue, 9 Jan 2018 16:19:08 +0100
+Subject: [PATCH] net/ena: TX L4 offload flags should not be set in RX path
+
+Information about received packet type detected by NIC should be stored
+in packet_type field of rte_mbuf. TX L4 offload flags should not be set
+in RX path.
+Only fields that could be set in of_flags during packet receiving are
+information if L4 and L3 checksum is correct.
+
+Fixes: 1173fca25af9 ("ena: add polling-mode driver")
+---
+ drivers/net/ena/ena_ethdev.c | 10 ++++++----
+ 1 file changed, 6 insertions(+), 4 deletions(-)
+
+diff --git a/drivers/net/ena/ena_ethdev.c b/drivers/net/ena/ena_ethdev.c
+index 80ce1f353..16a648206 100644
+--- a/drivers/net/ena/ena_ethdev.c
++++ b/drivers/net/ena/ena_ethdev.c
+@@ -260,16 +260,17 @@ static inline void ena_rx_mbuf_prepare(struct rte_mbuf *mbuf,
+ 				       struct ena_com_rx_ctx *ena_rx_ctx)
+ {
+ 	uint64_t ol_flags = 0;
++	uint32_t packet_type = 0;
+ 
+ 	if (ena_rx_ctx->l4_proto == ENA_ETH_IO_L4_PROTO_TCP)
+-		ol_flags |= PKT_TX_TCP_CKSUM;
++		packet_type |= RTE_PTYPE_L4_TCP;
+ 	else if (ena_rx_ctx->l4_proto == ENA_ETH_IO_L4_PROTO_UDP)
+-		ol_flags |= PKT_TX_UDP_CKSUM;
++		packet_type |= RTE_PTYPE_L4_UDP;
+ 
+ 	if (ena_rx_ctx->l3_proto == ENA_ETH_IO_L3_PROTO_IPV4)
+-		ol_flags |= PKT_TX_IPV4;
++		packet_type |= RTE_PTYPE_L3_IPV4;
+ 	else if (ena_rx_ctx->l3_proto == ENA_ETH_IO_L3_PROTO_IPV6)
+-		ol_flags |= PKT_TX_IPV6;
++		packet_type |= RTE_PTYPE_L3_IPV6;
+ 
+ 	if (unlikely(ena_rx_ctx->l4_csum_err))
+ 		ol_flags |= PKT_RX_L4_CKSUM_BAD;
+@@ -277,6 +278,7 @@ static inline void ena_rx_mbuf_prepare(struct rte_mbuf *mbuf,
+ 		ol_flags |= PKT_RX_IP_CKSUM_BAD;
+ 
+ 	mbuf->ol_flags = ol_flags;
++	mbuf->packet_type = packet_type;
+ }
+ 
+ static inline void ena_tx_mbuf_prepare(struct rte_mbuf *mbuf,
+-- 
+2.14.1
+

--- a/userspace/dpdk/17.11/0001-net-ena-TX-L4-offload-flags-should-not-be-set-in-RX-.patch
+++ b/userspace/dpdk/17.11/0001-net-ena-TX-L4-offload-flags-should-not-be-set-in-RX-.patch
@@ -1,0 +1,53 @@
+From d630a636b4bcb600b5b37512ba2168aa552698f3 Mon Sep 17 00:00:00 2001
+From: Rafal Kozik <rk@semihalf.com>
+Date: Tue, 9 Jan 2018 16:19:08 +0100
+Subject: [PATCH] net/ena: TX L4 offload flags should not be set in RX path
+
+Information about received packet type detected by NIC should be stored
+in packet_type field of rte_mbuf. TX L4 offload flags should not be set
+in RX path.
+Only fields that could be set in of_flags during packet receiving are
+information if L4 and L3 checksum is correct.
+
+Fixes: 1173fca25af9 ("ena: add polling-mode driver")
+---
+ drivers/net/ena/ena_ethdev.c | 10 ++++++----
+ 1 file changed, 6 insertions(+), 4 deletions(-)
+
+diff --git a/drivers/net/ena/ena_ethdev.c b/drivers/net/ena/ena_ethdev.c
+index 22db8951f..aa24ef36a 100644
+--- a/drivers/net/ena/ena_ethdev.c
++++ b/drivers/net/ena/ena_ethdev.c
+@@ -260,16 +260,17 @@ static inline void ena_rx_mbuf_prepare(struct rte_mbuf *mbuf,
+ 				       struct ena_com_rx_ctx *ena_rx_ctx)
+ {
+ 	uint64_t ol_flags = 0;
++	uint32_t packet_type = 0;
+ 
+ 	if (ena_rx_ctx->l4_proto == ENA_ETH_IO_L4_PROTO_TCP)
+-		ol_flags |= PKT_TX_TCP_CKSUM;
++		packet_type |= RTE_PTYPE_L4_TCP;
+ 	else if (ena_rx_ctx->l4_proto == ENA_ETH_IO_L4_PROTO_UDP)
+-		ol_flags |= PKT_TX_UDP_CKSUM;
++		packet_type |= RTE_PTYPE_L4_UDP;
+ 
+ 	if (ena_rx_ctx->l3_proto == ENA_ETH_IO_L3_PROTO_IPV4)
+-		ol_flags |= PKT_TX_IPV4;
++		packet_type |= RTE_PTYPE_L3_IPV4;
+ 	else if (ena_rx_ctx->l3_proto == ENA_ETH_IO_L3_PROTO_IPV6)
+-		ol_flags |= PKT_TX_IPV6;
++		packet_type |= RTE_PTYPE_L3_IPV6;
+ 
+ 	if (unlikely(ena_rx_ctx->l4_csum_err))
+ 		ol_flags |= PKT_RX_L4_CKSUM_BAD;
+@@ -277,6 +278,7 @@ static inline void ena_rx_mbuf_prepare(struct rte_mbuf *mbuf,
+ 		ol_flags |= PKT_RX_IP_CKSUM_BAD;
+ 
+ 	mbuf->ol_flags = ol_flags;
++	mbuf->packet_type = packet_type;
+ }
+ 
+ static inline void ena_tx_mbuf_prepare(struct rte_mbuf *mbuf,
+-- 
+2.14.1
+


### PR DESCRIPTION
Information about received packet type detected by NIC should be stored
in packet_type field of rte_mbuf. TX L4 offload flags should not be set
in RX path.
Only fields that could be set in of_flags during packet receiving are
information if L4 and L3 checksum is correct.

The patch for the given issue had been provided for all versions.