### PR TITLE
Fixes #56 - Remove use of __GFP_COLD for 4.15 kernel

### DIFF
--- a/kernel/linux/ena/ena_netdev.c
+++ b/kernel/linux/ena/ena_netdev.c
@@ -541,7 +541,7 @@ static int ena_refill_rx_bufs(struct ena_ring *rx_ring, u32 num)
 
 
 		rc = ena_alloc_rx_page(rx_ring, rx_info,
-				       __GFP_COLD | GFP_ATOMIC | __GFP_COMP);
+				       GFP_ATOMIC | __GFP_COMP);
 		if (unlikely(rc < 0)) {
 			netif_warn(rx_ring->adapter, rx_err, rx_ring->netdev,
 				   "failed to alloc buffer for rx queue %d\n",


### PR DESCRIPTION
This change will obviously affect all kernels, not just 4.15,
but per https://github.com/torvalds/linux/commit/453f85d43fa9ee243f0fc3ac4e1be45615301e3f
there should be no measurable real-world impact.