### PR TITLE
dpdk/ena: backport fixes added in 18.xx releases

### DIFF
--- a/userspace/dpdk/16.04/0001-Backport-ENA-PMD-to-v16.04.patch
+++ b/userspace/dpdk/16.04/0001-Backport-ENA-PMD-to-v16.04.patch
@@ -1,7 +1,7 @@
 From 65a31061fe33969bfc2dc73862d5446f0327041c Mon Sep 17 00:00:00 2001
 From: Michal Krawczyk <mk@semihalf.com>
 Date: Mon, 4 Sep 2017 14:46:32 +0200
-Subject: [PATCH] Backport ENA PMD to v16.04
+Subject: [PATCH 1/8] Backport ENA PMD to v16.04
 
 The ENA PMD was backported from the commit:
 222555480a7f9979d10faa9bb8b9773b0e1aa058
@@ -1023,10 +1023,11 @@ index fe4124697..7a031d903 100644
  /* feature_rss_flow_hash_input */
  #define ENA_ADMIN_FEATURE_RSS_FLOW_HASH_INPUT_L3_SORT_SHIFT 1
  #define ENA_ADMIN_FEATURE_RSS_FLOW_HASH_INPUT_L3_SORT_MASK BIT(1)
-@@ -1816,34 +1752,21 @@ set_ena_admin_feature_rss_flow_hash_function_selected_func(
+@@ -1815,35 +1751,22 @@ set_ena_admin_feature_rss_flow_hash_function_selected_func(
+ 		ENA_ADMIN_FEATURE_RSS_FLOW_HASH_FUNCTION_SELECTED_FUNC_MASK;
  }
  
- static inline uint16_t
+-static inline uint16_t
 -get_ena_admin_proto_input_inner(const struct ena_admin_proto_input *p)
 -{
 -	return p->flags & ENA_ADMIN_PROTO_INPUT_INNER_MASK;
@@ -1038,7 +1039,7 @@ index fe4124697..7a031d903 100644
 -	p->flags |= val & ENA_ADMIN_PROTO_INPUT_INNER_MASK;
 -}
 -
--static inline uint16_t
+ static inline uint16_t
  get_ena_admin_feature_rss_flow_hash_input_L3_sort(
  		const struct ena_admin_feature_rss_flow_hash_input *p)
  {
@@ -3010,5 +3011,5 @@ index ba6f01e66..dc3080ffd 100644
  	int id_number;
  	char name[ENA_NAME_MAX_LEN];
 -- 
-2.11.0
+2.14.1
 

--- a/userspace/dpdk/16.04/0002-net-ena-TX-L4-offload-flags-should-not-be-set-in-RX-.patch
+++ b/userspace/dpdk/16.04/0002-net-ena-TX-L4-offload-flags-should-not-be-set-in-RX-.patch
@@ -1,7 +1,7 @@
 From 25d9cb981fbd57a4a501473eb03cab1f3c7a6795 Mon Sep 17 00:00:00 2001
 From: Rafal Kozik <rk@semihalf.com>
 Date: Tue, 9 Jan 2018 16:19:08 +0100
-Subject: [PATCH 2/2] net/ena: TX L4 offload flags should not be set in RX path
+Subject: [PATCH 2/8] net/ena: TX L4 offload flags should not be set in RX path
 
 Information about received packet type detected by NIC should be stored
 in packet_type field of rte_mbuf. TX L4 offload flags should not be set

--- a/userspace/dpdk/16.04/0003-net-ena-check-pointer-before-memset.patch
+++ b/userspace/dpdk/16.04/0003-net-ena-check-pointer-before-memset.patch
@@ -1,0 +1,63 @@
+From 7bf3aba0f35b2a53efa505942a6b8afd7a0dc06a Mon Sep 17 00:00:00 2001
+From: Rafal Kozik <rk@semihalf.com>
+Date: Thu, 7 Jun 2018 11:43:18 +0200
+Subject: [PATCH 3/8] net/ena: check pointer before memset
+
+[ upstream commit 46916aa17d4b2007df8c0454f99ba0ca8b8cb93b ]
+
+Need to check if memory allocation succeed before using it.
+Using memset on NULL pointer cause segfault.
+
+Fixes: 9ba7981ec992 ("ena: add communication layer for DPDK")
+Cc: stable@dpdk.org
+
+Signed-off-by: Rafal Kozik <rk@semihalf.com>
+Acked-by: Michal Krawczyk <mk@semihalf.com>
+---
+ drivers/net/ena/base/ena_plat_dpdk.h | 22 ++++++++++++++++------
+ 1 file changed, 16 insertions(+), 6 deletions(-)
+
+diff --git a/drivers/net/ena/base/ena_plat_dpdk.h b/drivers/net/ena/base/ena_plat_dpdk.h
+index a812d75e2..cc69b3372 100644
+--- a/drivers/net/ena/base/ena_plat_dpdk.h
++++ b/drivers/net/ena/base/ena_plat_dpdk.h
+@@ -188,10 +188,15 @@ typedef uint64_t dma_addr_t;
+ 		snprintf(z_name, sizeof(z_name),			\
+ 				"ena_alloc_%d", ena_alloc_cnt++);	\
+ 		mz = rte_memzone_reserve(z_name, size, SOCKET_ID_ANY, 0); \
+-		memset(mz->addr, 0, size);				\
+-		virt = mz->addr;					\
+-		phys = mz->phys_addr;					\
+ 		handle = mz;						\
++		if (mz == NULL) {					\
++			virt = NULL;					\
++			phys = 0;					\
++		} else {						\
++			memset(mz->addr, 0, size);			\
++			virt = mz->addr;				\
++			phys = mz->phys_addr;				\
++		}							\
+ 	} while (0)
+ #define ENA_MEM_FREE_COHERENT(dmadev, size, virt, phys, handle) 	\
+ 		({ ENA_TOUCH(size); ENA_TOUCH(phys);			\
+@@ -206,9 +211,14 @@ typedef uint64_t dma_addr_t;
+ 		snprintf(z_name, sizeof(z_name),			\
+ 				"ena_alloc_%d", ena_alloc_cnt++);	\
+ 		mz = rte_memzone_reserve(z_name, size, node, 0); \
+-		memset(mz->addr, 0, size);				\
+-		virt = mz->addr;					\
+-		phys = mz->phys_addr;					\
++		if (mz == NULL) {					\
++			virt = NULL;					\
++			phys = 0;					\
++		} else {						\
++			memset(mz->addr, 0, size);			\
++			virt = mz->addr;				\
++			phys = mz->phys_addr;				\
++		}							\
+ 	} while (0)
+
+ #define ENA_MEM_ALLOC_NODE(dmadev, size, virt, node, dev_node) \
+--
+2.14.1
+

--- a/userspace/dpdk/16.04/0004-net-ena-change-memory-type.patch
+++ b/userspace/dpdk/16.04/0004-net-ena-change-memory-type.patch
@@ -1,0 +1,45 @@
+From 06ebe3a8c6dd4c95eb8f2cb0dd9fb15cf448bc4a Mon Sep 17 00:00:00 2001
+From: Rafal Kozik <rk@semihalf.com>
+Date: Thu, 7 Jun 2018 11:43:19 +0200
+Subject: [PATCH 4/8] net/ena: change memory type
+
+[ upstream commit 9f32c7e7e6ce58ab772913f54f8328c1c0186a17 ]
+
+ENA_MEM_ALLOC_NODE not need to use contiguous physical memory.
+Also using memset without checking if allocation succeed can cause
+segmentation fault.
+
+To avoid both issue use rte_zmalloc_socket.
+
+Fixes: 3d3edc265fc8 ("net/ena: make coherent memory allocation NUMA-aware")
+Cc: stable@dpdk.org
+
+Signed-off-by: Rafal Kozik <rk@semihalf.com>
+Acked-by: Michal Krawczyk <mk@semihalf.com>
+---
+ drivers/net/ena/base/ena_plat_dpdk.h | 8 +-------
+ 1 file changed, 1 insertion(+), 7 deletions(-)
+
+diff --git a/drivers/net/ena/base/ena_plat_dpdk.h b/drivers/net/ena/base/ena_plat_dpdk.h
+index cc69b3372..ff873e807 100644
+--- a/drivers/net/ena/base/ena_plat_dpdk.h
++++ b/drivers/net/ena/base/ena_plat_dpdk.h
+@@ -223,14 +223,8 @@ typedef uint64_t dma_addr_t;
+
+ #define ENA_MEM_ALLOC_NODE(dmadev, size, virt, node, dev_node) \
+ 	do {								\
+-		const struct rte_memzone *mz;				\
+-		char z_name[RTE_MEMZONE_NAMESIZE];			\
+ 		ENA_TOUCH(dmadev); ENA_TOUCH(dev_node);			\
+-		snprintf(z_name, sizeof(z_name),			\
+-				"ena_alloc_%d", ena_alloc_cnt++);	\
+-		mz = rte_memzone_reserve(z_name, size, node, 0); \
+-		memset(mz->addr, 0, size);				\
+-		virt = mz->addr;					\
++		virt = rte_zmalloc_socket(NULL, size, 0, node);		\
+ 	} while (0)
+
+ #define ENA_MEM_ALLOC(dmadev, size) rte_zmalloc(NULL, size, 1)
+--
+2.14.1
+

--- a/userspace/dpdk/16.04/0005-net-ena-fix-GENMASK_ULL-macro.patch
+++ b/userspace/dpdk/16.04/0005-net-ena-fix-GENMASK_ULL-macro.patch
@@ -1,0 +1,42 @@
+From b92f7986912e9d6fc483bdf3ce4a1bc7dcda7488 Mon Sep 17 00:00:00 2001
+From: Rafal Kozik <rk@semihalf.com>
+Date: Thu, 7 Jun 2018 11:43:20 +0200
+Subject: [PATCH 5/8] net/ena: fix GENMASK_ULL macro
+
+[ upstream commit 7544aee8d0b4ae0262b1ba7e1539cf8171664df7 ]
+
+When use GENMASK_ULL(63,0) left shift by 64 bits is performed.
+Shifting by number greater or equal then word length
+is undefined operation and failed on some platforms.
+
+Fixes: 9ba7981ec992 ("ena: add communication layer for DPDK")
+Cc: stable@dpdk.org
+
+Signed-off-by: Rafal Kozik <rk@semihalf.com>
+Acked-by: Michal Krawczyk <mk@semihalf.com>
+---
+ drivers/net/ena/base/ena_plat_dpdk.h | 4 +++-
+ 1 file changed, 3 insertions(+), 1 deletion(-)
+
+diff --git a/drivers/net/ena/base/ena_plat_dpdk.h b/drivers/net/ena/base/ena_plat_dpdk.h
+index ff873e807..791b44ff7 100644
+--- a/drivers/net/ena/base/ena_plat_dpdk.h
++++ b/drivers/net/ena/base/ena_plat_dpdk.h
+@@ -115,11 +115,13 @@ typedef uint64_t dma_addr_t;
+ #define ENA_MIN16(x, y) RTE_MIN((x), (y))
+ #define ENA_MIN8(x, y) RTE_MIN((x), (y))
+ 
++#define BITS_PER_LONG_LONG (__SIZEOF_LONG_LONG__ * 8)
+ #define U64_C(x) x ## ULL
+ #define BIT(nr)         (1UL << (nr))
+ #define BITS_PER_LONG	(__SIZEOF_LONG__ * 8)
+ #define GENMASK(h, l)	(((~0UL) << (l)) & (~0UL >> (BITS_PER_LONG - 1 - (h))))
+-#define GENMASK_ULL(h, l) (((U64_C(1) << ((h) - (l) + 1)) - 1) << (l))
++#define GENMASK_ULL(h, l) (((~0ULL) - (1ULL << (l)) + 1) & \
++			  (~0ULL >> (BITS_PER_LONG_LONG - 1 - (h))))
+ 
+ #ifdef RTE_LIBRTE_ENA_COM_DEBUG
+ #define ena_trc_dbg(format, arg...)					\
+-- 
+2.14.1
+

--- a/userspace/dpdk/16.04/0006-net-ena-set-link-speed-as-none.patch
+++ b/userspace/dpdk/16.04/0006-net-ena-set-link-speed-as-none.patch
@@ -1,0 +1,37 @@
+From 99b5c2ca40e0b0af44fcced13658abe743c64bae Mon Sep 17 00:00:00 2001
+From: Rafal Kozik <rk@semihalf.com>
+Date: Thu, 7 Jun 2018 11:43:22 +0200
+Subject: [PATCH 6/8] net/ena: set link speed as none
+
+[ upstream commit 41e59028dd8ab2038a7655c6fc3098222661aa53 ]
+
+Link speed should is not limited to 10Gb/s and it shouldn't be hardcoded.
+
+They link speed is set to none instead and the applications shouldn't
+rely on this value when using ENA PMD.
+
+Fixes: 1173fca25af9 ("ena: add polling-mode driver")
+Cc: stable@dpdk.org
+
+Signed-off-by: Rafal Kozik <rk@semihalf.com>
+Acked-by: Michal Krawczyk <mk@semihalf.com>
+---
+ drivers/net/ena/ena_ethdev.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/drivers/net/ena/ena_ethdev.c b/drivers/net/ena/ena_ethdev.c
+index 9d677b8d7..98848e935 100644
+--- a/drivers/net/ena/ena_ethdev.c
++++ b/drivers/net/ena/ena_ethdev.c
+@@ -707,7 +707,7 @@ static int ena_link_update(struct rte_eth_dev *dev,
+ 	struct rte_eth_link *link = &dev->data->dev_link;
+ 
+ 	link->link_status = 1;
+-	link->link_speed = ETH_SPEED_NUM_10G;
++	link->link_speed = ETH_SPEED_NUM_NONE;
+ 	link->link_duplex = ETH_LINK_FULL_DUPLEX;
+ 
+ 	return 0;
+-- 
+2.14.1
+

--- a/userspace/dpdk/16.04/0007-net-ena-fix-SIGFPE-with-0-Rx-queue.patch
+++ b/userspace/dpdk/16.04/0007-net-ena-fix-SIGFPE-with-0-Rx-queue.patch
@@ -1,0 +1,35 @@
+From 4997f78644c9ef96d39869534c3b76ab1157ec98 Mon Sep 17 00:00:00 2001
+From: Daria Kolistratova <daria.kolistratova@intel.com>
+Date: Tue, 26 Jun 2018 18:38:56 +0100
+Subject: [PATCH 7/8] net/ena: fix SIGFPE with 0 Rx queue
+
+[ upstream commit 361913ad6f8c05fc541fe4bfdae3b0dc095ae3af ]
+
+When the number of rx queues is 0 (what can be when application does
+not receive) failed with SIGFPE.
+It happens when the application is also requesting ETH_MQ_RX_RSS_FLAG
+in the rte_dev->data->dev_conf.rxmode.mq_mode.
+Fixed adding zero rx queues check.
+
+Signed-off-by: Daria Kolistratova <daria.kolistratova@intel.com>
+Acked-by: Michal Krawczyk <mk@semihalf.com>
+---
+ drivers/net/ena/ena_ethdev.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/drivers/net/ena/ena_ethdev.c b/drivers/net/ena/ena_ethdev.c
+index 98848e935..3a257a9e5 100644
+--- a/drivers/net/ena/ena_ethdev.c
++++ b/drivers/net/ena/ena_ethdev.c
+@@ -904,7 +904,7 @@ static int ena_start(struct rte_eth_dev *dev)
+ 		return rc;
+ 
+ 	if (adapter->rte_dev->data->dev_conf.rxmode.mq_mode &
+-	    ETH_MQ_RX_RSS_FLAG) {
++	    ETH_MQ_RX_RSS_FLAG && adapter->rte_dev->data->nb_rx_queues > 0) {
+ 		rc = ena_rss_init_default(adapter);
+ 		if (rc)
+ 			return rc;
+-- 
+2.14.1
+

--- a/userspace/dpdk/16.04/0008-net-ena-fix-passing-RSS-hash-to-mbuf.patch
+++ b/userspace/dpdk/16.04/0008-net-ena-fix-passing-RSS-hash-to-mbuf.patch
@@ -1,0 +1,35 @@
+From 2cf25ae25e4adc6b77d194d921699b1ca1952830 Mon Sep 17 00:00:00 2001
+From: Stewart Allen <allenste@amazon.com>
+Date: Thu, 25 Oct 2018 19:59:22 +0200
+Subject: [PATCH 8/8] net/ena: fix passing RSS hash to mbuf
+
+[ upstream commit e5df9f33db00eb9d322abaefff30da74fd0e625d ]
+
+The driver was passing to the mbuf Rx queue ID instead of hash received
+from the device. Now, the RSS hash from the Rx descriptor is being set.
+
+Fixes: 1173fca25af9 ("ena: add polling-mode driver")
+Cc: stable@dpdk.org
+
+Signed-off-by: Stewart Allen <allenste@amazon.com>
+Acked-by: Michal Krawczyk <mk@semihalf.com>
+---
+ drivers/net/ena/ena_ethdev.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/drivers/net/ena/ena_ethdev.c b/drivers/net/ena/ena_ethdev.c
+index 3a257a9e5..24e319764 100644
+--- a/drivers/net/ena/ena_ethdev.c
++++ b/drivers/net/ena/ena_ethdev.c
+@@ -1559,7 +1559,7 @@ static uint16_t eth_ena_recv_pkts(void *rx_queue, struct rte_mbuf **rx_pkts,
+ 
+ 		/* fill mbuf attributes if any */
+ 		ena_rx_mbuf_prepare(mbuf_head, &ena_rx_ctx);
+-		mbuf_head->hash.rss = (uint32_t)rx_ring->id;
++		mbuf_head->hash.rss = ena_rx_ctx.hash;
+ 
+ 		/* pass to DPDK application head mbuf */
+ 		rx_pkts[recv_idx] = mbuf_head;
+-- 
+2.14.1
+

--- a/userspace/dpdk/16.11/0001-net-ena-cleanup-if-refilling-of-Rx-descriptors-fails.patch
+++ b/userspace/dpdk/16.11/0001-net-ena-cleanup-if-refilling-of-Rx-descriptors-fails.patch
@@ -1,7 +1,7 @@
-From 20e314b0ea4dc9d779698510339bbd626edcaa09 Mon Sep 17 00:00:00 2001
+From 395ef06d77c3d2d7d1eb9400a3988ec8857fd5d7 Mon Sep 17 00:00:00 2001
 From: Michal Krawczyk <mk@semihalf.com>
 Date: Mon, 10 Apr 2017 16:28:10 +0200
-Subject: [PATCH 1/5] net/ena: cleanup if refilling of Rx descriptors fails
+Subject: [PATCH 01/12] net/ena: cleanup if refilling of Rx descriptors fails
 
 [ upstream commit 2732e07ad1e54c648c8ca5bc6965af5bf607ba10 ]
 
@@ -22,7 +22,7 @@ Acked-by: Jan Medala <jan.medala@outlook.com>
  1 file changed, 2 insertions(+)
 
 diff --git a/drivers/net/ena/ena_ethdev.c b/drivers/net/ena/ena_ethdev.c
-index ab9a178..dd53c32 100644
+index ab9a178f7..dd53c32d9 100644
 --- a/drivers/net/ena/ena_ethdev.c
 +++ b/drivers/net/ena/ena_ethdev.c
 @@ -1165,6 +1165,8 @@ static int ena_populate_rx_queue(struct ena_ring *rxq, unsigned int count)
@@ -35,5 +35,5 @@ index ab9a178..dd53c32 100644
  			break;
  		}
 -- 
-2.7.4
+2.14.1
 

--- a/userspace/dpdk/16.11/0002-net-ena-fix-Rx-descriptors-allocation.patch
+++ b/userspace/dpdk/16.11/0002-net-ena-fix-Rx-descriptors-allocation.patch
@@ -1,7 +1,7 @@
-From ca70c58c46b5df9c5a5d8d050320b8f0ee68f831 Mon Sep 17 00:00:00 2001
+From a8c9bdcc04fddbd930f1856ce7f56dc7b20e4d0b Mon Sep 17 00:00:00 2001
 From: Michal Krawczyk <mk@semihalf.com>
 Date: Thu, 18 May 2017 17:41:50 +0200
-Subject: [PATCH 2/5] net/ena: fix Rx descriptors allocation
+Subject: [PATCH 02/12] net/ena: fix Rx descriptors allocation
 
 [ backported from upstream commit a467e8f37a3eec98210c0c3ec04bf6e9506ddd81 ]
 
@@ -22,7 +22,7 @@ Acked-by: Jan Medala <jan.medala@outlook.com>
  1 file changed, 7 insertions(+), 5 deletions(-)
 
 diff --git a/drivers/net/ena/ena_ethdev.c b/drivers/net/ena/ena_ethdev.c
-index dd53c32..2318cf3 100644
+index dd53c32d9..2318cf35d 100644
 --- a/drivers/net/ena/ena_ethdev.c
 +++ b/drivers/net/ena/ena_ethdev.c
 @@ -913,7 +913,7 @@ static int ena_start(struct rte_eth_dev *dev)
@@ -66,5 +66,5 @@ index dd53c32..2318cf3 100644
  	if (ring_size - desc_in_use > ENA_RING_DESCS_RATIO(ring_size))
  		ena_populate_rx_queue(rx_ring, ring_size - desc_in_use);
 -- 
-2.7.4
+2.14.1
 

--- a/userspace/dpdk/16.11/0003-net-ena-fix-delayed-cleanup-of-Rx-descriptors.patch
+++ b/userspace/dpdk/16.11/0003-net-ena-fix-delayed-cleanup-of-Rx-descriptors.patch
@@ -1,7 +1,7 @@
-From 05f9fc6960a77bdf74c924824146e4af070e40de Mon Sep 17 00:00:00 2001
+From 726e5998ebf5f475675d8cded24e6180e965171e Mon Sep 17 00:00:00 2001
 From: Michal Krawczyk <mk@semihalf.com>
 Date: Thu, 18 May 2017 17:41:51 +0200
-Subject: [PATCH 3/5] net/ena: fix delayed cleanup of Rx descriptors
+Subject: [PATCH 03/12] net/ena: fix delayed cleanup of Rx descriptors
 
 [ backported from upstream commit ec78af6bc0556cf2a1133185ca33fb835b38afe0 ]
 
@@ -26,7 +26,7 @@ Acked-by: Jan Medala <jan.medala@outlook.com>
  1 file changed, 3 insertions(+), 3 deletions(-)
 
 diff --git a/drivers/net/ena/ena_ethdev.c b/drivers/net/ena/ena_ethdev.c
-index 2318cf3..8d4898d 100644
+index 2318cf35d..8d4898d67 100644
 --- a/drivers/net/ena/ena_ethdev.c
 +++ b/drivers/net/ena/ena_ethdev.c
 @@ -1564,13 +1564,13 @@ static uint16_t eth_ena_recv_pkts(void *rx_queue, struct rte_mbuf **rx_pkts,
@@ -47,5 +47,5 @@ index 2318cf3..8d4898d 100644
  }
  
 -- 
-2.7.4
+2.14.1
 

--- a/userspace/dpdk/16.11/0004-net-ena-fix-cleanup-of-the-Tx-bufs.patch
+++ b/userspace/dpdk/16.11/0004-net-ena-fix-cleanup-of-the-Tx-bufs.patch
@@ -1,7 +1,7 @@
-From 93e2d00f3871e592875c217eefb1f5ef270465a3 Mon Sep 17 00:00:00 2001
+From 160cd72af9ef198fcfb8942362f26840690af71a Mon Sep 17 00:00:00 2001
 From: Michal Krawczyk <mk@semihalf.com>
 Date: Fri, 16 Jun 2017 08:19:16 +0000
-Subject: [PATCH 4/5] net/ena: fix cleanup of the Tx bufs
+Subject: [PATCH 04/12] net/ena: fix cleanup of the Tx bufs
 
 After cleanup of the mbuf on Tx path, queue was still pointing to this
 mbuf and upon cleanup of the Tx buffers, it was being freed second time.
@@ -14,7 +14,7 @@ range between head and tail was being cleaned up.
  1 file changed, 4 insertions(+), 4 deletions(-)
 
 diff --git a/drivers/net/ena/ena_ethdev.c b/drivers/net/ena/ena_ethdev.c
-index 8d4898d..c832d24 100644
+index 8d4898d67..c832d241f 100644
 --- a/drivers/net/ena/ena_ethdev.c
 +++ b/drivers/net/ena/ena_ethdev.c
 @@ -682,11 +682,10 @@ static void ena_rx_queue_release_bufs(struct ena_ring *ring)
@@ -41,5 +41,5 @@ index 8d4898d..c832d24 100644
  		/* Put back descriptor to the ring for reuse */
  		tx_ring->empty_tx_reqs[next_to_clean & ring_mask] = req_id;
 -- 
-2.7.4
+2.14.1
 

--- a/userspace/dpdk/16.11/0005-net-ena-add-memory-initialization-for-the-allocation.patch
+++ b/userspace/dpdk/16.11/0005-net-ena-add-memory-initialization-for-the-allocation.patch
@@ -1,7 +1,7 @@
-From 7cef040dee66073cab9d7f3f54f7f2a858efd955 Mon Sep 17 00:00:00 2001
+From 431e45d00feb530ed6e016df0a5bd776a4e5df15 Mon Sep 17 00:00:00 2001
 From: Michal Krawczyk <mk@semihalf.com>
 Date: Fri, 16 Jun 2017 09:10:48 +0000
-Subject: [PATCH 5/5] net/ena: add memory initialization for the allocation
+Subject: [PATCH 05/12] net/ena: add memory initialization for the allocation
  macros
 
 Uninitilized memory could cause memory corruption, by indicating
@@ -11,7 +11,7 @@ completion of the invalid mbuf.
  1 file changed, 2 insertions(+)
 
 diff --git a/drivers/net/ena/base/ena_plat_dpdk.h b/drivers/net/ena/base/ena_plat_dpdk.h
-index 87c3bf1..a812d75 100644
+index 87c3bf13b..a812d75e2 100644
 --- a/drivers/net/ena/base/ena_plat_dpdk.h
 +++ b/drivers/net/ena/base/ena_plat_dpdk.h
 @@ -206,6 +206,7 @@ typedef uint64_t dma_addr_t;
@@ -31,5 +31,5 @@ index 87c3bf1..a812d75 100644
  	} while (0)
  
 -- 
-2.7.4
+2.14.1
 

--- a/userspace/dpdk/16.11/0006-net-ena-TX-L4-offload-flags-should-not-be-set-in-RX-.patch
+++ b/userspace/dpdk/16.11/0006-net-ena-TX-L4-offload-flags-should-not-be-set-in-RX-.patch
@@ -1,7 +1,8 @@
 From bae106e07e523acf0c2458b6542e6db025f886ff Mon Sep 17 00:00:00 2001
 From: Rafal Kozik <rk@semihalf.com>
 Date: Tue, 9 Jan 2018 16:19:08 +0100
-Subject: [PATCH 6/6] net/ena: TX L4 offload flags should not be set in RX path
+Subject: [PATCH 06/12] net/ena: TX L4 offload flags should not be set in RX
+ path
 
 Information about received packet type detected by NIC should be stored
 in packet_type field of rte_mbuf. TX L4 offload flags should not be set

--- a/userspace/dpdk/16.11/0007-net-ena-check-pointer-before-memset.patch
+++ b/userspace/dpdk/16.11/0007-net-ena-check-pointer-before-memset.patch
@@ -1,0 +1,63 @@
+From db2c69785fc37763ee93ff6233f3a825f110c2ea Mon Sep 17 00:00:00 2001
+From: Rafal Kozik <rk@semihalf.com>
+Date: Thu, 7 Jun 2018 11:43:18 +0200
+Subject: [PATCH 07/12] net/ena: check pointer before memset
+
+[ upstream commit 46916aa17d4b2007df8c0454f99ba0ca8b8cb93b ]
+
+Need to check if memory allocation succeed before using it.
+Using memset on NULL pointer cause segfault.
+
+Fixes: 9ba7981ec992 ("ena: add communication layer for DPDK")
+Cc: stable@dpdk.org
+
+Signed-off-by: Rafal Kozik <rk@semihalf.com>
+Acked-by: Michal Krawczyk <mk@semihalf.com>
+---
+ drivers/net/ena/base/ena_plat_dpdk.h | 22 ++++++++++++++++------
+ 1 file changed, 16 insertions(+), 6 deletions(-)
+
+diff --git a/drivers/net/ena/base/ena_plat_dpdk.h b/drivers/net/ena/base/ena_plat_dpdk.h
+index a812d75e2..cc69b3372 100644
+--- a/drivers/net/ena/base/ena_plat_dpdk.h
++++ b/drivers/net/ena/base/ena_plat_dpdk.h
+@@ -188,10 +188,15 @@ typedef uint64_t dma_addr_t;
+ 		snprintf(z_name, sizeof(z_name),			\
+ 				"ena_alloc_%d", ena_alloc_cnt++);	\
+ 		mz = rte_memzone_reserve(z_name, size, SOCKET_ID_ANY, 0); \
+-		memset(mz->addr, 0, size);				\
+-		virt = mz->addr;					\
+-		phys = mz->phys_addr;					\
+ 		handle = mz;						\
++		if (mz == NULL) {					\
++			virt = NULL;					\
++			phys = 0;					\
++		} else {						\
++			memset(mz->addr, 0, size);			\
++			virt = mz->addr;				\
++			phys = mz->phys_addr;				\
++		}							\
+ 	} while (0)
+ #define ENA_MEM_FREE_COHERENT(dmadev, size, virt, phys, handle) 	\
+ 		({ ENA_TOUCH(size); ENA_TOUCH(phys);			\
+@@ -206,9 +211,14 @@ typedef uint64_t dma_addr_t;
+ 		snprintf(z_name, sizeof(z_name),			\
+ 				"ena_alloc_%d", ena_alloc_cnt++);	\
+ 		mz = rte_memzone_reserve(z_name, size, node, 0); \
+-		memset(mz->addr, 0, size);				\
+-		virt = mz->addr;					\
+-		phys = mz->phys_addr;					\
++		if (mz == NULL) {					\
++			virt = NULL;					\
++			phys = 0;					\
++		} else {						\
++			memset(mz->addr, 0, size);			\
++			virt = mz->addr;				\
++			phys = mz->phys_addr;				\
++		}							\
+ 	} while (0)
+ 
+ #define ENA_MEM_ALLOC_NODE(dmadev, size, virt, node, dev_node) \
+-- 
+2.14.1
+

--- a/userspace/dpdk/16.11/0008-net-ena-change-memory-type.patch
+++ b/userspace/dpdk/16.11/0008-net-ena-change-memory-type.patch
@@ -1,0 +1,45 @@
+From 08ce00cc6edfa822e17e6c917fc106d5373e5315 Mon Sep 17 00:00:00 2001
+From: Rafal Kozik <rk@semihalf.com>
+Date: Thu, 7 Jun 2018 11:43:19 +0200
+Subject: [PATCH 08/12] net/ena: change memory type
+
+[ upstream commit 9f32c7e7e6ce58ab772913f54f8328c1c0186a17 ]
+
+ENA_MEM_ALLOC_NODE not need to use contiguous physical memory.
+Also using memset without checking if allocation succeed can cause
+segmentation fault.
+
+To avoid both issue use rte_zmalloc_socket.
+
+Fixes: 3d3edc265fc8 ("net/ena: make coherent memory allocation NUMA-aware")
+Cc: stable@dpdk.org
+
+Signed-off-by: Rafal Kozik <rk@semihalf.com>
+Acked-by: Michal Krawczyk <mk@semihalf.com>
+---
+ drivers/net/ena/base/ena_plat_dpdk.h | 8 +-------
+ 1 file changed, 1 insertion(+), 7 deletions(-)
+
+diff --git a/drivers/net/ena/base/ena_plat_dpdk.h b/drivers/net/ena/base/ena_plat_dpdk.h
+index cc69b3372..ff873e807 100644
+--- a/drivers/net/ena/base/ena_plat_dpdk.h
++++ b/drivers/net/ena/base/ena_plat_dpdk.h
+@@ -223,14 +223,8 @@ typedef uint64_t dma_addr_t;
+ 
+ #define ENA_MEM_ALLOC_NODE(dmadev, size, virt, node, dev_node) \
+ 	do {								\
+-		const struct rte_memzone *mz;				\
+-		char z_name[RTE_MEMZONE_NAMESIZE];			\
+ 		ENA_TOUCH(dmadev); ENA_TOUCH(dev_node);			\
+-		snprintf(z_name, sizeof(z_name),			\
+-				"ena_alloc_%d", ena_alloc_cnt++);	\
+-		mz = rte_memzone_reserve(z_name, size, node, 0); \
+-		memset(mz->addr, 0, size);				\
+-		virt = mz->addr;					\
++		virt = rte_zmalloc_socket(NULL, size, 0, node);		\
+ 	} while (0)
+ 
+ #define ENA_MEM_ALLOC(dmadev, size) rte_zmalloc(NULL, size, 1)
+-- 
+2.14.1
+

--- a/userspace/dpdk/16.11/0009-net-ena-fix-GENMASK_ULL-macro.patch
+++ b/userspace/dpdk/16.11/0009-net-ena-fix-GENMASK_ULL-macro.patch
@@ -1,0 +1,42 @@
+From 64d22bcab46f0e9119f9d2f1d3fa88b2dd016487 Mon Sep 17 00:00:00 2001
+From: Rafal Kozik <rk@semihalf.com>
+Date: Thu, 7 Jun 2018 11:43:20 +0200
+Subject: [PATCH 09/12] net/ena: fix GENMASK_ULL macro
+
+[ upstream commit 7544aee8d0b4ae0262b1ba7e1539cf8171664df7 ]
+
+When use GENMASK_ULL(63,0) left shift by 64 bits is performed.
+Shifting by number greater or equal then word length
+is undefined operation and failed on some platforms.
+
+Fixes: 9ba7981ec992 ("ena: add communication layer for DPDK")
+Cc: stable@dpdk.org
+
+Signed-off-by: Rafal Kozik <rk@semihalf.com>
+Acked-by: Michal Krawczyk <mk@semihalf.com>
+---
+ drivers/net/ena/base/ena_plat_dpdk.h | 4 +++-
+ 1 file changed, 3 insertions(+), 1 deletion(-)
+
+diff --git a/drivers/net/ena/base/ena_plat_dpdk.h b/drivers/net/ena/base/ena_plat_dpdk.h
+index ff873e807..791b44ff7 100644
+--- a/drivers/net/ena/base/ena_plat_dpdk.h
++++ b/drivers/net/ena/base/ena_plat_dpdk.h
+@@ -115,11 +115,13 @@ typedef uint64_t dma_addr_t;
+ #define ENA_MIN16(x, y) RTE_MIN((x), (y))
+ #define ENA_MIN8(x, y) RTE_MIN((x), (y))
+ 
++#define BITS_PER_LONG_LONG (__SIZEOF_LONG_LONG__ * 8)
+ #define U64_C(x) x ## ULL
+ #define BIT(nr)         (1UL << (nr))
+ #define BITS_PER_LONG	(__SIZEOF_LONG__ * 8)
+ #define GENMASK(h, l)	(((~0UL) << (l)) & (~0UL >> (BITS_PER_LONG - 1 - (h))))
+-#define GENMASK_ULL(h, l) (((U64_C(1) << ((h) - (l) + 1)) - 1) << (l))
++#define GENMASK_ULL(h, l) (((~0ULL) - (1ULL << (l)) + 1) & \
++			  (~0ULL >> (BITS_PER_LONG_LONG - 1 - (h))))
+ 
+ #ifdef RTE_LIBRTE_ENA_COM_DEBUG
+ #define ena_trc_dbg(format, arg...)					\
+-- 
+2.14.1
+

--- a/userspace/dpdk/16.11/0010-net-ena-set-link-speed-as-none.patch
+++ b/userspace/dpdk/16.11/0010-net-ena-set-link-speed-as-none.patch
@@ -1,0 +1,37 @@
+From 4eb7356bfeb023d94e90d8022b0a47b6f8ddc1f7 Mon Sep 17 00:00:00 2001
+From: Rafal Kozik <rk@semihalf.com>
+Date: Thu, 7 Jun 2018 11:43:22 +0200
+Subject: [PATCH 10/12] net/ena: set link speed as none
+
+[ upstream commit 41e59028dd8ab2038a7655c6fc3098222661aa53 ]
+
+Link speed should is not limited to 10Gb/s and it shouldn't be hardcoded.
+
+They link speed is set to none instead and the applications shouldn't
+rely on this value when using ENA PMD.
+
+Fixes: 1173fca25af9 ("ena: add polling-mode driver")
+Cc: stable@dpdk.org
+
+Signed-off-by: Rafal Kozik <rk@semihalf.com>
+Acked-by: Michal Krawczyk <mk@semihalf.com>
+---
+ drivers/net/ena/ena_ethdev.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/drivers/net/ena/ena_ethdev.c b/drivers/net/ena/ena_ethdev.c
+index 3e73fe1fb..713f5323e 100644
+--- a/drivers/net/ena/ena_ethdev.c
++++ b/drivers/net/ena/ena_ethdev.c
+@@ -702,7 +702,7 @@ static int ena_link_update(struct rte_eth_dev *dev,
+ 	struct rte_eth_link *link = &dev->data->dev_link;
+ 
+ 	link->link_status = 1;
+-	link->link_speed = ETH_SPEED_NUM_10G;
++	link->link_speed = ETH_SPEED_NUM_NONE;
+ 	link->link_duplex = ETH_LINK_FULL_DUPLEX;
+ 
+ 	return 0;
+-- 
+2.14.1
+

--- a/userspace/dpdk/16.11/0011-net-ena-fix-SIGFPE-with-0-Rx-queue.patch
+++ b/userspace/dpdk/16.11/0011-net-ena-fix-SIGFPE-with-0-Rx-queue.patch
@@ -1,0 +1,35 @@
+From adbc483cacf56071296bb9ffae63e7550bc93979 Mon Sep 17 00:00:00 2001
+From: Daria Kolistratova <daria.kolistratova@intel.com>
+Date: Tue, 26 Jun 2018 18:38:56 +0100
+Subject: [PATCH 11/12] net/ena: fix SIGFPE with 0 Rx queue
+
+[ upstream commit 361913ad6f8c05fc541fe4bfdae3b0dc095ae3af ]
+
+When the number of rx queues is 0 (what can be when application does
+not receive) failed with SIGFPE.
+It happens when the application is also requesting ETH_MQ_RX_RSS_FLAG
+in the rte_dev->data->dev_conf.rxmode.mq_mode.
+Fixed adding zero rx queues check.
+
+Signed-off-by: Daria Kolistratova <daria.kolistratova@intel.com>
+Acked-by: Michal Krawczyk <mk@semihalf.com>
+---
+ drivers/net/ena/ena_ethdev.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/drivers/net/ena/ena_ethdev.c b/drivers/net/ena/ena_ethdev.c
+index 713f5323e..a67065398 100644
+--- a/drivers/net/ena/ena_ethdev.c
++++ b/drivers/net/ena/ena_ethdev.c
+@@ -899,7 +899,7 @@ static int ena_start(struct rte_eth_dev *dev)
+ 		return rc;
+ 
+ 	if (adapter->rte_dev->data->dev_conf.rxmode.mq_mode &
+-	    ETH_MQ_RX_RSS_FLAG) {
++	    ETH_MQ_RX_RSS_FLAG && adapter->rte_dev->data->nb_rx_queues > 0) {
+ 		rc = ena_rss_init_default(adapter);
+ 		if (rc)
+ 			return rc;
+-- 
+2.14.1
+

--- a/userspace/dpdk/16.11/0012-net-ena-fix-passing-RSS-hash-to-mbuf.patch
+++ b/userspace/dpdk/16.11/0012-net-ena-fix-passing-RSS-hash-to-mbuf.patch
@@ -1,0 +1,35 @@
+From 1f39810341c45d0da6322e5302cbc89f3f300750 Mon Sep 17 00:00:00 2001
+From: Stewart Allen <allenste@amazon.com>
+Date: Thu, 25 Oct 2018 19:59:22 +0200
+Subject: [PATCH 12/12] net/ena: fix passing RSS hash to mbuf
+
+[ upstream commit e5df9f33db00eb9d322abaefff30da74fd0e625d ]
+
+The driver was passing to the mbuf Rx queue ID instead of hash received
+from the device. Now, the RSS hash from the Rx descriptor is being set.
+
+Fixes: 1173fca25af9 ("ena: add polling-mode driver")
+Cc: stable@dpdk.org
+
+Signed-off-by: Stewart Allen <allenste@amazon.com>
+Acked-by: Michal Krawczyk <mk@semihalf.com>
+---
+ drivers/net/ena/ena_ethdev.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/drivers/net/ena/ena_ethdev.c b/drivers/net/ena/ena_ethdev.c
+index a67065398..e38407287 100644
+--- a/drivers/net/ena/ena_ethdev.c
++++ b/drivers/net/ena/ena_ethdev.c
+@@ -1558,7 +1558,7 @@ static uint16_t eth_ena_recv_pkts(void *rx_queue, struct rte_mbuf **rx_pkts,
+ 
+ 		/* fill mbuf attributes if any */
+ 		ena_rx_mbuf_prepare(mbuf_head, &ena_rx_ctx);
+-		mbuf_head->hash.rss = (uint32_t)rx_ring->id;
++		mbuf_head->hash.rss = ena_rx_ctx.hash;
+ 
+ 		/* pass to DPDK application head mbuf */
+ 		rx_pkts[recv_idx] = mbuf_head;
+-- 
+2.14.1
+

--- a/userspace/dpdk/17.02/0001-net-ena-fix-Rx-descriptors-allocation.patch
+++ b/userspace/dpdk/17.02/0001-net-ena-fix-Rx-descriptors-allocation.patch
@@ -1,7 +1,7 @@
-From b48023f7ac2a8ddacf646de5dccfbf79f7a917eb Mon Sep 17 00:00:00 2001
+From ad5f91443d2f6596268e7a0619c9509e00ba3b12 Mon Sep 17 00:00:00 2001
 From: Michal Krawczyk <mk@semihalf.com>
 Date: Mon, 10 Apr 2017 16:28:08 +0200
-Subject: [PATCH 1/6] net/ena: fix Rx descriptors allocation
+Subject: [PATCH 01/13] net/ena: fix Rx descriptors allocation
 
 [ upstream commit a467e8f37a3eec98210c0c3ec04bf6e9506ddd81 ]
 
@@ -22,7 +22,7 @@ Acked-by: Jan Medala <jan.medala@outlook.com>
  1 file changed, 6 insertions(+), 4 deletions(-)
 
 diff --git a/drivers/net/ena/ena_ethdev.c b/drivers/net/ena/ena_ethdev.c
-index b5e6db6..90cf2ad 100644
+index b5e6db624..90cf2ad3c 100644
 --- a/drivers/net/ena/ena_ethdev.c
 +++ b/drivers/net/ena/ena_ethdev.c
 @@ -919,7 +919,7 @@ static int ena_start(struct rte_eth_dev *dev)
@@ -64,5 +64,5 @@ index b5e6db6..90cf2ad 100644
  	if (ring_size - desc_in_use > ENA_RING_DESCS_RATIO(ring_size))
  		ena_populate_rx_queue(rx_ring, ring_size - desc_in_use);
 -- 
-2.7.4
+2.14.1
 

--- a/userspace/dpdk/17.02/0002-net-ena-fix-delayed-cleanup-of-Rx-descriptors.patch
+++ b/userspace/dpdk/17.02/0002-net-ena-fix-delayed-cleanup-of-Rx-descriptors.patch
@@ -1,7 +1,7 @@
-From a5777d43c67c4cca34ccaec06b09b4cc33e40699 Mon Sep 17 00:00:00 2001
+From 1e449ffd3b2d11d7d296222fce58de4a12b769c6 Mon Sep 17 00:00:00 2001
 From: Michal Krawczyk <mk@semihalf.com>
 Date: Mon, 10 Apr 2017 16:28:09 +0200
-Subject: [PATCH 2/6] net/ena: fix delayed cleanup of Rx descriptors
+Subject: [PATCH 02/13] net/ena: fix delayed cleanup of Rx descriptors
 
 [ upstream commit ec78af6bc0556cf2a1133185ca33fb835b38afe0 ]
 
@@ -26,7 +26,7 @@ Acked-by: Jan Medala <jan.medala@outlook.com>
  1 file changed, 3 insertions(+), 3 deletions(-)
 
 diff --git a/drivers/net/ena/ena_ethdev.c b/drivers/net/ena/ena_ethdev.c
-index 90cf2ad..b4c713f 100644
+index 90cf2ad3c..b4c713f94 100644
 --- a/drivers/net/ena/ena_ethdev.c
 +++ b/drivers/net/ena/ena_ethdev.c
 @@ -1575,13 +1575,13 @@ static uint16_t eth_ena_recv_pkts(void *rx_queue, struct rte_mbuf **rx_pkts,
@@ -47,5 +47,5 @@ index 90cf2ad..b4c713f 100644
  }
  
 -- 
-2.7.4
+2.14.1
 

--- a/userspace/dpdk/17.02/0003-net-ena-cleanup-if-refilling-of-Rx-descriptors-fails.patch
+++ b/userspace/dpdk/17.02/0003-net-ena-cleanup-if-refilling-of-Rx-descriptors-fails.patch
@@ -1,7 +1,7 @@
-From 87751e3752243b14268cfc1da98cc0c262efea30 Mon Sep 17 00:00:00 2001
+From 1b794e3d217507604a567ba692121ccfff415dd7 Mon Sep 17 00:00:00 2001
 From: Michal Krawczyk <mk@semihalf.com>
 Date: Mon, 10 Apr 2017 16:28:10 +0200
-Subject: [PATCH 3/6] net/ena: cleanup if refilling of Rx descriptors fails
+Subject: [PATCH 03/13] net/ena: cleanup if refilling of Rx descriptors fails
 
 [ upstream commit 2732e07ad1e54c648c8ca5bc6965af5bf607ba10 ]
 
@@ -22,7 +22,7 @@ Acked-by: Jan Medala <jan.medala@outlook.com>
  1 file changed, 2 insertions(+)
 
 diff --git a/drivers/net/ena/ena_ethdev.c b/drivers/net/ena/ena_ethdev.c
-index b4c713f..e6e889b 100644
+index b4c713f94..e6e889bdd 100644
 --- a/drivers/net/ena/ena_ethdev.c
 +++ b/drivers/net/ena/ena_ethdev.c
 @@ -1172,6 +1172,8 @@ static int ena_populate_rx_queue(struct ena_ring *rxq, unsigned int count)
@@ -35,5 +35,5 @@ index b4c713f..e6e889b 100644
  			break;
  		}
 -- 
-2.7.4
+2.14.1
 

--- a/userspace/dpdk/17.02/0004-net-ena-calculate-partial-checksum-if-DF-bit-is-disa.patch
+++ b/userspace/dpdk/17.02/0004-net-ena-calculate-partial-checksum-if-DF-bit-is-disa.patch
@@ -1,7 +1,8 @@
-From c0f6478a684b86bf2f7eb99640dd8e5a1e1d9a4c Mon Sep 17 00:00:00 2001
+From 5ca7ebc1ea8550f502bfb2b176a1348a6adaff7e Mon Sep 17 00:00:00 2001
 From: Michal Krawczyk <mk@semihalf.com>
 Date: Mon, 10 Apr 2017 16:28:11 +0200
-Subject: [PATCH 4/6] net/ena: calculate partial checksum if DF bit is disabled
+Subject: [PATCH 04/13] net/ena: calculate partial checksum if DF bit is
+ disabled
 
 When TSO is disabled we still have to calculate partial checksum if DF bit
 if turned off. This is caused by firmware bug.
@@ -23,7 +24,7 @@ Acked-by: Jan Medala <jan.medala@outlook.com>
  1 file changed, 23 insertions(+), 13 deletions(-)
 
 diff --git a/drivers/net/ena/ena_ethdev.c b/drivers/net/ena/ena_ethdev.c
-index e6e889b..3ba9901 100644
+index e6e889bdd..3ba990142 100644
 --- a/drivers/net/ena/ena_ethdev.c
 +++ b/drivers/net/ena/ena_ethdev.c
 @@ -1599,14 +1599,33 @@ eth_ena_prep_pkts(void *tx_queue, struct rte_mbuf **tx_pkts,
@@ -81,5 +82,5 @@ index e6e889b..3ba9901 100644
  		 * hardware must be provided with partial checksum, otherwise
  		 * it will take care of necessary calculations.
 -- 
-2.7.4
+2.14.1
 

--- a/userspace/dpdk/17.02/0005-net-ena-fix-cleanup-of-the-Tx-bufs.patch
+++ b/userspace/dpdk/17.02/0005-net-ena-fix-cleanup-of-the-Tx-bufs.patch
@@ -1,7 +1,7 @@
-From d01de580d9c37d947ed5694554e54650155c8f6f Mon Sep 17 00:00:00 2001
+From d91417989f5750386457b45237c8eb10283260e6 Mon Sep 17 00:00:00 2001
 From: Michal Krawczyk <mk@semihalf.com>
 Date: Fri, 16 Jun 2017 08:19:16 +0000
-Subject: [PATCH 5/6] net/ena: fix cleanup of the Tx bufs
+Subject: [PATCH 05/13] net/ena: fix cleanup of the Tx bufs
 
 After cleanup of the mbuf on Tx path, queue was still pointing to this
 mbuf and upon cleanup of the Tx buffers, it was being freed second time.
@@ -14,7 +14,7 @@ range between head and tail was being cleaned up.
  1 file changed, 4 insertions(+), 4 deletions(-)
 
 diff --git a/drivers/net/ena/ena_ethdev.c b/drivers/net/ena/ena_ethdev.c
-index 3ba9901..7fca027 100644
+index 3ba990142..7fca0278d 100644
 --- a/drivers/net/ena/ena_ethdev.c
 +++ b/drivers/net/ena/ena_ethdev.c
 @@ -688,11 +688,10 @@ static void ena_rx_queue_release_bufs(struct ena_ring *ring)
@@ -41,5 +41,5 @@ index 3ba9901..7fca027 100644
  		/* Put back descriptor to the ring for reuse */
  		tx_ring->empty_tx_reqs[next_to_clean & ring_mask] = req_id;
 -- 
-2.7.4
+2.14.1
 

--- a/userspace/dpdk/17.02/0006-net-ena-add-memory-initialization-for-the-allocation.patch
+++ b/userspace/dpdk/17.02/0006-net-ena-add-memory-initialization-for-the-allocation.patch
@@ -1,7 +1,7 @@
-From 35e14ab46a9fb75bc33acc193404b29f3a4932ba Mon Sep 17 00:00:00 2001
+From c62d9188ae77242249f22d7e8a63b3ecaa17c2fe Mon Sep 17 00:00:00 2001
 From: Michal Krawczyk <mk@semihalf.com>
 Date: Fri, 16 Jun 2017 09:10:48 +0000
-Subject: [PATCH 6/6] net/ena: add memory initialization for the allocation
+Subject: [PATCH 06/13] net/ena: add memory initialization for the allocation
  macros
 
 Uninitilized memory could cause memory corruption, by indicating
@@ -11,7 +11,7 @@ completion of the invalid mbuf.
  1 file changed, 2 insertions(+)
 
 diff --git a/drivers/net/ena/base/ena_plat_dpdk.h b/drivers/net/ena/base/ena_plat_dpdk.h
-index 7eaebf4..71a8c1e 100644
+index 7eaebf40f..71a8c1e22 100644
 --- a/drivers/net/ena/base/ena_plat_dpdk.h
 +++ b/drivers/net/ena/base/ena_plat_dpdk.h
 @@ -207,6 +207,7 @@ typedef uint64_t dma_addr_t;
@@ -31,5 +31,5 @@ index 7eaebf4..71a8c1e 100644
  	} while (0)
  
 -- 
-2.7.4
+2.14.1
 

--- a/userspace/dpdk/17.02/0007-net-ena-TX-L4-offload-flags-should-not-be-set-in-RX-.patch
+++ b/userspace/dpdk/17.02/0007-net-ena-TX-L4-offload-flags-should-not-be-set-in-RX-.patch
@@ -1,7 +1,8 @@
 From 0793c84c650946f4814086a72075b329e161455c Mon Sep 17 00:00:00 2001
 From: Rafal Kozik <rk@semihalf.com>
 Date: Tue, 9 Jan 2018 16:19:08 +0100
-Subject: [PATCH 7/7] net/ena: TX L4 offload flags should not be set in RX path
+Subject: [PATCH 07/13] net/ena: TX L4 offload flags should not be set in RX
+ path
 
 Information about received packet type detected by NIC should be stored
 in packet_type field of rte_mbuf. TX L4 offload flags should not be set

--- a/userspace/dpdk/17.02/0008-net-ena-check-pointer-before-memset.patch
+++ b/userspace/dpdk/17.02/0008-net-ena-check-pointer-before-memset.patch
@@ -1,0 +1,63 @@
+From 226bbeef8ff71b0fb8d303cac6fcf2946d2bce0a Mon Sep 17 00:00:00 2001
+From: Rafal Kozik <rk@semihalf.com>
+Date: Thu, 7 Jun 2018 11:43:18 +0200
+Subject: [PATCH 08/13] net/ena: check pointer before memset
+
+[ upstream commit 46916aa17d4b2007df8c0454f99ba0ca8b8cb93b ]
+
+Need to check if memory allocation succeed before using it.
+Using memset on NULL pointer cause segfault.
+
+Fixes: 9ba7981ec992 ("ena: add communication layer for DPDK")
+Cc: stable@dpdk.org
+
+Signed-off-by: Rafal Kozik <rk@semihalf.com>
+Acked-by: Michal Krawczyk <mk@semihalf.com>
+---
+ drivers/net/ena/base/ena_plat_dpdk.h | 22 ++++++++++++++++------
+ 1 file changed, 16 insertions(+), 6 deletions(-)
+
+diff --git a/drivers/net/ena/base/ena_plat_dpdk.h b/drivers/net/ena/base/ena_plat_dpdk.h
+index 71a8c1e22..955d6302d 100644
+--- a/drivers/net/ena/base/ena_plat_dpdk.h
++++ b/drivers/net/ena/base/ena_plat_dpdk.h
+@@ -189,10 +189,15 @@ typedef uint64_t dma_addr_t;
+ 		snprintf(z_name, sizeof(z_name),			\
+ 				"ena_alloc_%d", ena_alloc_cnt++);	\
+ 		mz = rte_memzone_reserve(z_name, size, SOCKET_ID_ANY, 0); \
+-		memset(mz->addr, 0, size);				\
+-		virt = mz->addr;					\
+-		phys = mz->phys_addr;					\
+ 		handle = mz;						\
++		if (mz == NULL) {					\
++			virt = NULL;					\
++			phys = 0;					\
++		} else {						\
++			memset(mz->addr, 0, size);			\
++			virt = mz->addr;				\
++			phys = mz->phys_addr;				\
++		}							\
+ 	} while (0)
+ #define ENA_MEM_FREE_COHERENT(dmadev, size, virt, phys, handle) 	\
+ 		({ ENA_TOUCH(size); ENA_TOUCH(phys);			\
+@@ -207,9 +212,14 @@ typedef uint64_t dma_addr_t;
+ 		snprintf(z_name, sizeof(z_name),			\
+ 				"ena_alloc_%d", ena_alloc_cnt++);	\
+ 		mz = rte_memzone_reserve(z_name, size, node, 0); \
+-		memset(mz->addr, 0, size);				\
+-		virt = mz->addr;					\
+-		phys = mz->phys_addr;					\
++		if (mz == NULL) {					\
++			virt = NULL;					\
++			phys = 0;					\
++		} else {						\
++			memset(mz->addr, 0, size);			\
++			virt = mz->addr;				\
++			phys = mz->phys_addr;				\
++		}							\
+ 	} while (0)
+ 
+ #define ENA_MEM_ALLOC_NODE(dmadev, size, virt, node, dev_node) \
+-- 
+2.14.1
+

--- a/userspace/dpdk/17.02/0009-net-ena-change-memory-type.patch
+++ b/userspace/dpdk/17.02/0009-net-ena-change-memory-type.patch
@@ -1,0 +1,45 @@
+From f32cbdad06f7801f16f7c5271880e6d5c440c4e5 Mon Sep 17 00:00:00 2001
+From: Rafal Kozik <rk@semihalf.com>
+Date: Thu, 7 Jun 2018 11:43:19 +0200
+Subject: [PATCH 09/13] net/ena: change memory type
+
+[ upstream commit 9f32c7e7e6ce58ab772913f54f8328c1c0186a17 ]
+
+ENA_MEM_ALLOC_NODE not need to use contiguous physical memory.
+Also using memset without checking if allocation succeed can cause
+segmentation fault.
+
+To avoid both issue use rte_zmalloc_socket.
+
+Fixes: 3d3edc265fc8 ("net/ena: make coherent memory allocation NUMA-aware")
+Cc: stable@dpdk.org
+
+Signed-off-by: Rafal Kozik <rk@semihalf.com>
+Acked-by: Michal Krawczyk <mk@semihalf.com>
+---
+ drivers/net/ena/base/ena_plat_dpdk.h | 8 +-------
+ 1 file changed, 1 insertion(+), 7 deletions(-)
+
+diff --git a/drivers/net/ena/base/ena_plat_dpdk.h b/drivers/net/ena/base/ena_plat_dpdk.h
+index 955d6302d..977bee49f 100644
+--- a/drivers/net/ena/base/ena_plat_dpdk.h
++++ b/drivers/net/ena/base/ena_plat_dpdk.h
+@@ -224,14 +224,8 @@ typedef uint64_t dma_addr_t;
+ 
+ #define ENA_MEM_ALLOC_NODE(dmadev, size, virt, node, dev_node) \
+ 	do {								\
+-		const struct rte_memzone *mz;				\
+-		char z_name[RTE_MEMZONE_NAMESIZE];			\
+ 		ENA_TOUCH(dmadev); ENA_TOUCH(dev_node);			\
+-		snprintf(z_name, sizeof(z_name),			\
+-				"ena_alloc_%d", ena_alloc_cnt++);	\
+-		mz = rte_memzone_reserve(z_name, size, node, 0); \
+-		memset(mz->addr, 0, size);				\
+-		virt = mz->addr;					\
++		virt = rte_zmalloc_socket(NULL, size, 0, node);		\
+ 	} while (0)
+ 
+ #define ENA_MEM_ALLOC(dmadev, size) rte_zmalloc(NULL, size, 1)
+-- 
+2.14.1
+

--- a/userspace/dpdk/17.02/0010-net-ena-fix-GENMASK_ULL-macro.patch
+++ b/userspace/dpdk/17.02/0010-net-ena-fix-GENMASK_ULL-macro.patch
@@ -1,0 +1,42 @@
+From 430ba7897b4d0c8bab367f9f68fa0b1c1ec75980 Mon Sep 17 00:00:00 2001
+From: Rafal Kozik <rk@semihalf.com>
+Date: Thu, 7 Jun 2018 11:43:20 +0200
+Subject: [PATCH 10/13] net/ena: fix GENMASK_ULL macro
+
+[ upstream commit 7544aee8d0b4ae0262b1ba7e1539cf8171664df7 ]
+
+When use GENMASK_ULL(63,0) left shift by 64 bits is performed.
+Shifting by number greater or equal then word length
+is undefined operation and failed on some platforms.
+
+Fixes: 9ba7981ec992 ("ena: add communication layer for DPDK")
+Cc: stable@dpdk.org
+
+Signed-off-by: Rafal Kozik <rk@semihalf.com>
+Acked-by: Michal Krawczyk <mk@semihalf.com>
+---
+ drivers/net/ena/base/ena_plat_dpdk.h | 4 +++-
+ 1 file changed, 3 insertions(+), 1 deletion(-)
+
+diff --git a/drivers/net/ena/base/ena_plat_dpdk.h b/drivers/net/ena/base/ena_plat_dpdk.h
+index 977bee49f..06b637870 100644
+--- a/drivers/net/ena/base/ena_plat_dpdk.h
++++ b/drivers/net/ena/base/ena_plat_dpdk.h
+@@ -116,11 +116,13 @@ typedef uint64_t dma_addr_t;
+ #define ENA_MIN16(x, y) RTE_MIN((x), (y))
+ #define ENA_MIN8(x, y) RTE_MIN((x), (y))
+ 
++#define BITS_PER_LONG_LONG (__SIZEOF_LONG_LONG__ * 8)
+ #define U64_C(x) x ## ULL
+ #define BIT(nr)         (1UL << (nr))
+ #define BITS_PER_LONG	(__SIZEOF_LONG__ * 8)
+ #define GENMASK(h, l)	(((~0UL) << (l)) & (~0UL >> (BITS_PER_LONG - 1 - (h))))
+-#define GENMASK_ULL(h, l) (((U64_C(1) << ((h) - (l) + 1)) - 1) << (l))
++#define GENMASK_ULL(h, l) (((~0ULL) - (1ULL << (l)) + 1) & \
++			  (~0ULL >> (BITS_PER_LONG_LONG - 1 - (h))))
+ 
+ #ifdef RTE_LIBRTE_ENA_COM_DEBUG
+ #define ena_trc_dbg(format, arg...)					\
+-- 
+2.14.1
+

--- a/userspace/dpdk/17.02/0011-net-ena-set-link-speed-as-none.patch
+++ b/userspace/dpdk/17.02/0011-net-ena-set-link-speed-as-none.patch
@@ -1,0 +1,37 @@
+From e1076584de59cdf79ec44639c8fc0969f3714bc4 Mon Sep 17 00:00:00 2001
+From: Rafal Kozik <rk@semihalf.com>
+Date: Thu, 7 Jun 2018 11:43:22 +0200
+Subject: [PATCH 11/13] net/ena: set link speed as none
+
+[ upstream commit 41e59028dd8ab2038a7655c6fc3098222661aa53 ]
+
+Link speed should is not limited to 10Gb/s and it shouldn't be hardcoded.
+
+They link speed is set to none instead and the applications shouldn't
+rely on this value when using ENA PMD.
+
+Fixes: 1173fca25af9 ("ena: add polling-mode driver")
+Cc: stable@dpdk.org
+
+Signed-off-by: Rafal Kozik <rk@semihalf.com>
+Acked-by: Michal Krawczyk <mk@semihalf.com>
+---
+ drivers/net/ena/ena_ethdev.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/drivers/net/ena/ena_ethdev.c b/drivers/net/ena/ena_ethdev.c
+index b7812c62b..13eeb6b7b 100644
+--- a/drivers/net/ena/ena_ethdev.c
++++ b/drivers/net/ena/ena_ethdev.c
+@@ -708,7 +708,7 @@ static int ena_link_update(struct rte_eth_dev *dev,
+ 	struct rte_eth_link *link = &dev->data->dev_link;
+ 
+ 	link->link_status = 1;
+-	link->link_speed = ETH_SPEED_NUM_10G;
++	link->link_speed = ETH_SPEED_NUM_NONE;
+ 	link->link_duplex = ETH_LINK_FULL_DUPLEX;
+ 
+ 	return 0;
+-- 
+2.14.1
+

--- a/userspace/dpdk/17.02/0012-net-ena-fix-SIGFPE-with-0-Rx-queue.patch
+++ b/userspace/dpdk/17.02/0012-net-ena-fix-SIGFPE-with-0-Rx-queue.patch
@@ -1,0 +1,35 @@
+From 0622e8498dc4009972013fcf5475dfd61029e5d2 Mon Sep 17 00:00:00 2001
+From: Daria Kolistratova <daria.kolistratova@intel.com>
+Date: Tue, 26 Jun 2018 18:38:56 +0100
+Subject: [PATCH 12/13] net/ena: fix SIGFPE with 0 Rx queue
+
+[ upstream commit 361913ad6f8c05fc541fe4bfdae3b0dc095ae3af ]
+
+When the number of rx queues is 0 (what can be when application does
+not receive) failed with SIGFPE.
+It happens when the application is also requesting ETH_MQ_RX_RSS_FLAG
+in the rte_dev->data->dev_conf.rxmode.mq_mode.
+Fixed adding zero rx queues check.
+
+Signed-off-by: Daria Kolistratova <daria.kolistratova@intel.com>
+Acked-by: Michal Krawczyk <mk@semihalf.com>
+---
+ drivers/net/ena/ena_ethdev.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/drivers/net/ena/ena_ethdev.c b/drivers/net/ena/ena_ethdev.c
+index 13eeb6b7b..72473e06a 100644
+--- a/drivers/net/ena/ena_ethdev.c
++++ b/drivers/net/ena/ena_ethdev.c
+@@ -905,7 +905,7 @@ static int ena_start(struct rte_eth_dev *dev)
+ 		return rc;
+ 
+ 	if (adapter->rte_dev->data->dev_conf.rxmode.mq_mode &
+-	    ETH_MQ_RX_RSS_FLAG) {
++	    ETH_MQ_RX_RSS_FLAG && adapter->rte_dev->data->nb_rx_queues > 0) {
+ 		rc = ena_rss_init_default(adapter);
+ 		if (rc)
+ 			return rc;
+-- 
+2.14.1
+

--- a/userspace/dpdk/17.02/0013-net-ena-fix-passing-RSS-hash-to-mbuf.patch
+++ b/userspace/dpdk/17.02/0013-net-ena-fix-passing-RSS-hash-to-mbuf.patch
@@ -1,0 +1,35 @@
+From bfba48718737bf328c6b3c385110ffa98a022b0d Mon Sep 17 00:00:00 2001
+From: Stewart Allen <allenste@amazon.com>
+Date: Thu, 25 Oct 2018 19:59:22 +0200
+Subject: [PATCH 13/13] net/ena: fix passing RSS hash to mbuf
+
+[ upstream commit e5df9f33db00eb9d322abaefff30da74fd0e625d ]
+
+The driver was passing to the mbuf Rx queue ID instead of hash received
+from the device. Now, the RSS hash from the Rx descriptor is being set.
+
+Fixes: 1173fca25af9 ("ena: add polling-mode driver")
+Cc: stable@dpdk.org
+
+Signed-off-by: Stewart Allen <allenste@amazon.com>
+Acked-by: Michal Krawczyk <mk@semihalf.com>
+---
+ drivers/net/ena/ena_ethdev.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/drivers/net/ena/ena_ethdev.c b/drivers/net/ena/ena_ethdev.c
+index 72473e06a..837ab468c 100644
+--- a/drivers/net/ena/ena_ethdev.c
++++ b/drivers/net/ena/ena_ethdev.c
+@@ -1571,7 +1571,7 @@ static uint16_t eth_ena_recv_pkts(void *rx_queue, struct rte_mbuf **rx_pkts,
+ 
+ 		/* fill mbuf attributes if any */
+ 		ena_rx_mbuf_prepare(mbuf_head, &ena_rx_ctx);
+-		mbuf_head->hash.rss = (uint32_t)rx_ring->id;
++		mbuf_head->hash.rss = ena_rx_ctx.hash;
+ 
+ 		/* pass to DPDK application head mbuf */
+ 		rx_pkts[recv_idx] = mbuf_head;
+-- 
+2.14.1
+

--- a/userspace/dpdk/17.05/0001-net-ena-fix-cleanup-of-the-Tx-bufs.patch
+++ b/userspace/dpdk/17.05/0001-net-ena-fix-cleanup-of-the-Tx-bufs.patch
@@ -1,7 +1,7 @@
-From 8fe8d97eba16389217155fa5a47ea1db4ebdce4f Mon Sep 17 00:00:00 2001
+From d3e13919d15c950b97696126bf0d4861494ad10b Mon Sep 17 00:00:00 2001
 From: Michal Krawczyk <mk@semihalf.com>
 Date: Fri, 16 Jun 2017 08:19:16 +0000
-Subject: [PATCH 1/2] net/ena: fix cleanup of the Tx bufs
+Subject: [PATCH 1/9] net/ena: fix cleanup of the Tx bufs
 
 After cleanup of the mbuf on Tx path, queue was still pointing to this
 mbuf and upon cleanup of the Tx buffers, it was being freed second time.
@@ -14,7 +14,7 @@ range between head and tail was being cleaned up.
  1 file changed, 4 insertions(+), 4 deletions(-)
 
 diff --git a/drivers/net/ena/ena_ethdev.c b/drivers/net/ena/ena_ethdev.c
-index 64fee05..ce07a26 100644
+index 64fee05d3..ce07a26d0 100644
 --- a/drivers/net/ena/ena_ethdev.c
 +++ b/drivers/net/ena/ena_ethdev.c
 @@ -689,11 +689,10 @@ static void ena_rx_queue_release_bufs(struct ena_ring *ring)
@@ -41,5 +41,5 @@ index 64fee05..ce07a26 100644
  		/* Put back descriptor to the ring for reuse */
  		tx_ring->empty_tx_reqs[next_to_clean & ring_mask] = req_id;
 -- 
-2.7.4
+2.14.1
 

--- a/userspace/dpdk/17.05/0002-net-ena-add-memory-initialization-for-the-allocation.patch
+++ b/userspace/dpdk/17.05/0002-net-ena-add-memory-initialization-for-the-allocation.patch
@@ -1,7 +1,7 @@
-From 639348ce1f9d7a23c57a3db151084cf39b5d3099 Mon Sep 17 00:00:00 2001
+From 3c96ed02a9285d15b8a4975e6c16a30965cbd088 Mon Sep 17 00:00:00 2001
 From: Michal Krawczyk <mk@semihalf.com>
 Date: Fri, 16 Jun 2017 09:10:48 +0000
-Subject: [PATCH 2/2] net/ena: add memory initialization for the allocation
+Subject: [PATCH 2/9] net/ena: add memory initialization for the allocation
  macros
 
 Uninitilized memory could cause memory corruption, by indicating
@@ -11,7 +11,7 @@ completion of the invalid mbuf.
  1 file changed, 2 insertions(+)
 
 diff --git a/drivers/net/ena/base/ena_plat_dpdk.h b/drivers/net/ena/base/ena_plat_dpdk.h
-index 7eaebf4..71a8c1e 100644
+index 7eaebf40f..71a8c1e22 100644
 --- a/drivers/net/ena/base/ena_plat_dpdk.h
 +++ b/drivers/net/ena/base/ena_plat_dpdk.h
 @@ -207,6 +207,7 @@ typedef uint64_t dma_addr_t;
@@ -31,5 +31,5 @@ index 7eaebf4..71a8c1e 100644
  	} while (0)
  
 -- 
-2.7.4
+2.14.1
 

--- a/userspace/dpdk/17.05/0003-net-ena-TX-L4-offload-flags-should-not-be-set-in-RX-.patch
+++ b/userspace/dpdk/17.05/0003-net-ena-TX-L4-offload-flags-should-not-be-set-in-RX-.patch
@@ -1,7 +1,7 @@
 From 983994bc5959bb40320e748aa90d5367b46f1ec1 Mon Sep 17 00:00:00 2001
 From: Rafal Kozik <rk@semihalf.com>
 Date: Tue, 9 Jan 2018 16:19:08 +0100
-Subject: [PATCH 3/3] net/ena: TX L4 offload flags should not be set in RX path
+Subject: [PATCH 3/9] net/ena: TX L4 offload flags should not be set in RX path
 
 Information about received packet type detected by NIC should be stored
 in packet_type field of rte_mbuf. TX L4 offload flags should not be set

--- a/userspace/dpdk/17.05/0004-net-ena-check-pointer-before-memset.patch
+++ b/userspace/dpdk/17.05/0004-net-ena-check-pointer-before-memset.patch
@@ -1,0 +1,63 @@
+From c680b65bc1dd3874189a4acfa80ea70762b0b4ce Mon Sep 17 00:00:00 2001
+From: Rafal Kozik <rk@semihalf.com>
+Date: Thu, 7 Jun 2018 11:43:18 +0200
+Subject: [PATCH 4/9] net/ena: check pointer before memset
+
+[ upstream commit 46916aa17d4b2007df8c0454f99ba0ca8b8cb93b ]
+
+Need to check if memory allocation succeed before using it.
+Using memset on NULL pointer cause segfault.
+
+Fixes: 9ba7981ec992 ("ena: add communication layer for DPDK")
+Cc: stable@dpdk.org
+
+Signed-off-by: Rafal Kozik <rk@semihalf.com>
+Acked-by: Michal Krawczyk <mk@semihalf.com>
+---
+ drivers/net/ena/base/ena_plat_dpdk.h | 22 ++++++++++++++++------
+ 1 file changed, 16 insertions(+), 6 deletions(-)
+
+diff --git a/drivers/net/ena/base/ena_plat_dpdk.h b/drivers/net/ena/base/ena_plat_dpdk.h
+index 71a8c1e22..955d6302d 100644
+--- a/drivers/net/ena/base/ena_plat_dpdk.h
++++ b/drivers/net/ena/base/ena_plat_dpdk.h
+@@ -189,10 +189,15 @@ typedef uint64_t dma_addr_t;
+ 		snprintf(z_name, sizeof(z_name),			\
+ 				"ena_alloc_%d", ena_alloc_cnt++);	\
+ 		mz = rte_memzone_reserve(z_name, size, SOCKET_ID_ANY, 0); \
+-		memset(mz->addr, 0, size);				\
+-		virt = mz->addr;					\
+-		phys = mz->phys_addr;					\
+ 		handle = mz;						\
++		if (mz == NULL) {					\
++			virt = NULL;					\
++			phys = 0;					\
++		} else {						\
++			memset(mz->addr, 0, size);			\
++			virt = mz->addr;				\
++			phys = mz->phys_addr;				\
++		}							\
+ 	} while (0)
+ #define ENA_MEM_FREE_COHERENT(dmadev, size, virt, phys, handle) 	\
+ 		({ ENA_TOUCH(size); ENA_TOUCH(phys);			\
+@@ -207,9 +212,14 @@ typedef uint64_t dma_addr_t;
+ 		snprintf(z_name, sizeof(z_name),			\
+ 				"ena_alloc_%d", ena_alloc_cnt++);	\
+ 		mz = rte_memzone_reserve(z_name, size, node, 0); \
+-		memset(mz->addr, 0, size);				\
+-		virt = mz->addr;					\
+-		phys = mz->phys_addr;					\
++		if (mz == NULL) {					\
++			virt = NULL;					\
++			phys = 0;					\
++		} else {						\
++			memset(mz->addr, 0, size);			\
++			virt = mz->addr;				\
++			phys = mz->phys_addr;				\
++		}							\
+ 	} while (0)
+ 
+ #define ENA_MEM_ALLOC_NODE(dmadev, size, virt, node, dev_node) \
+-- 
+2.14.1
+

--- a/userspace/dpdk/17.05/0005-net-ena-change-memory-type.patch
+++ b/userspace/dpdk/17.05/0005-net-ena-change-memory-type.patch
@@ -1,0 +1,45 @@
+From c2c5a26b6665c452d5a3673fe6e2165ec6fe715b Mon Sep 17 00:00:00 2001
+From: Rafal Kozik <rk@semihalf.com>
+Date: Thu, 7 Jun 2018 11:43:19 +0200
+Subject: [PATCH 5/9] net/ena: change memory type
+
+[ upstream commit 9f32c7e7e6ce58ab772913f54f8328c1c0186a17 ]
+
+ENA_MEM_ALLOC_NODE not need to use contiguous physical memory.
+Also using memset without checking if allocation succeed can cause
+segmentation fault.
+
+To avoid both issue use rte_zmalloc_socket.
+
+Fixes: 3d3edc265fc8 ("net/ena: make coherent memory allocation NUMA-aware")
+Cc: stable@dpdk.org
+
+Signed-off-by: Rafal Kozik <rk@semihalf.com>
+Acked-by: Michal Krawczyk <mk@semihalf.com>
+---
+ drivers/net/ena/base/ena_plat_dpdk.h | 8 +-------
+ 1 file changed, 1 insertion(+), 7 deletions(-)
+
+diff --git a/drivers/net/ena/base/ena_plat_dpdk.h b/drivers/net/ena/base/ena_plat_dpdk.h
+index 955d6302d..977bee49f 100644
+--- a/drivers/net/ena/base/ena_plat_dpdk.h
++++ b/drivers/net/ena/base/ena_plat_dpdk.h
+@@ -224,14 +224,8 @@ typedef uint64_t dma_addr_t;
+ 
+ #define ENA_MEM_ALLOC_NODE(dmadev, size, virt, node, dev_node) \
+ 	do {								\
+-		const struct rte_memzone *mz;				\
+-		char z_name[RTE_MEMZONE_NAMESIZE];			\
+ 		ENA_TOUCH(dmadev); ENA_TOUCH(dev_node);			\
+-		snprintf(z_name, sizeof(z_name),			\
+-				"ena_alloc_%d", ena_alloc_cnt++);	\
+-		mz = rte_memzone_reserve(z_name, size, node, 0); \
+-		memset(mz->addr, 0, size);				\
+-		virt = mz->addr;					\
++		virt = rte_zmalloc_socket(NULL, size, 0, node);		\
+ 	} while (0)
+ 
+ #define ENA_MEM_ALLOC(dmadev, size) rte_zmalloc(NULL, size, 1)
+-- 
+2.14.1
+

--- a/userspace/dpdk/17.05/0006-net-ena-fix-GENMASK_ULL-macro.patch
+++ b/userspace/dpdk/17.05/0006-net-ena-fix-GENMASK_ULL-macro.patch
@@ -1,0 +1,42 @@
+From 73a9b2019ab8cd397c4ae4654f35a3ff58dc8acf Mon Sep 17 00:00:00 2001
+From: Rafal Kozik <rk@semihalf.com>
+Date: Thu, 7 Jun 2018 11:43:20 +0200
+Subject: [PATCH 6/9] net/ena: fix GENMASK_ULL macro
+
+[ upstream commit 7544aee8d0b4ae0262b1ba7e1539cf8171664df7 ]
+
+When use GENMASK_ULL(63,0) left shift by 64 bits is performed.
+Shifting by number greater or equal then word length
+is undefined operation and failed on some platforms.
+
+Fixes: 9ba7981ec992 ("ena: add communication layer for DPDK")
+Cc: stable@dpdk.org
+
+Signed-off-by: Rafal Kozik <rk@semihalf.com>
+Acked-by: Michal Krawczyk <mk@semihalf.com>
+---
+ drivers/net/ena/base/ena_plat_dpdk.h | 4 +++-
+ 1 file changed, 3 insertions(+), 1 deletion(-)
+
+diff --git a/drivers/net/ena/base/ena_plat_dpdk.h b/drivers/net/ena/base/ena_plat_dpdk.h
+index 977bee49f..06b637870 100644
+--- a/drivers/net/ena/base/ena_plat_dpdk.h
++++ b/drivers/net/ena/base/ena_plat_dpdk.h
+@@ -116,11 +116,13 @@ typedef uint64_t dma_addr_t;
+ #define ENA_MIN16(x, y) RTE_MIN((x), (y))
+ #define ENA_MIN8(x, y) RTE_MIN((x), (y))
+ 
++#define BITS_PER_LONG_LONG (__SIZEOF_LONG_LONG__ * 8)
+ #define U64_C(x) x ## ULL
+ #define BIT(nr)         (1UL << (nr))
+ #define BITS_PER_LONG	(__SIZEOF_LONG__ * 8)
+ #define GENMASK(h, l)	(((~0UL) << (l)) & (~0UL >> (BITS_PER_LONG - 1 - (h))))
+-#define GENMASK_ULL(h, l) (((U64_C(1) << ((h) - (l) + 1)) - 1) << (l))
++#define GENMASK_ULL(h, l) (((~0ULL) - (1ULL << (l)) + 1) & \
++			  (~0ULL >> (BITS_PER_LONG_LONG - 1 - (h))))
+ 
+ #ifdef RTE_LIBRTE_ENA_COM_DEBUG
+ #define ena_trc_dbg(format, arg...)					\
+-- 
+2.14.1
+

--- a/userspace/dpdk/17.05/0007-net-ena-set-link-speed-as-none.patch
+++ b/userspace/dpdk/17.05/0007-net-ena-set-link-speed-as-none.patch
@@ -1,0 +1,37 @@
+From 665d2ab1d999ab1efcdaf46bbe94ddce3cd50e70 Mon Sep 17 00:00:00 2001
+From: Rafal Kozik <rk@semihalf.com>
+Date: Thu, 7 Jun 2018 11:43:22 +0200
+Subject: [PATCH 7/9] net/ena: set link speed as none
+
+[ upstream commit 41e59028dd8ab2038a7655c6fc3098222661aa53 ]
+
+Link speed should is not limited to 10Gb/s and it shouldn't be hardcoded.
+
+They link speed is set to none instead and the applications shouldn't
+rely on this value when using ENA PMD.
+
+Fixes: 1173fca25af9 ("ena: add polling-mode driver")
+Cc: stable@dpdk.org
+
+Signed-off-by: Rafal Kozik <rk@semihalf.com>
+Acked-by: Michal Krawczyk <mk@semihalf.com>
+---
+ drivers/net/ena/ena_ethdev.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/drivers/net/ena/ena_ethdev.c b/drivers/net/ena/ena_ethdev.c
+index 58b0b6355..185fc6fca 100644
+--- a/drivers/net/ena/ena_ethdev.c
++++ b/drivers/net/ena/ena_ethdev.c
+@@ -709,7 +709,7 @@ static int ena_link_update(struct rte_eth_dev *dev,
+ 	struct rte_eth_link *link = &dev->data->dev_link;
+ 
+ 	link->link_status = 1;
+-	link->link_speed = ETH_SPEED_NUM_10G;
++	link->link_speed = ETH_SPEED_NUM_NONE;
+ 	link->link_duplex = ETH_LINK_FULL_DUPLEX;
+ 
+ 	return 0;
+-- 
+2.14.1
+

--- a/userspace/dpdk/17.05/0008-net-ena-fix-SIGFPE-with-0-Rx-queue.patch
+++ b/userspace/dpdk/17.05/0008-net-ena-fix-SIGFPE-with-0-Rx-queue.patch
@@ -1,0 +1,35 @@
+From 0bf212a542cec7978d7599eb55285d5478f94071 Mon Sep 17 00:00:00 2001
+From: Daria Kolistratova <daria.kolistratova@intel.com>
+Date: Tue, 26 Jun 2018 18:38:56 +0100
+Subject: [PATCH 8/9] net/ena: fix SIGFPE with 0 Rx queue
+
+[ upstream commit 361913ad6f8c05fc541fe4bfdae3b0dc095ae3af ]
+
+When the number of rx queues is 0 (what can be when application does
+not receive) failed with SIGFPE.
+It happens when the application is also requesting ETH_MQ_RX_RSS_FLAG
+in the rte_dev->data->dev_conf.rxmode.mq_mode.
+Fixed adding zero rx queues check.
+
+Signed-off-by: Daria Kolistratova <daria.kolistratova@intel.com>
+Acked-by: Michal Krawczyk <mk@semihalf.com>
+---
+ drivers/net/ena/ena_ethdev.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/drivers/net/ena/ena_ethdev.c b/drivers/net/ena/ena_ethdev.c
+index 185fc6fca..52e353c2d 100644
+--- a/drivers/net/ena/ena_ethdev.c
++++ b/drivers/net/ena/ena_ethdev.c
+@@ -906,7 +906,7 @@ static int ena_start(struct rte_eth_dev *dev)
+ 		return rc;
+ 
+ 	if (adapter->rte_dev->data->dev_conf.rxmode.mq_mode &
+-	    ETH_MQ_RX_RSS_FLAG) {
++	    ETH_MQ_RX_RSS_FLAG && adapter->rte_dev->data->nb_rx_queues > 0) {
+ 		rc = ena_rss_init_default(adapter);
+ 		if (rc)
+ 			return rc;
+-- 
+2.14.1
+

--- a/userspace/dpdk/17.05/0009-net-ena-fix-passing-RSS-hash-to-mbuf.patch
+++ b/userspace/dpdk/17.05/0009-net-ena-fix-passing-RSS-hash-to-mbuf.patch
@@ -1,0 +1,35 @@
+From f2a4ba8bbbbd7aaf933225d187a16c8976f841f5 Mon Sep 17 00:00:00 2001
+From: Stewart Allen <allenste@amazon.com>
+Date: Thu, 25 Oct 2018 19:59:22 +0200
+Subject: [PATCH 9/9] net/ena: fix passing RSS hash to mbuf
+
+[ upstream commit e5df9f33db00eb9d322abaefff30da74fd0e625d ]
+
+The driver was passing to the mbuf Rx queue ID instead of hash received
+from the device. Now, the RSS hash from the Rx descriptor is being set.
+
+Fixes: 1173fca25af9 ("ena: add polling-mode driver")
+Cc: stable@dpdk.org
+
+Signed-off-by: Stewart Allen <allenste@amazon.com>
+Acked-by: Michal Krawczyk <mk@semihalf.com>
+---
+ drivers/net/ena/ena_ethdev.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/drivers/net/ena/ena_ethdev.c b/drivers/net/ena/ena_ethdev.c
+index 52e353c2d..aa88309f2 100644
+--- a/drivers/net/ena/ena_ethdev.c
++++ b/drivers/net/ena/ena_ethdev.c
+@@ -1572,7 +1572,7 @@ static uint16_t eth_ena_recv_pkts(void *rx_queue, struct rte_mbuf **rx_pkts,
+ 
+ 		/* fill mbuf attributes if any */
+ 		ena_rx_mbuf_prepare(mbuf_head, &ena_rx_ctx);
+-		mbuf_head->hash.rss = (uint32_t)rx_ring->id;
++		mbuf_head->hash.rss = ena_rx_ctx.hash;
+ 
+ 		/* pass to DPDK application head mbuf */
+ 		rx_pkts[recv_idx] = mbuf_head;
+-- 
+2.14.1
+

--- a/userspace/dpdk/17.08/0001-net-ena-TX-L4-offload-flags-should-not-be-set-in-RX-.patch
+++ b/userspace/dpdk/17.08/0001-net-ena-TX-L4-offload-flags-should-not-be-set-in-RX-.patch
@@ -1,7 +1,7 @@
 From 1b7a4729eb1f069850f5b08f9f00057dac2aa33d Mon Sep 17 00:00:00 2001
 From: Rafal Kozik <rk@semihalf.com>
 Date: Tue, 9 Jan 2018 16:19:08 +0100
-Subject: [PATCH] net/ena: TX L4 offload flags should not be set in RX path
+Subject: [PATCH 1/7] net/ena: TX L4 offload flags should not be set in RX path
 
 Information about received packet type detected by NIC should be stored
 in packet_type field of rte_mbuf. TX L4 offload flags should not be set

--- a/userspace/dpdk/17.08/0002-net-ena-check-pointer-before-memset.patch
+++ b/userspace/dpdk/17.08/0002-net-ena-check-pointer-before-memset.patch
@@ -1,0 +1,63 @@
+From 676d1979aa2df0298639ec43a3beb4f7fd775e8d Mon Sep 17 00:00:00 2001
+From: Rafal Kozik <rk@semihalf.com>
+Date: Thu, 7 Jun 2018 11:43:18 +0200
+Subject: [PATCH 2/7] net/ena: check pointer before memset
+
+[ upstream commit 46916aa17d4b2007df8c0454f99ba0ca8b8cb93b ]
+
+Need to check if memory allocation succeed before using it.
+Using memset on NULL pointer cause segfault.
+
+Fixes: 9ba7981ec992 ("ena: add communication layer for DPDK")
+Cc: stable@dpdk.org
+
+Signed-off-by: Rafal Kozik <rk@semihalf.com>
+Acked-by: Michal Krawczyk <mk@semihalf.com>
+---
+ drivers/net/ena/base/ena_plat_dpdk.h | 22 ++++++++++++++++------
+ 1 file changed, 16 insertions(+), 6 deletions(-)
+
+diff --git a/drivers/net/ena/base/ena_plat_dpdk.h b/drivers/net/ena/base/ena_plat_dpdk.h
+index 71a8c1e22..955d6302d 100644
+--- a/drivers/net/ena/base/ena_plat_dpdk.h
++++ b/drivers/net/ena/base/ena_plat_dpdk.h
+@@ -189,10 +189,15 @@ typedef uint64_t dma_addr_t;
+ 		snprintf(z_name, sizeof(z_name),			\
+ 				"ena_alloc_%d", ena_alloc_cnt++);	\
+ 		mz = rte_memzone_reserve(z_name, size, SOCKET_ID_ANY, 0); \
+-		memset(mz->addr, 0, size);				\
+-		virt = mz->addr;					\
+-		phys = mz->phys_addr;					\
+ 		handle = mz;						\
++		if (mz == NULL) {					\
++			virt = NULL;					\
++			phys = 0;					\
++		} else {						\
++			memset(mz->addr, 0, size);			\
++			virt = mz->addr;				\
++			phys = mz->phys_addr;				\
++		}							\
+ 	} while (0)
+ #define ENA_MEM_FREE_COHERENT(dmadev, size, virt, phys, handle) 	\
+ 		({ ENA_TOUCH(size); ENA_TOUCH(phys);			\
+@@ -207,9 +212,14 @@ typedef uint64_t dma_addr_t;
+ 		snprintf(z_name, sizeof(z_name),			\
+ 				"ena_alloc_%d", ena_alloc_cnt++);	\
+ 		mz = rte_memzone_reserve(z_name, size, node, 0); \
+-		memset(mz->addr, 0, size);				\
+-		virt = mz->addr;					\
+-		phys = mz->phys_addr;					\
++		if (mz == NULL) {					\
++			virt = NULL;					\
++			phys = 0;					\
++		} else {						\
++			memset(mz->addr, 0, size);			\
++			virt = mz->addr;				\
++			phys = mz->phys_addr;				\
++		}							\
+ 	} while (0)
+ 
+ #define ENA_MEM_ALLOC_NODE(dmadev, size, virt, node, dev_node) \
+-- 
+2.14.1
+

--- a/userspace/dpdk/17.08/0003-net-ena-change-memory-type.patch
+++ b/userspace/dpdk/17.08/0003-net-ena-change-memory-type.patch
@@ -1,0 +1,45 @@
+From 1f59f90463634e43e5fbcde044207c855dfe9f1d Mon Sep 17 00:00:00 2001
+From: Rafal Kozik <rk@semihalf.com>
+Date: Thu, 7 Jun 2018 11:43:19 +0200
+Subject: [PATCH 3/7] net/ena: change memory type
+
+[ upstream commit 9f32c7e7e6ce58ab772913f54f8328c1c0186a17 ]
+
+ENA_MEM_ALLOC_NODE not need to use contiguous physical memory.
+Also using memset without checking if allocation succeed can cause
+segmentation fault.
+
+To avoid both issue use rte_zmalloc_socket.
+
+Fixes: 3d3edc265fc8 ("net/ena: make coherent memory allocation NUMA-aware")
+Cc: stable@dpdk.org
+
+Signed-off-by: Rafal Kozik <rk@semihalf.com>
+Acked-by: Michal Krawczyk <mk@semihalf.com>
+---
+ drivers/net/ena/base/ena_plat_dpdk.h | 8 +-------
+ 1 file changed, 1 insertion(+), 7 deletions(-)
+
+diff --git a/drivers/net/ena/base/ena_plat_dpdk.h b/drivers/net/ena/base/ena_plat_dpdk.h
+index 955d6302d..977bee49f 100644
+--- a/drivers/net/ena/base/ena_plat_dpdk.h
++++ b/drivers/net/ena/base/ena_plat_dpdk.h
+@@ -224,14 +224,8 @@ typedef uint64_t dma_addr_t;
+ 
+ #define ENA_MEM_ALLOC_NODE(dmadev, size, virt, node, dev_node) \
+ 	do {								\
+-		const struct rte_memzone *mz;				\
+-		char z_name[RTE_MEMZONE_NAMESIZE];			\
+ 		ENA_TOUCH(dmadev); ENA_TOUCH(dev_node);			\
+-		snprintf(z_name, sizeof(z_name),			\
+-				"ena_alloc_%d", ena_alloc_cnt++);	\
+-		mz = rte_memzone_reserve(z_name, size, node, 0); \
+-		memset(mz->addr, 0, size);				\
+-		virt = mz->addr;					\
++		virt = rte_zmalloc_socket(NULL, size, 0, node);		\
+ 	} while (0)
+ 
+ #define ENA_MEM_ALLOC(dmadev, size) rte_zmalloc(NULL, size, 1)
+-- 
+2.14.1
+

--- a/userspace/dpdk/17.08/0004-net-ena-fix-GENMASK_ULL-macro.patch
+++ b/userspace/dpdk/17.08/0004-net-ena-fix-GENMASK_ULL-macro.patch
@@ -1,0 +1,42 @@
+From 0f9cc355479cd2d6a2fe3d8f6684cf5831a92f71 Mon Sep 17 00:00:00 2001
+From: Rafal Kozik <rk@semihalf.com>
+Date: Thu, 7 Jun 2018 11:43:20 +0200
+Subject: [PATCH 4/7] net/ena: fix GENMASK_ULL macro
+
+[ upstream commit 7544aee8d0b4ae0262b1ba7e1539cf8171664df7 ]
+
+When use GENMASK_ULL(63,0) left shift by 64 bits is performed.
+Shifting by number greater or equal then word length
+is undefined operation and failed on some platforms.
+
+Fixes: 9ba7981ec992 ("ena: add communication layer for DPDK")
+Cc: stable@dpdk.org
+
+Signed-off-by: Rafal Kozik <rk@semihalf.com>
+Acked-by: Michal Krawczyk <mk@semihalf.com>
+---
+ drivers/net/ena/base/ena_plat_dpdk.h | 4 +++-
+ 1 file changed, 3 insertions(+), 1 deletion(-)
+
+diff --git a/drivers/net/ena/base/ena_plat_dpdk.h b/drivers/net/ena/base/ena_plat_dpdk.h
+index 977bee49f..06b637870 100644
+--- a/drivers/net/ena/base/ena_plat_dpdk.h
++++ b/drivers/net/ena/base/ena_plat_dpdk.h
+@@ -116,11 +116,13 @@ typedef uint64_t dma_addr_t;
+ #define ENA_MIN16(x, y) RTE_MIN((x), (y))
+ #define ENA_MIN8(x, y) RTE_MIN((x), (y))
+ 
++#define BITS_PER_LONG_LONG (__SIZEOF_LONG_LONG__ * 8)
+ #define U64_C(x) x ## ULL
+ #define BIT(nr)         (1UL << (nr))
+ #define BITS_PER_LONG	(__SIZEOF_LONG__ * 8)
+ #define GENMASK(h, l)	(((~0UL) << (l)) & (~0UL >> (BITS_PER_LONG - 1 - (h))))
+-#define GENMASK_ULL(h, l) (((U64_C(1) << ((h) - (l) + 1)) - 1) << (l))
++#define GENMASK_ULL(h, l) (((~0ULL) - (1ULL << (l)) + 1) & \
++			  (~0ULL >> (BITS_PER_LONG_LONG - 1 - (h))))
+ 
+ #ifdef RTE_LIBRTE_ENA_COM_DEBUG
+ #define ena_trc_dbg(format, arg...)					\
+-- 
+2.14.1
+

--- a/userspace/dpdk/17.08/0005-net-ena-set-link-speed-as-none.patch
+++ b/userspace/dpdk/17.08/0005-net-ena-set-link-speed-as-none.patch
@@ -1,0 +1,37 @@
+From 16394f95984c76e5b934d1554d7fc833bc376767 Mon Sep 17 00:00:00 2001
+From: Rafal Kozik <rk@semihalf.com>
+Date: Thu, 7 Jun 2018 11:43:22 +0200
+Subject: [PATCH 5/7] net/ena: set link speed as none
+
+[ upstream commit 41e59028dd8ab2038a7655c6fc3098222661aa53 ]
+
+Link speed should is not limited to 10Gb/s and it shouldn't be hardcoded.
+
+They link speed is set to none instead and the applications shouldn't
+rely on this value when using ENA PMD.
+
+Fixes: 1173fca25af9 ("ena: add polling-mode driver")
+Cc: stable@dpdk.org
+
+Signed-off-by: Rafal Kozik <rk@semihalf.com>
+Acked-by: Michal Krawczyk <mk@semihalf.com>
+---
+ drivers/net/ena/ena_ethdev.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/drivers/net/ena/ena_ethdev.c b/drivers/net/ena/ena_ethdev.c
+index 16a648206..e5da94a59 100644
+--- a/drivers/net/ena/ena_ethdev.c
++++ b/drivers/net/ena/ena_ethdev.c
+@@ -709,7 +709,7 @@ static int ena_link_update(struct rte_eth_dev *dev,
+ 	struct rte_eth_link *link = &dev->data->dev_link;
+ 
+ 	link->link_status = 1;
+-	link->link_speed = ETH_SPEED_NUM_10G;
++	link->link_speed = ETH_SPEED_NUM_NONE;
+ 	link->link_duplex = ETH_LINK_FULL_DUPLEX;
+ 
+ 	return 0;
+-- 
+2.14.1
+

--- a/userspace/dpdk/17.08/0006-net-ena-fix-SIGFPE-with-0-Rx-queue.patch
+++ b/userspace/dpdk/17.08/0006-net-ena-fix-SIGFPE-with-0-Rx-queue.patch
@@ -1,0 +1,35 @@
+From 3203a68b15accfe176bf4a9a743f1a20d651cb6a Mon Sep 17 00:00:00 2001
+From: Daria Kolistratova <daria.kolistratova@intel.com>
+Date: Tue, 26 Jun 2018 18:38:56 +0100
+Subject: [PATCH 6/7] net/ena: fix SIGFPE with 0 Rx queue
+
+[ upstream commit 361913ad6f8c05fc541fe4bfdae3b0dc095ae3af ]
+
+When the number of rx queues is 0 (what can be when application does
+not receive) failed with SIGFPE.
+It happens when the application is also requesting ETH_MQ_RX_RSS_FLAG
+in the rte_dev->data->dev_conf.rxmode.mq_mode.
+Fixed adding zero rx queues check.
+
+Signed-off-by: Daria Kolistratova <daria.kolistratova@intel.com>
+Acked-by: Michal Krawczyk <mk@semihalf.com>
+---
+ drivers/net/ena/ena_ethdev.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/drivers/net/ena/ena_ethdev.c b/drivers/net/ena/ena_ethdev.c
+index e5da94a59..01c463a33 100644
+--- a/drivers/net/ena/ena_ethdev.c
++++ b/drivers/net/ena/ena_ethdev.c
+@@ -906,7 +906,7 @@ static int ena_start(struct rte_eth_dev *dev)
+ 		return rc;
+ 
+ 	if (adapter->rte_dev->data->dev_conf.rxmode.mq_mode &
+-	    ETH_MQ_RX_RSS_FLAG) {
++	    ETH_MQ_RX_RSS_FLAG && adapter->rte_dev->data->nb_rx_queues > 0) {
+ 		rc = ena_rss_init_default(adapter);
+ 		if (rc)
+ 			return rc;
+-- 
+2.14.1
+

--- a/userspace/dpdk/17.08/0007-net-ena-fix-passing-RSS-hash-to-mbuf.patch
+++ b/userspace/dpdk/17.08/0007-net-ena-fix-passing-RSS-hash-to-mbuf.patch
@@ -1,0 +1,35 @@
+From f4ea00c92097bf87da4a3de788f161c485be55eb Mon Sep 17 00:00:00 2001
+From: Stewart Allen <allenste@amazon.com>
+Date: Thu, 25 Oct 2018 19:59:22 +0200
+Subject: [PATCH 7/7] net/ena: fix passing RSS hash to mbuf
+
+[ upstream commit e5df9f33db00eb9d322abaefff30da74fd0e625d ]
+
+The driver was passing to the mbuf Rx queue ID instead of hash received
+from the device. Now, the RSS hash from the Rx descriptor is being set.
+
+Fixes: 1173fca25af9 ("ena: add polling-mode driver")
+Cc: stable@dpdk.org
+
+Signed-off-by: Stewart Allen <allenste@amazon.com>
+Acked-by: Michal Krawczyk <mk@semihalf.com>
+---
+ drivers/net/ena/ena_ethdev.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/drivers/net/ena/ena_ethdev.c b/drivers/net/ena/ena_ethdev.c
+index 01c463a33..434f2ecf2 100644
+--- a/drivers/net/ena/ena_ethdev.c
++++ b/drivers/net/ena/ena_ethdev.c
+@@ -1572,7 +1572,7 @@ static uint16_t eth_ena_recv_pkts(void *rx_queue, struct rte_mbuf **rx_pkts,
+ 
+ 		/* fill mbuf attributes if any */
+ 		ena_rx_mbuf_prepare(mbuf_head, &ena_rx_ctx);
+-		mbuf_head->hash.rss = (uint32_t)rx_ring->id;
++		mbuf_head->hash.rss = ena_rx_ctx.hash;
+ 
+ 		/* pass to DPDK application head mbuf */
+ 		rx_pkts[recv_idx] = mbuf_head;
+-- 
+2.14.1
+

--- a/userspace/dpdk/17.11/0001-net-ena-TX-L4-offload-flags-should-not-be-set-in-RX-.patch
+++ b/userspace/dpdk/17.11/0001-net-ena-TX-L4-offload-flags-should-not-be-set-in-RX-.patch
@@ -1,7 +1,7 @@
 From d630a636b4bcb600b5b37512ba2168aa552698f3 Mon Sep 17 00:00:00 2001
 From: Rafal Kozik <rk@semihalf.com>
 Date: Tue, 9 Jan 2018 16:19:08 +0100
-Subject: [PATCH] net/ena: TX L4 offload flags should not be set in RX path
+Subject: [PATCH 1/7] net/ena: TX L4 offload flags should not be set in RX path
 
 Information about received packet type detected by NIC should be stored
 in packet_type field of rte_mbuf. TX L4 offload flags should not be set

--- a/userspace/dpdk/17.11/0002-net-ena-check-pointer-before-memset.patch
+++ b/userspace/dpdk/17.11/0002-net-ena-check-pointer-before-memset.patch
@@ -1,0 +1,63 @@
+From 6422ee1ea183598921abce8870906225625cde80 Mon Sep 17 00:00:00 2001
+From: Rafal Kozik <rk@semihalf.com>
+Date: Thu, 7 Jun 2018 11:43:18 +0200
+Subject: [PATCH 2/7] net/ena: check pointer before memset
+
+[ upstream commit 46916aa17d4b2007df8c0454f99ba0ca8b8cb93b ]
+
+Need to check if memory allocation succeed before using it.
+Using memset on NULL pointer cause segfault.
+
+Fixes: 9ba7981ec992 ("ena: add communication layer for DPDK")
+Cc: stable@dpdk.org
+
+Signed-off-by: Rafal Kozik <rk@semihalf.com>
+Acked-by: Michal Krawczyk <mk@semihalf.com>
+---
+ drivers/net/ena/base/ena_plat_dpdk.h | 22 ++++++++++++++++------
+ 1 file changed, 16 insertions(+), 6 deletions(-)
+
+diff --git a/drivers/net/ena/base/ena_plat_dpdk.h b/drivers/net/ena/base/ena_plat_dpdk.h
+index accecf518..362741aa2 100644
+--- a/drivers/net/ena/base/ena_plat_dpdk.h
++++ b/drivers/net/ena/base/ena_plat_dpdk.h
+@@ -189,10 +189,15 @@ typedef uint64_t dma_addr_t;
+ 		snprintf(z_name, sizeof(z_name),			\
+ 				"ena_alloc_%d", ena_alloc_cnt++);	\
+ 		mz = rte_memzone_reserve(z_name, size, SOCKET_ID_ANY, 0); \
+-		memset(mz->addr, 0, size);				\
+-		virt = mz->addr;					\
+-		phys = mz->iova;					\
+ 		handle = mz;						\
++		if (mz == NULL) {					\
++			virt = NULL;					\
++			phys = 0;					\
++		} else {						\
++			memset(mz->addr, 0, size);			\
++			virt = mz->addr;				\
++			phys = mz->iova;				\
++		}							\
+ 	} while (0)
+ #define ENA_MEM_FREE_COHERENT(dmadev, size, virt, phys, handle) 	\
+ 		({ ENA_TOUCH(size); ENA_TOUCH(phys);			\
+@@ -207,9 +212,14 @@ typedef uint64_t dma_addr_t;
+ 		snprintf(z_name, sizeof(z_name),			\
+ 				"ena_alloc_%d", ena_alloc_cnt++);	\
+ 		mz = rte_memzone_reserve(z_name, size, node, 0); \
+-		memset(mz->addr, 0, size);				\
+-		virt = mz->addr;					\
+-		phys = mz->iova;					\
++		if (mz == NULL) {					\
++			virt = NULL;					\
++			phys = 0;					\
++		} else {						\
++			memset(mz->addr, 0, size);			\
++			virt = mz->addr;				\
++			phys = mz->iova;				\
++		}							\
+ 	} while (0)
+ 
+ #define ENA_MEM_ALLOC_NODE(dmadev, size, virt, node, dev_node) \
+-- 
+2.14.1
+

--- a/userspace/dpdk/17.11/0003-net-ena-change-memory-type.patch
+++ b/userspace/dpdk/17.11/0003-net-ena-change-memory-type.patch
@@ -1,0 +1,45 @@
+From 95990c9716ca93ca1b6a570737dabae8eb25d9cf Mon Sep 17 00:00:00 2001
+From: Rafal Kozik <rk@semihalf.com>
+Date: Thu, 7 Jun 2018 11:43:19 +0200
+Subject: [PATCH 3/7] net/ena: change memory type
+
+[ upstream commit 9f32c7e7e6ce58ab772913f54f8328c1c0186a17 ]
+
+ENA_MEM_ALLOC_NODE not need to use contiguous physical memory.
+Also using memset without checking if allocation succeed can cause
+segmentation fault.
+
+To avoid both issue use rte_zmalloc_socket.
+
+Fixes: 3d3edc265fc8 ("net/ena: make coherent memory allocation NUMA-aware")
+Cc: stable@dpdk.org
+
+Signed-off-by: Rafal Kozik <rk@semihalf.com>
+Acked-by: Michal Krawczyk <mk@semihalf.com>
+---
+ drivers/net/ena/base/ena_plat_dpdk.h | 8 +-------
+ 1 file changed, 1 insertion(+), 7 deletions(-)
+
+diff --git a/drivers/net/ena/base/ena_plat_dpdk.h b/drivers/net/ena/base/ena_plat_dpdk.h
+index 362741aa2..8363fb482 100644
+--- a/drivers/net/ena/base/ena_plat_dpdk.h
++++ b/drivers/net/ena/base/ena_plat_dpdk.h
+@@ -224,14 +224,8 @@ typedef uint64_t dma_addr_t;
+ 
+ #define ENA_MEM_ALLOC_NODE(dmadev, size, virt, node, dev_node) \
+ 	do {								\
+-		const struct rte_memzone *mz;				\
+-		char z_name[RTE_MEMZONE_NAMESIZE];			\
+ 		ENA_TOUCH(dmadev); ENA_TOUCH(dev_node);			\
+-		snprintf(z_name, sizeof(z_name),			\
+-				"ena_alloc_%d", ena_alloc_cnt++);	\
+-		mz = rte_memzone_reserve(z_name, size, node, 0); \
+-		memset(mz->addr, 0, size);				\
+-		virt = mz->addr;					\
++		virt = rte_zmalloc_socket(NULL, size, 0, node);		\
+ 	} while (0)
+ 
+ #define ENA_MEM_ALLOC(dmadev, size) rte_zmalloc(NULL, size, 1)
+-- 
+2.14.1
+

--- a/userspace/dpdk/17.11/0004-net-ena-fix-GENMASK_ULL-macro.patch
+++ b/userspace/dpdk/17.11/0004-net-ena-fix-GENMASK_ULL-macro.patch
@@ -1,0 +1,42 @@
+From 3bb4954143db9b0fd85a0ac8e7d7c2f2636013ca Mon Sep 17 00:00:00 2001
+From: Rafal Kozik <rk@semihalf.com>
+Date: Thu, 7 Jun 2018 11:43:20 +0200
+Subject: [PATCH 4/7] net/ena: fix GENMASK_ULL macro
+
+[ upstream commit 7544aee8d0b4ae0262b1ba7e1539cf8171664df7 ]
+
+When use GENMASK_ULL(63,0) left shift by 64 bits is performed.
+Shifting by number greater or equal then word length
+is undefined operation and failed on some platforms.
+
+Fixes: 9ba7981ec992 ("ena: add communication layer for DPDK")
+Cc: stable@dpdk.org
+
+Signed-off-by: Rafal Kozik <rk@semihalf.com>
+Acked-by: Michal Krawczyk <mk@semihalf.com>
+---
+ drivers/net/ena/base/ena_plat_dpdk.h | 4 +++-
+ 1 file changed, 3 insertions(+), 1 deletion(-)
+
+diff --git a/drivers/net/ena/base/ena_plat_dpdk.h b/drivers/net/ena/base/ena_plat_dpdk.h
+index 8363fb482..ea78e8d72 100644
+--- a/drivers/net/ena/base/ena_plat_dpdk.h
++++ b/drivers/net/ena/base/ena_plat_dpdk.h
+@@ -116,11 +116,13 @@ typedef uint64_t dma_addr_t;
+ #define ENA_MIN16(x, y) RTE_MIN((x), (y))
+ #define ENA_MIN8(x, y) RTE_MIN((x), (y))
+ 
++#define BITS_PER_LONG_LONG (__SIZEOF_LONG_LONG__ * 8)
+ #define U64_C(x) x ## ULL
+ #define BIT(nr)         (1UL << (nr))
+ #define BITS_PER_LONG	(__SIZEOF_LONG__ * 8)
+ #define GENMASK(h, l)	(((~0UL) << (l)) & (~0UL >> (BITS_PER_LONG - 1 - (h))))
+-#define GENMASK_ULL(h, l) (((U64_C(1) << ((h) - (l) + 1)) - 1) << (l))
++#define GENMASK_ULL(h, l) (((~0ULL) - (1ULL << (l)) + 1) & \
++			  (~0ULL >> (BITS_PER_LONG_LONG - 1 - (h))))
+ 
+ #ifdef RTE_LIBRTE_ENA_COM_DEBUG
+ #define ena_trc_dbg(format, arg...)					\
+-- 
+2.14.1
+

--- a/userspace/dpdk/17.11/0005-net-ena-set-link-speed-as-none.patch
+++ b/userspace/dpdk/17.11/0005-net-ena-set-link-speed-as-none.patch
@@ -1,0 +1,37 @@
+From a6c7a0e0a1fe89f84c09e0b5d45d82916764a8a2 Mon Sep 17 00:00:00 2001
+From: Rafal Kozik <rk@semihalf.com>
+Date: Thu, 7 Jun 2018 11:43:22 +0200
+Subject: [PATCH 5/7] net/ena: set link speed as none
+
+[ upstream commit 41e59028dd8ab2038a7655c6fc3098222661aa53 ]
+
+Link speed should is not limited to 10Gb/s and it shouldn't be hardcoded.
+
+They link speed is set to none instead and the applications shouldn't
+rely on this value when using ENA PMD.
+
+Fixes: 1173fca25af9 ("ena: add polling-mode driver")
+Cc: stable@dpdk.org
+
+Signed-off-by: Rafal Kozik <rk@semihalf.com>
+Acked-by: Michal Krawczyk <mk@semihalf.com>
+---
+ drivers/net/ena/ena_ethdev.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/drivers/net/ena/ena_ethdev.c b/drivers/net/ena/ena_ethdev.c
+index aa24ef36a..32fcc0dc8 100644
+--- a/drivers/net/ena/ena_ethdev.c
++++ b/drivers/net/ena/ena_ethdev.c
+@@ -709,7 +709,7 @@ static int ena_link_update(struct rte_eth_dev *dev,
+ 	struct rte_eth_link *link = &dev->data->dev_link;
+ 
+ 	link->link_status = 1;
+-	link->link_speed = ETH_SPEED_NUM_10G;
++	link->link_speed = ETH_SPEED_NUM_NONE;
+ 	link->link_duplex = ETH_LINK_FULL_DUPLEX;
+ 
+ 	return 0;
+-- 
+2.14.1
+

--- a/userspace/dpdk/17.11/0006-net-ena-fix-SIGFPE-with-0-Rx-queue.patch
+++ b/userspace/dpdk/17.11/0006-net-ena-fix-SIGFPE-with-0-Rx-queue.patch
@@ -1,0 +1,35 @@
+From 22286a7f2588ac5f3cebcc7efe2b2b99debd7542 Mon Sep 17 00:00:00 2001
+From: Daria Kolistratova <daria.kolistratova@intel.com>
+Date: Tue, 26 Jun 2018 18:38:56 +0100
+Subject: [PATCH 6/7] net/ena: fix SIGFPE with 0 Rx queue
+
+[ upstream commit 361913ad6f8c05fc541fe4bfdae3b0dc095ae3af ]
+
+When the number of rx queues is 0 (what can be when application does
+not receive) failed with SIGFPE.
+It happens when the application is also requesting ETH_MQ_RX_RSS_FLAG
+in the rte_dev->data->dev_conf.rxmode.mq_mode.
+Fixed adding zero rx queues check.
+
+Signed-off-by: Daria Kolistratova <daria.kolistratova@intel.com>
+Acked-by: Michal Krawczyk <mk@semihalf.com>
+---
+ drivers/net/ena/ena_ethdev.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/drivers/net/ena/ena_ethdev.c b/drivers/net/ena/ena_ethdev.c
+index 32fcc0dc8..4e5265679 100644
+--- a/drivers/net/ena/ena_ethdev.c
++++ b/drivers/net/ena/ena_ethdev.c
+@@ -907,7 +907,7 @@ static int ena_start(struct rte_eth_dev *dev)
+ 		return rc;
+ 
+ 	if (adapter->rte_dev->data->dev_conf.rxmode.mq_mode &
+-	    ETH_MQ_RX_RSS_FLAG) {
++	    ETH_MQ_RX_RSS_FLAG && adapter->rte_dev->data->nb_rx_queues > 0) {
+ 		rc = ena_rss_init_default(adapter);
+ 		if (rc)
+ 			return rc;
+-- 
+2.14.1
+

--- a/userspace/dpdk/17.11/0007-net-ena-fix-passing-RSS-hash-to-mbuf.patch
+++ b/userspace/dpdk/17.11/0007-net-ena-fix-passing-RSS-hash-to-mbuf.patch
@@ -1,0 +1,35 @@
+From b184080a23dc7e8447dd65b79894133a8b510b63 Mon Sep 17 00:00:00 2001
+From: Stewart Allen <allenste@amazon.com>
+Date: Thu, 25 Oct 2018 19:59:22 +0200
+Subject: [PATCH 7/7] net/ena: fix passing RSS hash to mbuf
+
+[ upstream commit e5df9f33db00eb9d322abaefff30da74fd0e625d ]
+
+The driver was passing to the mbuf Rx queue ID instead of hash received
+from the device. Now, the RSS hash from the Rx descriptor is being set.
+
+Fixes: 1173fca25af9 ("ena: add polling-mode driver")
+Cc: stable@dpdk.org
+
+Signed-off-by: Stewart Allen <allenste@amazon.com>
+Acked-by: Michal Krawczyk <mk@semihalf.com>
+---
+ drivers/net/ena/ena_ethdev.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/drivers/net/ena/ena_ethdev.c b/drivers/net/ena/ena_ethdev.c
+index 4e5265679..6b96f4042 100644
+--- a/drivers/net/ena/ena_ethdev.c
++++ b/drivers/net/ena/ena_ethdev.c
+@@ -1573,7 +1573,7 @@ static uint16_t eth_ena_recv_pkts(void *rx_queue, struct rte_mbuf **rx_pkts,
+ 
+ 		/* fill mbuf attributes if any */
+ 		ena_rx_mbuf_prepare(mbuf_head, &ena_rx_ctx);
+-		mbuf_head->hash.rss = (uint32_t)rx_ring->id;
++		mbuf_head->hash.rss = ena_rx_ctx.hash;
+ 
+ 		/* pass to DPDK application head mbuf */
+ 		rx_pkts[recv_idx] = mbuf_head;
+-- 
+2.14.1
+

--- a/userspace/dpdk/18.02/0001-net-ena-check-pointer-before-memset.patch
+++ b/userspace/dpdk/18.02/0001-net-ena-check-pointer-before-memset.patch
@@ -1,0 +1,63 @@
+From a81ebdfe8e3ef6224696a8d66b2daf0540903f19 Mon Sep 17 00:00:00 2001
+From: Rafal Kozik <rk@semihalf.com>
+Date: Thu, 7 Jun 2018 11:43:18 +0200
+Subject: [PATCH 1/6] net/ena: check pointer before memset
+
+[ upstream commit 46916aa17d4b2007df8c0454f99ba0ca8b8cb93b ]
+
+Need to check if memory allocation succeed before using it.
+Using memset on NULL pointer cause segfault.
+
+Fixes: 9ba7981ec992 ("ena: add communication layer for DPDK")
+Cc: stable@dpdk.org
+
+Signed-off-by: Rafal Kozik <rk@semihalf.com>
+Acked-by: Michal Krawczyk <mk@semihalf.com>
+---
+ drivers/net/ena/base/ena_plat_dpdk.h | 22 ++++++++++++++++------
+ 1 file changed, 16 insertions(+), 6 deletions(-)
+
+diff --git a/drivers/net/ena/base/ena_plat_dpdk.h b/drivers/net/ena/base/ena_plat_dpdk.h
+index 8cba319eb..95f2d9f6f 100644
+--- a/drivers/net/ena/base/ena_plat_dpdk.h
++++ b/drivers/net/ena/base/ena_plat_dpdk.h
+@@ -189,10 +189,15 @@ typedef uint64_t dma_addr_t;
+ 		snprintf(z_name, sizeof(z_name),			\
+ 				"ena_alloc_%d", ena_alloc_cnt++);	\
+ 		mz = rte_memzone_reserve(z_name, size, SOCKET_ID_ANY, 0); \
+-		memset(mz->addr, 0, size);				\
+-		virt = mz->addr;					\
+-		phys = mz->iova;					\
+ 		handle = mz;						\
++		if (mz == NULL) {					\
++			virt = NULL;					\
++			phys = 0;					\
++		} else {						\
++			memset(mz->addr, 0, size);			\
++			virt = mz->addr;				\
++			phys = mz->iova;				\
++		}							\
+ 	} while (0)
+ #define ENA_MEM_FREE_COHERENT(dmadev, size, virt, phys, handle) 	\
+ 		({ ENA_TOUCH(size); ENA_TOUCH(phys);			\
+@@ -207,9 +212,14 @@ typedef uint64_t dma_addr_t;
+ 		snprintf(z_name, sizeof(z_name),			\
+ 				"ena_alloc_%d", ena_alloc_cnt++);	\
+ 		mz = rte_memzone_reserve(z_name, size, node, 0); \
+-		memset(mz->addr, 0, size);				\
+-		virt = mz->addr;					\
+-		phys = mz->iova;					\
++		if (mz == NULL) {					\
++			virt = NULL;					\
++			phys = 0;					\
++		} else {						\
++			memset(mz->addr, 0, size);			\
++			virt = mz->addr;				\
++			phys = mz->iova;				\
++		}							\
+ 	} while (0)
+ 
+ #define ENA_MEM_ALLOC_NODE(dmadev, size, virt, node, dev_node) \
+-- 
+2.14.1
+

--- a/userspace/dpdk/18.02/0002-net-ena-change-memory-type.patch
+++ b/userspace/dpdk/18.02/0002-net-ena-change-memory-type.patch
@@ -1,0 +1,45 @@
+From 338c21f83954ea47a3288f3ee1f64e54837b2e1f Mon Sep 17 00:00:00 2001
+From: Rafal Kozik <rk@semihalf.com>
+Date: Thu, 7 Jun 2018 11:43:19 +0200
+Subject: [PATCH 2/6] net/ena: change memory type
+
+[ upstream commit 9f32c7e7e6ce58ab772913f54f8328c1c0186a17 ]
+
+ENA_MEM_ALLOC_NODE not need to use contiguous physical memory.
+Also using memset without checking if allocation succeed can cause
+segmentation fault.
+
+To avoid both issue use rte_zmalloc_socket.
+
+Fixes: 3d3edc265fc8 ("net/ena: make coherent memory allocation NUMA-aware")
+Cc: stable@dpdk.org
+
+Signed-off-by: Rafal Kozik <rk@semihalf.com>
+Acked-by: Michal Krawczyk <mk@semihalf.com>
+---
+ drivers/net/ena/base/ena_plat_dpdk.h | 8 +-------
+ 1 file changed, 1 insertion(+), 7 deletions(-)
+
+diff --git a/drivers/net/ena/base/ena_plat_dpdk.h b/drivers/net/ena/base/ena_plat_dpdk.h
+index 95f2d9f6f..00ff9363c 100644
+--- a/drivers/net/ena/base/ena_plat_dpdk.h
++++ b/drivers/net/ena/base/ena_plat_dpdk.h
+@@ -224,14 +224,8 @@ typedef uint64_t dma_addr_t;
+ 
+ #define ENA_MEM_ALLOC_NODE(dmadev, size, virt, node, dev_node) \
+ 	do {								\
+-		const struct rte_memzone *mz;				\
+-		char z_name[RTE_MEMZONE_NAMESIZE];			\
+ 		ENA_TOUCH(dmadev); ENA_TOUCH(dev_node);			\
+-		snprintf(z_name, sizeof(z_name),			\
+-				"ena_alloc_%d", ena_alloc_cnt++);	\
+-		mz = rte_memzone_reserve(z_name, size, node, 0); \
+-		memset(mz->addr, 0, size);				\
+-		virt = mz->addr;					\
++		virt = rte_zmalloc_socket(NULL, size, 0, node);		\
+ 	} while (0)
+ 
+ #define ENA_MEM_ALLOC(dmadev, size) rte_zmalloc(NULL, size, 1)
+-- 
+2.14.1
+

--- a/userspace/dpdk/18.02/0003-net-ena-fix-GENMASK_ULL-macro.patch
+++ b/userspace/dpdk/18.02/0003-net-ena-fix-GENMASK_ULL-macro.patch
@@ -1,0 +1,42 @@
+From 5960b6d766b0802a77bebe4887a6c633e4f8c3a9 Mon Sep 17 00:00:00 2001
+From: Rafal Kozik <rk@semihalf.com>
+Date: Thu, 7 Jun 2018 11:43:20 +0200
+Subject: [PATCH 3/6] net/ena: fix GENMASK_ULL macro
+
+[ upstream commit 7544aee8d0b4ae0262b1ba7e1539cf8171664df7 ]
+
+When use GENMASK_ULL(63,0) left shift by 64 bits is performed.
+Shifting by number greater or equal then word length
+is undefined operation and failed on some platforms.
+
+Fixes: 9ba7981ec992 ("ena: add communication layer for DPDK")
+Cc: stable@dpdk.org
+
+Signed-off-by: Rafal Kozik <rk@semihalf.com>
+Acked-by: Michal Krawczyk <mk@semihalf.com>
+---
+ drivers/net/ena/base/ena_plat_dpdk.h | 4 +++-
+ 1 file changed, 3 insertions(+), 1 deletion(-)
+
+diff --git a/drivers/net/ena/base/ena_plat_dpdk.h b/drivers/net/ena/base/ena_plat_dpdk.h
+index 00ff9363c..72d501538 100644
+--- a/drivers/net/ena/base/ena_plat_dpdk.h
++++ b/drivers/net/ena/base/ena_plat_dpdk.h
+@@ -116,11 +116,13 @@ typedef uint64_t dma_addr_t;
+ #define ENA_MIN16(x, y) RTE_MIN((x), (y))
+ #define ENA_MIN8(x, y) RTE_MIN((x), (y))
+ 
++#define BITS_PER_LONG_LONG (__SIZEOF_LONG_LONG__ * 8)
+ #define U64_C(x) x ## ULL
+ #define BIT(nr)         (1UL << (nr))
+ #define BITS_PER_LONG	(__SIZEOF_LONG__ * 8)
+ #define GENMASK(h, l)	(((~0UL) << (l)) & (~0UL >> (BITS_PER_LONG - 1 - (h))))
+-#define GENMASK_ULL(h, l) (((U64_C(1) << ((h) - (l) + 1)) - 1) << (l))
++#define GENMASK_ULL(h, l) (((~0ULL) - (1ULL << (l)) + 1) & \
++			  (~0ULL >> (BITS_PER_LONG_LONG - 1 - (h))))
+ 
+ #ifdef RTE_LIBRTE_ENA_COM_DEBUG
+ #define ena_trc_dbg(format, arg...)					\
+-- 
+2.14.1
+

--- a/userspace/dpdk/18.02/0004-net-ena-set-link-speed-as-none.patch
+++ b/userspace/dpdk/18.02/0004-net-ena-set-link-speed-as-none.patch
@@ -1,0 +1,37 @@
+From ab96831a8a190f887430181af291670826413568 Mon Sep 17 00:00:00 2001
+From: Rafal Kozik <rk@semihalf.com>
+Date: Thu, 7 Jun 2018 11:43:22 +0200
+Subject: [PATCH 4/6] net/ena: set link speed as none
+
+[ upstream commit 41e59028dd8ab2038a7655c6fc3098222661aa53 ]
+
+Link speed should is not limited to 10Gb/s and it shouldn't be hardcoded.
+
+They link speed is set to none instead and the applications shouldn't
+rely on this value when using ENA PMD.
+
+Fixes: 1173fca25af9 ("ena: add polling-mode driver")
+Cc: stable@dpdk.org
+
+Signed-off-by: Rafal Kozik <rk@semihalf.com>
+Acked-by: Michal Krawczyk <mk@semihalf.com>
+---
+ drivers/net/ena/ena_ethdev.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/drivers/net/ena/ena_ethdev.c b/drivers/net/ena/ena_ethdev.c
+index 34b2a8d78..9eecb986e 100644
+--- a/drivers/net/ena/ena_ethdev.c
++++ b/drivers/net/ena/ena_ethdev.c
+@@ -725,7 +725,7 @@ static int ena_link_update(struct rte_eth_dev *dev,
+ 	struct rte_eth_link *link = &dev->data->dev_link;
+ 
+ 	link->link_status = 1;
+-	link->link_speed = ETH_SPEED_NUM_10G;
++	link->link_speed = ETH_SPEED_NUM_NONE;
+ 	link->link_duplex = ETH_LINK_FULL_DUPLEX;
+ 
+ 	return 0;
+-- 
+2.14.1
+

--- a/userspace/dpdk/18.02/0005-net-ena-fix-SIGFPE-with-0-Rx-queue.patch
+++ b/userspace/dpdk/18.02/0005-net-ena-fix-SIGFPE-with-0-Rx-queue.patch
@@ -1,0 +1,35 @@
+From 3d1ec83f9e963e57e731debc6c74e05a4e955687 Mon Sep 17 00:00:00 2001
+From: Daria Kolistratova <daria.kolistratova@intel.com>
+Date: Tue, 26 Jun 2018 18:38:56 +0100
+Subject: [PATCH 5/6] net/ena: fix SIGFPE with 0 Rx queue
+
+[ upstream commit 361913ad6f8c05fc541fe4bfdae3b0dc095ae3af ]
+
+When the number of rx queues is 0 (what can be when application does
+not receive) failed with SIGFPE.
+It happens when the application is also requesting ETH_MQ_RX_RSS_FLAG
+in the rte_dev->data->dev_conf.rxmode.mq_mode.
+Fixed adding zero rx queues check.
+
+Signed-off-by: Daria Kolistratova <daria.kolistratova@intel.com>
+Acked-by: Michal Krawczyk <mk@semihalf.com>
+---
+ drivers/net/ena/ena_ethdev.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/drivers/net/ena/ena_ethdev.c b/drivers/net/ena/ena_ethdev.c
+index 9eecb986e..ec72407f6 100644
+--- a/drivers/net/ena/ena_ethdev.c
++++ b/drivers/net/ena/ena_ethdev.c
+@@ -924,7 +924,7 @@ static int ena_start(struct rte_eth_dev *dev)
+ 		return rc;
+ 
+ 	if (adapter->rte_dev->data->dev_conf.rxmode.mq_mode &
+-	    ETH_MQ_RX_RSS_FLAG) {
++	    ETH_MQ_RX_RSS_FLAG && adapter->rte_dev->data->nb_rx_queues > 0) {
+ 		rc = ena_rss_init_default(adapter);
+ 		if (rc)
+ 			return rc;
+-- 
+2.14.1
+

--- a/userspace/dpdk/18.02/0006-net-ena-fix-passing-RSS-hash-to-mbuf.patch
+++ b/userspace/dpdk/18.02/0006-net-ena-fix-passing-RSS-hash-to-mbuf.patch
@@ -1,0 +1,35 @@
+From 2b705349532283b0c80d7ec7ea622fce7f177142 Mon Sep 17 00:00:00 2001
+From: Stewart Allen <allenste@amazon.com>
+Date: Thu, 25 Oct 2018 19:59:22 +0200
+Subject: [PATCH 6/6] net/ena: fix passing RSS hash to mbuf
+
+[ upstream commit e5df9f33db00eb9d322abaefff30da74fd0e625d ]
+
+The driver was passing to the mbuf Rx queue ID instead of hash received
+from the device. Now, the RSS hash from the Rx descriptor is being set.
+
+Fixes: 1173fca25af9 ("ena: add polling-mode driver")
+Cc: stable@dpdk.org
+
+Signed-off-by: Stewart Allen <allenste@amazon.com>
+Acked-by: Michal Krawczyk <mk@semihalf.com>
+---
+ drivers/net/ena/ena_ethdev.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/drivers/net/ena/ena_ethdev.c b/drivers/net/ena/ena_ethdev.c
+index ec72407f6..51b351a95 100644
+--- a/drivers/net/ena/ena_ethdev.c
++++ b/drivers/net/ena/ena_ethdev.c
+@@ -1654,7 +1654,7 @@ static uint16_t eth_ena_recv_pkts(void *rx_queue, struct rte_mbuf **rx_pkts,
+ 
+ 		/* fill mbuf attributes if any */
+ 		ena_rx_mbuf_prepare(mbuf_head, &ena_rx_ctx);
+-		mbuf_head->hash.rss = (uint32_t)rx_ring->id;
++		mbuf_head->hash.rss = ena_rx_ctx.hash;
+ 
+ 		/* pass to DPDK application head mbuf */
+ 		rx_pkts[recv_idx] = mbuf_head;
+-- 
+2.14.1
+

--- a/userspace/dpdk/18.05/0001-net-ena-check-pointer-before-memset.patch
+++ b/userspace/dpdk/18.05/0001-net-ena-check-pointer-before-memset.patch
@@ -1,0 +1,63 @@
+From f130532579c8a60e7757cf315189fbe5087acc46 Mon Sep 17 00:00:00 2001
+From: Rafal Kozik <rk@semihalf.com>
+Date: Thu, 7 Jun 2018 11:43:18 +0200
+Subject: [PATCH 1/6] net/ena: check pointer before memset
+
+[ upstream commit 46916aa17d4b2007df8c0454f99ba0ca8b8cb93b ]
+
+Need to check if memory allocation succeed before using it.
+Using memset on NULL pointer cause segfault.
+
+Fixes: 9ba7981ec992 ("ena: add communication layer for DPDK")
+Cc: stable@dpdk.org
+
+Signed-off-by: Rafal Kozik <rk@semihalf.com>
+Acked-by: Michal Krawczyk <mk@semihalf.com>
+---
+ drivers/net/ena/base/ena_plat_dpdk.h | 22 ++++++++++++++++------
+ 1 file changed, 16 insertions(+), 6 deletions(-)
+
+diff --git a/drivers/net/ena/base/ena_plat_dpdk.h b/drivers/net/ena/base/ena_plat_dpdk.h
+index 93345199a..0ee440c21 100644
+--- a/drivers/net/ena/base/ena_plat_dpdk.h
++++ b/drivers/net/ena/base/ena_plat_dpdk.h
+@@ -190,10 +190,15 @@ typedef uint64_t dma_addr_t;
+ 				"ena_alloc_%d", ena_alloc_cnt++);	\
+ 		mz = rte_memzone_reserve(z_name, size, SOCKET_ID_ANY,	\
+ 				RTE_MEMZONE_IOVA_CONTIG);		\
+-		memset(mz->addr, 0, size);				\
+-		virt = mz->addr;					\
+-		phys = mz->iova;					\
+ 		handle = mz;						\
++		if (mz == NULL) {					\
++			virt = NULL;					\
++			phys = 0;					\
++		} else {						\
++			memset(mz->addr, 0, size);			\
++			virt = mz->addr;				\
++			phys = mz->iova;				\
++		}							\
+ 	} while (0)
+ #define ENA_MEM_FREE_COHERENT(dmadev, size, virt, phys, handle) 	\
+ 		({ ENA_TOUCH(size); ENA_TOUCH(phys);			\
+@@ -209,9 +214,14 @@ typedef uint64_t dma_addr_t;
+ 				"ena_alloc_%d", ena_alloc_cnt++);	\
+ 		mz = rte_memzone_reserve(z_name, size, node,		\
+ 				RTE_MEMZONE_IOVA_CONTIG);		\
+-		memset(mz->addr, 0, size);				\
+-		virt = mz->addr;					\
+-		phys = mz->iova;					\
++		if (mz == NULL) {					\
++			virt = NULL;					\
++			phys = 0;					\
++		} else {						\
++			memset(mz->addr, 0, size);			\
++			virt = mz->addr;				\
++			phys = mz->iova;				\
++		}							\
+ 	} while (0)
+ 
+ #define ENA_MEM_ALLOC_NODE(dmadev, size, virt, node, dev_node) \
+-- 
+2.14.1
+

--- a/userspace/dpdk/18.05/0002-net-ena-change-memory-type.patch
+++ b/userspace/dpdk/18.05/0002-net-ena-change-memory-type.patch
@@ -1,0 +1,46 @@
+From 52b4a8350aa705f1a0bf31d40db72d18fc1e24ea Mon Sep 17 00:00:00 2001
+From: Rafal Kozik <rk@semihalf.com>
+Date: Thu, 7 Jun 2018 11:43:19 +0200
+Subject: [PATCH 2/6] net/ena: change memory type
+
+[ upstream commit 9f32c7e7e6ce58ab772913f54f8328c1c0186a17 ]
+
+ENA_MEM_ALLOC_NODE not need to use contiguous physical memory.
+Also using memset without checking if allocation succeed can cause
+segmentation fault.
+
+To avoid both issue use rte_zmalloc_socket.
+
+Fixes: 3d3edc265fc8 ("net/ena: make coherent memory allocation NUMA-aware")
+Cc: stable@dpdk.org
+
+Signed-off-by: Rafal Kozik <rk@semihalf.com>
+Acked-by: Michal Krawczyk <mk@semihalf.com>
+---
+ drivers/net/ena/base/ena_plat_dpdk.h | 9 +--------
+ 1 file changed, 1 insertion(+), 8 deletions(-)
+
+diff --git a/drivers/net/ena/base/ena_plat_dpdk.h b/drivers/net/ena/base/ena_plat_dpdk.h
+index 0ee440c21..e7917c506 100644
+--- a/drivers/net/ena/base/ena_plat_dpdk.h
++++ b/drivers/net/ena/base/ena_plat_dpdk.h
+@@ -226,15 +226,8 @@ typedef uint64_t dma_addr_t;
+ 
+ #define ENA_MEM_ALLOC_NODE(dmadev, size, virt, node, dev_node) \
+ 	do {								\
+-		const struct rte_memzone *mz;				\
+-		char z_name[RTE_MEMZONE_NAMESIZE];			\
+ 		ENA_TOUCH(dmadev); ENA_TOUCH(dev_node);			\
+-		snprintf(z_name, sizeof(z_name),			\
+-				"ena_alloc_%d", ena_alloc_cnt++);	\
+-		mz = rte_memzone_reserve(z_name, size, node,		\
+-				RTE_MEMZONE_IOVA_CONTIG);		\
+-		memset(mz->addr, 0, size);				\
+-		virt = mz->addr;					\
++		virt = rte_zmalloc_socket(NULL, size, 0, node);		\
+ 	} while (0)
+ 
+ #define ENA_MEM_ALLOC(dmadev, size) rte_zmalloc(NULL, size, 1)
+-- 
+2.14.1
+

--- a/userspace/dpdk/18.05/0003-net-ena-fix-GENMASK_ULL-macro.patch
+++ b/userspace/dpdk/18.05/0003-net-ena-fix-GENMASK_ULL-macro.patch
@@ -1,0 +1,42 @@
+From 622fcfae471ebc7af522a43748649ec22e32a8ca Mon Sep 17 00:00:00 2001
+From: Rafal Kozik <rk@semihalf.com>
+Date: Thu, 7 Jun 2018 11:43:20 +0200
+Subject: [PATCH 3/6] net/ena: fix GENMASK_ULL macro
+
+[ upstream commit 7544aee8d0b4ae0262b1ba7e1539cf8171664df7 ]
+
+When use GENMASK_ULL(63,0) left shift by 64 bits is performed.
+Shifting by number greater or equal then word length
+is undefined operation and failed on some platforms.
+
+Fixes: 9ba7981ec992 ("ena: add communication layer for DPDK")
+Cc: stable@dpdk.org
+
+Signed-off-by: Rafal Kozik <rk@semihalf.com>
+Acked-by: Michal Krawczyk <mk@semihalf.com>
+---
+ drivers/net/ena/base/ena_plat_dpdk.h | 4 +++-
+ 1 file changed, 3 insertions(+), 1 deletion(-)
+
+diff --git a/drivers/net/ena/base/ena_plat_dpdk.h b/drivers/net/ena/base/ena_plat_dpdk.h
+index e7917c506..558966517 100644
+--- a/drivers/net/ena/base/ena_plat_dpdk.h
++++ b/drivers/net/ena/base/ena_plat_dpdk.h
+@@ -116,11 +116,13 @@ typedef uint64_t dma_addr_t;
+ #define ENA_MIN16(x, y) RTE_MIN((x), (y))
+ #define ENA_MIN8(x, y) RTE_MIN((x), (y))
+ 
++#define BITS_PER_LONG_LONG (__SIZEOF_LONG_LONG__ * 8)
+ #define U64_C(x) x ## ULL
+ #define BIT(nr)         (1UL << (nr))
+ #define BITS_PER_LONG	(__SIZEOF_LONG__ * 8)
+ #define GENMASK(h, l)	(((~0UL) << (l)) & (~0UL >> (BITS_PER_LONG - 1 - (h))))
+-#define GENMASK_ULL(h, l) (((U64_C(1) << ((h) - (l) + 1)) - 1) << (l))
++#define GENMASK_ULL(h, l) (((~0ULL) - (1ULL << (l)) + 1) & \
++			  (~0ULL >> (BITS_PER_LONG_LONG - 1 - (h))))
+ 
+ #ifdef RTE_LIBRTE_ENA_COM_DEBUG
+ #define ena_trc_dbg(format, arg...)					\
+-- 
+2.14.1
+

--- a/userspace/dpdk/18.05/0004-net-ena-set-link-speed-as-none.patch
+++ b/userspace/dpdk/18.05/0004-net-ena-set-link-speed-as-none.patch
@@ -1,0 +1,37 @@
+From fd3792a1316689d1fa54346fcbf1d71f6751eccd Mon Sep 17 00:00:00 2001
+From: Rafal Kozik <rk@semihalf.com>
+Date: Thu, 7 Jun 2018 11:43:22 +0200
+Subject: [PATCH 4/6] net/ena: set link speed as none
+
+[ upstream commit 41e59028dd8ab2038a7655c6fc3098222661aa53 ]
+
+Link speed should is not limited to 10Gb/s and it shouldn't be hardcoded.
+
+They link speed is set to none instead and the applications shouldn't
+rely on this value when using ENA PMD.
+
+Fixes: 1173fca25af9 ("ena: add polling-mode driver")
+Cc: stable@dpdk.org
+
+Signed-off-by: Rafal Kozik <rk@semihalf.com>
+Acked-by: Michal Krawczyk <mk@semihalf.com>
+---
+ drivers/net/ena/ena_ethdev.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/drivers/net/ena/ena_ethdev.c b/drivers/net/ena/ena_ethdev.c
+index c595cc7e6..f10bee236 100644
+--- a/drivers/net/ena/ena_ethdev.c
++++ b/drivers/net/ena/ena_ethdev.c
+@@ -725,7 +725,7 @@ static int ena_link_update(struct rte_eth_dev *dev,
+ 	struct rte_eth_link *link = &dev->data->dev_link;
+ 
+ 	link->link_status = ETH_LINK_UP;
+-	link->link_speed = ETH_SPEED_NUM_10G;
++	link->link_speed = ETH_SPEED_NUM_NONE;
+ 	link->link_duplex = ETH_LINK_FULL_DUPLEX;
+ 
+ 	return 0;
+-- 
+2.14.1
+

--- a/userspace/dpdk/18.05/0005-net-ena-fix-SIGFPE-with-0-Rx-queue.patch
+++ b/userspace/dpdk/18.05/0005-net-ena-fix-SIGFPE-with-0-Rx-queue.patch
@@ -1,0 +1,35 @@
+From 68f8ac904a0079e519af7ddc191f4f22f66a2069 Mon Sep 17 00:00:00 2001
+From: Daria Kolistratova <daria.kolistratova@intel.com>
+Date: Tue, 26 Jun 2018 18:38:56 +0100
+Subject: [PATCH 5/6] net/ena: fix SIGFPE with 0 Rx queue
+
+[ upstream commit 361913ad6f8c05fc541fe4bfdae3b0dc095ae3af ]
+
+When the number of rx queues is 0 (what can be when application does
+not receive) failed with SIGFPE.
+It happens when the application is also requesting ETH_MQ_RX_RSS_FLAG
+in the rte_dev->data->dev_conf.rxmode.mq_mode.
+Fixed adding zero rx queues check.
+
+Signed-off-by: Daria Kolistratova <daria.kolistratova@intel.com>
+Acked-by: Michal Krawczyk <mk@semihalf.com>
+---
+ drivers/net/ena/ena_ethdev.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/drivers/net/ena/ena_ethdev.c b/drivers/net/ena/ena_ethdev.c
+index f10bee236..ebc911168 100644
+--- a/drivers/net/ena/ena_ethdev.c
++++ b/drivers/net/ena/ena_ethdev.c
+@@ -924,7 +924,7 @@ static int ena_start(struct rte_eth_dev *dev)
+ 		return rc;
+ 
+ 	if (adapter->rte_dev->data->dev_conf.rxmode.mq_mode &
+-	    ETH_MQ_RX_RSS_FLAG) {
++	    ETH_MQ_RX_RSS_FLAG && adapter->rte_dev->data->nb_rx_queues > 0) {
+ 		rc = ena_rss_init_default(adapter);
+ 		if (rc)
+ 			return rc;
+-- 
+2.14.1
+

--- a/userspace/dpdk/18.05/0006-net-ena-fix-passing-RSS-hash-to-mbuf.patch
+++ b/userspace/dpdk/18.05/0006-net-ena-fix-passing-RSS-hash-to-mbuf.patch
@@ -1,0 +1,35 @@
+From 952581ced26c55856be49a2e8220debd940966ab Mon Sep 17 00:00:00 2001
+From: Stewart Allen <allenste@amazon.com>
+Date: Thu, 25 Oct 2018 19:59:22 +0200
+Subject: [PATCH 6/6] net/ena: fix passing RSS hash to mbuf
+
+[ upstream commit e5df9f33db00eb9d322abaefff30da74fd0e625d ]
+
+The driver was passing to the mbuf Rx queue ID instead of hash received
+from the device. Now, the RSS hash from the Rx descriptor is being set.
+
+Fixes: 1173fca25af9 ("ena: add polling-mode driver")
+Cc: stable@dpdk.org
+
+Signed-off-by: Stewart Allen <allenste@amazon.com>
+Acked-by: Michal Krawczyk <mk@semihalf.com>
+---
+ drivers/net/ena/ena_ethdev.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/drivers/net/ena/ena_ethdev.c b/drivers/net/ena/ena_ethdev.c
+index ebc911168..f0849a455 100644
+--- a/drivers/net/ena/ena_ethdev.c
++++ b/drivers/net/ena/ena_ethdev.c
+@@ -1599,7 +1599,7 @@ static uint16_t eth_ena_recv_pkts(void *rx_queue, struct rte_mbuf **rx_pkts,
+ 
+ 		/* fill mbuf attributes if any */
+ 		ena_rx_mbuf_prepare(mbuf_head, &ena_rx_ctx);
+-		mbuf_head->hash.rss = (uint32_t)rx_ring->id;
++		mbuf_head->hash.rss = ena_rx_ctx.hash;
+ 
+ 		/* pass to DPDK application head mbuf */
+ 		rx_pkts[recv_idx] = mbuf_head;
+-- 
+2.14.1
+

--- a/userspace/dpdk/18.08/0001-net-ena-recreate-HW-IO-rings-on-start-and-stop.patch
+++ b/userspace/dpdk/18.08/0001-net-ena-recreate-HW-IO-rings-on-start-and-stop.patch
@@ -1,0 +1,363 @@
+From 126e0497aa41ff7b6fb6f2569626e6fed44bfe78 Mon Sep 17 00:00:00 2001
+From: Michal Krawczyk <mk@semihalf.com>
+Date: Thu, 25 Oct 2018 19:59:21 +0200
+Subject: [PATCH 1/4] net/ena: recreate HW IO rings on start and stop
+
+[ upstream commit df238f84c0a21d642bb9517d0c75ba831eeceb46 ]
+
+On the start the driver was refilling all Rx buffs, but the old ones
+were not released. That way running start/stop for a few times was
+causing device to run out of descriptors.
+
+To fix the issue, IO rings are now being destroyed on stop, and
+recreated on start. That way the device is not losing any descriptors.
+
+Furthermore, there was also memory leak for the Rx mbufs, which were
+created on start and not destroyed on stop.
+
+Fixes: eb0ef49dd5d5 ("net/ena: add stop and uninit routines")
+Cc: stable@dpdk.org
+
+Signed-off-by: Michal Krawczyk <mk@semihalf.com>
+---
+ drivers/net/ena/ena_ethdev.c | 196 ++++++++++++++++++++-----------------------
+ 1 file changed, 91 insertions(+), 105 deletions(-)
+
+diff --git a/drivers/net/ena/ena_ethdev.c b/drivers/net/ena/ena_ethdev.c
+index c255dc6db..de5d2edc2 100644
+--- a/drivers/net/ena/ena_ethdev.c
++++ b/drivers/net/ena/ena_ethdev.c
+@@ -239,6 +239,8 @@ static void ena_rx_queue_release_bufs(struct ena_ring *ring);
+ static void ena_tx_queue_release_bufs(struct ena_ring *ring);
+ static int ena_link_update(struct rte_eth_dev *dev,
+ 			   int wait_to_complete);
++static int ena_create_io_queue(struct ena_ring *ring);
++static void ena_free_io_queues_all(struct ena_adapter *adapter);
+ static int ena_queue_restart(struct ena_ring *ring);
+ static int ena_queue_restart_all(struct rte_eth_dev *dev,
+ 				 enum ena_ring_type ring_type);
+@@ -510,7 +512,8 @@ static void ena_close(struct rte_eth_dev *dev)
+ 	struct ena_adapter *adapter =
+ 		(struct ena_adapter *)(dev->data->dev_private);
+ 
+-	ena_stop(dev);
++	if (adapter->state == ENA_ADAPTER_STATE_RUNNING)
++		ena_stop(dev);
+ 	adapter->state = ENA_ADAPTER_STATE_CLOSED;
+ 
+ 	ena_rx_queue_release_all(dev);
+@@ -746,21 +749,12 @@ static void ena_tx_queue_release_all(struct rte_eth_dev *dev)
+ static void ena_rx_queue_release(void *queue)
+ {
+ 	struct ena_ring *ring = (struct ena_ring *)queue;
+-	struct ena_adapter *adapter = ring->adapter;
+-	int ena_qid;
+ 
+ 	ena_assert_msg(ring->configured,
+ 		       "API violation - releasing not configured queue");
+ 	ena_assert_msg(ring->adapter->state != ENA_ADAPTER_STATE_RUNNING,
+ 		       "API violation");
+ 
+-	/* Destroy HW queue */
+-	ena_qid = ENA_IO_RXQ_IDX(ring->id);
+-	ena_com_destroy_io_queue(&adapter->ena_dev, ena_qid);
+-
+-	/* Free all bufs */
+-	ena_rx_queue_release_bufs(ring);
+-
+ 	/* Free ring resources */
+ 	if (ring->rx_buffer_info)
+ 		rte_free(ring->rx_buffer_info);
+@@ -779,18 +773,12 @@ static void ena_rx_queue_release(void *queue)
+ static void ena_tx_queue_release(void *queue)
+ {
+ 	struct ena_ring *ring = (struct ena_ring *)queue;
+-	struct ena_adapter *adapter = ring->adapter;
+-	int ena_qid;
+ 
+ 	ena_assert_msg(ring->configured,
+ 		       "API violation. Releasing not configured queue");
+ 	ena_assert_msg(ring->adapter->state != ENA_ADAPTER_STATE_RUNNING,
+ 		       "API violation");
+ 
+-	/* Destroy HW queue */
+-	ena_qid = ENA_IO_TXQ_IDX(ring->id);
+-	ena_com_destroy_io_queue(&adapter->ena_dev, ena_qid);
+-
+ 	/* Free all bufs */
+ 	ena_tx_queue_release_bufs(ring);
+ 
+@@ -1078,10 +1066,86 @@ static void ena_stop(struct rte_eth_dev *dev)
+ 		(struct ena_adapter *)(dev->data->dev_private);
+ 
+ 	rte_timer_stop_sync(&adapter->timer_wd);
++	ena_free_io_queues_all(adapter);
+ 
+ 	adapter->state = ENA_ADAPTER_STATE_STOPPED;
+ }
+ 
++static int ena_create_io_queue(struct ena_ring *ring)
++{
++	struct ena_adapter *adapter;
++	struct ena_com_dev *ena_dev;
++	struct ena_com_create_io_ctx ctx =
++		/* policy set to _HOST just to satisfy icc compiler */
++		{ ENA_ADMIN_PLACEMENT_POLICY_HOST,
++		  0, 0, 0, 0, 0 };
++	uint16_t ena_qid;
++	int rc;
++
++	adapter = ring->adapter;
++	ena_dev = &adapter->ena_dev;
++
++	if (ring->type == ENA_RING_TYPE_TX) {
++		ena_qid = ENA_IO_TXQ_IDX(ring->id);
++		ctx.direction = ENA_COM_IO_QUEUE_DIRECTION_TX;
++		ctx.mem_queue_type = ena_dev->tx_mem_queue_type;
++		ctx.queue_size = adapter->tx_ring_size;
++	} else {
++		ena_qid = ENA_IO_RXQ_IDX(ring->id);
++		ctx.direction = ENA_COM_IO_QUEUE_DIRECTION_RX;
++		ctx.queue_size = adapter->rx_ring_size;
++	}
++	ctx.qid = ena_qid;
++	ctx.msix_vector = -1; /* interrupts not used */
++	ctx.numa_node = ena_cpu_to_node(ring->id);
++
++	rc = ena_com_create_io_queue(ena_dev, &ctx);
++	if (rc) {
++		RTE_LOG(ERR, PMD,
++			"failed to create io queue #%d (qid:%d) rc: %d\n",
++			ring->id, ena_qid, rc);
++		return rc;
++	}
++
++	rc = ena_com_get_io_handlers(ena_dev, ena_qid,
++				     &ring->ena_com_io_sq,
++				     &ring->ena_com_io_cq);
++	if (rc) {
++		RTE_LOG(ERR, PMD,
++			"Failed to get io queue handlers. queue num %d rc: %d\n",
++			ring->id, rc);
++		ena_com_destroy_io_queue(ena_dev, ena_qid);
++		return rc;
++	}
++
++	if (ring->type == ENA_RING_TYPE_TX)
++		ena_com_update_numa_node(ring->ena_com_io_cq, ctx.numa_node);
++
++	return 0;
++}
++
++static void ena_free_io_queues_all(struct ena_adapter *adapter)
++{
++	struct rte_eth_dev *eth_dev = adapter->rte_dev;
++	struct ena_com_dev *ena_dev = &adapter->ena_dev;
++	int i;
++	uint16_t ena_qid;
++	uint16_t nb_rxq = eth_dev->data->nb_rx_queues;
++	uint16_t nb_txq = eth_dev->data->nb_tx_queues;
++
++	for (i = 0; i < nb_txq; ++i) {
++		ena_qid = ENA_IO_TXQ_IDX(i);
++		ena_com_destroy_io_queue(ena_dev, ena_qid);
++	}
++
++	for (i = 0; i < nb_rxq; ++i) {
++		ena_qid = ENA_IO_RXQ_IDX(i);
++		ena_com_destroy_io_queue(ena_dev, ena_qid);
++
++		ena_rx_queue_release_bufs(&adapter->rx_ring[i]);
++	}
++}
++
+ static int ena_queue_restart(struct ena_ring *ring)
+ {
+ 	int rc, bufs_num;
+@@ -1089,6 +1153,12 @@ static int ena_queue_restart(struct ena_ring *ring)
+ 	ena_assert_msg(ring->configured == 1,
+ 		       "Trying to restart unconfigured queue\n");
+ 
++	rc = ena_create_io_queue(ring);
++	if (rc) {
++		PMD_INIT_LOG(ERR, "Failed to create IO queue!\n");
++		return rc;
++	}
++
+ 	ring->next_to_clean = 0;
+ 	ring->next_to_use = 0;
+ 
+@@ -1111,17 +1181,10 @@ static int ena_tx_queue_setup(struct rte_eth_dev *dev,
+ 			      __rte_unused unsigned int socket_id,
+ 			      const struct rte_eth_txconf *tx_conf)
+ {
+-	struct ena_com_create_io_ctx ctx =
+-		/* policy set to _HOST just to satisfy icc compiler */
+-		{ ENA_ADMIN_PLACEMENT_POLICY_HOST,
+-		  ENA_COM_IO_QUEUE_DIRECTION_TX, 0, 0, 0, 0 };
+ 	struct ena_ring *txq = NULL;
+ 	struct ena_adapter *adapter =
+ 		(struct ena_adapter *)(dev->data->dev_private);
+ 	unsigned int i;
+-	int ena_qid;
+-	int rc;
+-	struct ena_com_dev *ena_dev = &adapter->ena_dev;
+ 
+ 	txq = &adapter->tx_ring[queue_idx];
+ 
+@@ -1146,37 +1209,6 @@ static int ena_tx_queue_setup(struct rte_eth_dev *dev,
+ 		return -EINVAL;
+ 	}
+ 
+-	ena_qid = ENA_IO_TXQ_IDX(queue_idx);
+-
+-	ctx.direction = ENA_COM_IO_QUEUE_DIRECTION_TX;
+-	ctx.qid = ena_qid;
+-	ctx.msix_vector = -1; /* admin interrupts not used */
+-	ctx.mem_queue_type = ena_dev->tx_mem_queue_type;
+-	ctx.queue_size = adapter->tx_ring_size;
+-	ctx.numa_node = ena_cpu_to_node(queue_idx);
+-
+-	rc = ena_com_create_io_queue(ena_dev, &ctx);
+-	if (rc) {
+-		RTE_LOG(ERR, PMD,
+-			"failed to create io TX queue #%d (qid:%d) rc: %d\n",
+-			queue_idx, ena_qid, rc);
+-		return rc;
+-	}
+-	txq->ena_com_io_cq = &ena_dev->io_cq_queues[ena_qid];
+-	txq->ena_com_io_sq = &ena_dev->io_sq_queues[ena_qid];
+-
+-	rc = ena_com_get_io_handlers(ena_dev, ena_qid,
+-				     &txq->ena_com_io_sq,
+-				     &txq->ena_com_io_cq);
+-	if (rc) {
+-		RTE_LOG(ERR, PMD,
+-			"Failed to get TX queue handlers. TX queue num %d rc: %d\n",
+-			queue_idx, rc);
+-		goto err_destroy_io_queue;
+-	}
+-
+-	ena_com_update_numa_node(txq->ena_com_io_cq, ctx.numa_node);
+-
+ 	txq->port_id = dev->data->port_id;
+ 	txq->next_to_clean = 0;
+ 	txq->next_to_use = 0;
+@@ -1188,8 +1220,7 @@ static int ena_tx_queue_setup(struct rte_eth_dev *dev,
+ 					  RTE_CACHE_LINE_SIZE);
+ 	if (!txq->tx_buffer_info) {
+ 		RTE_LOG(ERR, PMD, "failed to alloc mem for tx buffer info\n");
+-		rc = -ENOMEM;
+-		goto err_destroy_io_queue;
++		return -ENOMEM;
+ 	}
+ 
+ 	txq->empty_tx_reqs = rte_zmalloc("txq->empty_tx_reqs",
+@@ -1197,8 +1228,8 @@ static int ena_tx_queue_setup(struct rte_eth_dev *dev,
+ 					 RTE_CACHE_LINE_SIZE);
+ 	if (!txq->empty_tx_reqs) {
+ 		RTE_LOG(ERR, PMD, "failed to alloc mem for tx reqs\n");
+-		rc = -ENOMEM;
+-		goto err_free;
++		rte_free(txq->tx_buffer_info);
++		return -ENOMEM;
+ 	}
+ 
+ 	for (i = 0; i < txq->ring_size; i++)
+@@ -1214,13 +1245,6 @@ static int ena_tx_queue_setup(struct rte_eth_dev *dev,
+ 	dev->data->tx_queues[queue_idx] = txq;
+ 
+ 	return 0;
+-
+-err_free:
+-	rte_free(txq->tx_buffer_info);
+-
+-err_destroy_io_queue:
+-	ena_com_destroy_io_queue(ena_dev, ena_qid);
+-	return rc;
+ }
+ 
+ static int ena_rx_queue_setup(struct rte_eth_dev *dev,
+@@ -1230,16 +1254,10 @@ static int ena_rx_queue_setup(struct rte_eth_dev *dev,
+ 			      __rte_unused const struct rte_eth_rxconf *rx_conf,
+ 			      struct rte_mempool *mp)
+ {
+-	struct ena_com_create_io_ctx ctx =
+-		/* policy set to _HOST just to satisfy icc compiler */
+-		{ ENA_ADMIN_PLACEMENT_POLICY_HOST,
+-		  ENA_COM_IO_QUEUE_DIRECTION_RX, 0, 0, 0, 0 };
+ 	struct ena_adapter *adapter =
+ 		(struct ena_adapter *)(dev->data->dev_private);
+ 	struct ena_ring *rxq = NULL;
+-	uint16_t ena_qid = 0;
+-	int i, rc = 0;
+-	struct ena_com_dev *ena_dev = &adapter->ena_dev;
++	int i;
+ 
+ 	rxq = &adapter->rx_ring[queue_idx];
+ 	if (rxq->configured) {
+@@ -1263,36 +1281,6 @@ static int ena_rx_queue_setup(struct rte_eth_dev *dev,
+ 		return -EINVAL;
+ 	}
+ 
+-	ena_qid = ENA_IO_RXQ_IDX(queue_idx);
+-
+-	ctx.qid = ena_qid;
+-	ctx.direction = ENA_COM_IO_QUEUE_DIRECTION_RX;
+-	ctx.mem_queue_type = ENA_ADMIN_PLACEMENT_POLICY_HOST;
+-	ctx.msix_vector = -1; /* admin interrupts not used */
+-	ctx.queue_size = adapter->rx_ring_size;
+-	ctx.numa_node = ena_cpu_to_node(queue_idx);
+-
+-	rc = ena_com_create_io_queue(ena_dev, &ctx);
+-	if (rc) {
+-		RTE_LOG(ERR, PMD, "failed to create io RX queue #%d rc: %d\n",
+-			queue_idx, rc);
+-		return rc;
+-	}
+-
+-	rxq->ena_com_io_cq = &ena_dev->io_cq_queues[ena_qid];
+-	rxq->ena_com_io_sq = &ena_dev->io_sq_queues[ena_qid];
+-
+-	rc = ena_com_get_io_handlers(ena_dev, ena_qid,
+-				     &rxq->ena_com_io_sq,
+-				     &rxq->ena_com_io_cq);
+-	if (rc) {
+-		RTE_LOG(ERR, PMD,
+-			"Failed to get RX queue handlers. RX queue num %d rc: %d\n",
+-			queue_idx, rc);
+-		ena_com_destroy_io_queue(ena_dev, ena_qid);
+-		return rc;
+-	}
+-
+ 	rxq->port_id = dev->data->port_id;
+ 	rxq->next_to_clean = 0;
+ 	rxq->next_to_use = 0;
+@@ -1304,7 +1292,6 @@ static int ena_rx_queue_setup(struct rte_eth_dev *dev,
+ 					  RTE_CACHE_LINE_SIZE);
+ 	if (!rxq->rx_buffer_info) {
+ 		RTE_LOG(ERR, PMD, "failed to alloc mem for rx buffer info\n");
+-		ena_com_destroy_io_queue(ena_dev, ena_qid);
+ 		return -ENOMEM;
+ 	}
+ 
+@@ -1315,7 +1302,6 @@ static int ena_rx_queue_setup(struct rte_eth_dev *dev,
+ 		RTE_LOG(ERR, PMD, "failed to alloc mem for empty rx reqs\n");
+ 		rte_free(rxq->rx_buffer_info);
+ 		rxq->rx_buffer_info = NULL;
+-		ena_com_destroy_io_queue(ena_dev, ena_qid);
+ 		return -ENOMEM;
+ 	}
+ 
+@@ -1326,7 +1312,7 @@ static int ena_rx_queue_setup(struct rte_eth_dev *dev,
+ 	rxq->configured = 1;
+ 	dev->data->rx_queues[queue_idx] = rxq;
+ 
+-	return rc;
++	return 0;
+ }
+ 
+ static int ena_populate_rx_queue(struct ena_ring *rxq, unsigned int count)
+-- 
+2.14.1
+

--- a/userspace/dpdk/18.08/0002-net-ena-fix-passing-RSS-hash-to-mbuf.patch
+++ b/userspace/dpdk/18.08/0002-net-ena-fix-passing-RSS-hash-to-mbuf.patch
@@ -1,0 +1,35 @@
+From 8e68880600b5ac56dc55850d5f9b9db03823e668 Mon Sep 17 00:00:00 2001
+From: Stewart Allen <allenste@amazon.com>
+Date: Thu, 25 Oct 2018 19:59:22 +0200
+Subject: [PATCH 2/4] net/ena: fix passing RSS hash to mbuf
+
+[ upstream commit e5df9f33db00eb9d322abaefff30da74fd0e625d ]
+
+The driver was passing to the mbuf Rx queue ID instead of hash received
+from the device. Now, the RSS hash from the Rx descriptor is being set.
+
+Fixes: 1173fca25af9 ("ena: add polling-mode driver")
+Cc: stable@dpdk.org
+
+Signed-off-by: Stewart Allen <allenste@amazon.com>
+Acked-by: Michal Krawczyk <mk@semihalf.com>
+---
+ drivers/net/ena/ena_ethdev.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/drivers/net/ena/ena_ethdev.c b/drivers/net/ena/ena_ethdev.c
+index de5d2edc2..acb1a08e0 100644
+--- a/drivers/net/ena/ena_ethdev.c
++++ b/drivers/net/ena/ena_ethdev.c
+@@ -1910,7 +1910,7 @@ static uint16_t eth_ena_recv_pkts(void *rx_queue, struct rte_mbuf **rx_pkts,
+ 
+ 		/* fill mbuf attributes if any */
+ 		ena_rx_mbuf_prepare(mbuf_head, &ena_rx_ctx);
+-		mbuf_head->hash.rss = (uint32_t)rx_ring->id;
++		mbuf_head->hash.rss = ena_rx_ctx.hash;
+ 
+ 		/* pass to DPDK application head mbuf */
+ 		rx_pkts[recv_idx] = mbuf_head;
+-- 
+2.14.1
+

--- a/userspace/dpdk/18.08/0003-net-ena-fix-cleaning-HW-IO-rings-configuration.patch
+++ b/userspace/dpdk/18.08/0003-net-ena-fix-cleaning-HW-IO-rings-configuration.patch
@@ -1,0 +1,58 @@
+From 79f7b061bfc354f660d4db0173bec4d47e6c43dd Mon Sep 17 00:00:00 2001
+From: Rafal Kozik <rk@semihalf.com>
+Date: Wed, 14 Nov 2018 10:59:45 +0100
+Subject: [PATCH 3/4] net/ena: fix cleaning HW IO rings configuration
+
+[ upstream commit 778677dcb20cf29d966f239972b043f0640f55ef ]
+
+When queues are stopped release Tx buffers.
+During start initialize array of empty Tx/Rx reqs with default values.
+
+Fixes: df238f84c0a2 ("net/ena: recreate HW IO rings on start and stop")
+Cc: stable@dpdk.org
+
+Signed-off-by: Rafal Kozik <rk@semihalf.com>
+Acked-by: Michal Krawczyk <mk@semihalf.com>
+---
+ drivers/net/ena/ena_ethdev.c | 7 +++++++
+ 1 file changed, 7 insertions(+)
+
+diff --git a/drivers/net/ena/ena_ethdev.c b/drivers/net/ena/ena_ethdev.c
+index acb1a08e0..9e462099f 100644
+--- a/drivers/net/ena/ena_ethdev.c
++++ b/drivers/net/ena/ena_ethdev.c
+@@ -1080,6 +1080,7 @@ static int ena_create_io_queue(struct ena_ring *ring)
+ 		{ ENA_ADMIN_PLACEMENT_POLICY_HOST,
+ 		  0, 0, 0, 0, 0 };
+ 	uint16_t ena_qid;
++	unsigned int i;
+ 	int rc;
+ 
+ 	adapter = ring->adapter;
+@@ -1090,10 +1091,14 @@ static int ena_create_io_queue(struct ena_ring *ring)
+ 		ctx.direction = ENA_COM_IO_QUEUE_DIRECTION_TX;
+ 		ctx.mem_queue_type = ena_dev->tx_mem_queue_type;
+ 		ctx.queue_size = adapter->tx_ring_size;
++		for (i = 0; i < ring->ring_size; i++)
++			ring->empty_tx_reqs[i] = i;
+ 	} else {
+ 		ena_qid = ENA_IO_RXQ_IDX(ring->id);
+ 		ctx.direction = ENA_COM_IO_QUEUE_DIRECTION_RX;
+ 		ctx.queue_size = adapter->rx_ring_size;
++		for (i = 0; i < ring->ring_size; i++)
++			ring->empty_rx_reqs[i] = i;
+ 	}
+ 	ctx.qid = ena_qid;
+ 	ctx.msix_vector = -1; /* interrupts not used */
+@@ -1136,6 +1141,8 @@ static void ena_free_io_queues_all(struct ena_adapter *adapter)
+ 	for (i = 0; i < nb_txq; ++i) {
+ 		ena_qid = ENA_IO_TXQ_IDX(i);
+ 		ena_com_destroy_io_queue(ena_dev, ena_qid);
++
++		ena_tx_queue_release_bufs(&adapter->tx_ring[i]);
+ 	}
+ 
+ 	for (i = 0; i < nb_rxq; ++i) {
+-- 
+2.14.1
+

--- a/userspace/dpdk/18.08/0004-net-ena-fix-out-of-order-completion.patch
+++ b/userspace/dpdk/18.08/0004-net-ena-fix-out-of-order-completion.patch
@@ -1,0 +1,149 @@
+From 53253faf9e1064d1571eed8d95d3be1cc47cbff9 Mon Sep 17 00:00:00 2001
+From: Rafal Kozik <rk@semihalf.com>
+Date: Wed, 21 Nov 2018 09:21:14 +0100
+Subject: [PATCH 4/4] net/ena: fix out of order completion
+
+[ upstream commit 79405ee175857cfdbb508f9d55e2a51d95483be6 ]
+
+rx_buffer_info should be refill not linearly, but out of order.
+IDs should be taken from empty_rx_reqs array.
+
+rx_refill_buffer is introduced to temporary storage
+bulk of mbufs taken from pool.
+
+In case of error unused mbufs are put back to pool.
+
+Fixes: c2034976673d ("net/ena: add Rx out of order completion")
+Cc: stable@dpdk.org
+
+Signed-off-by: Rafal Kozik <rk@semihalf.com>
+Acked-by: Michal Krawczyk <mk@semihalf.com>
+---
+ drivers/net/ena/ena_ethdev.c | 40 ++++++++++++++++++++++++++++------------
+ drivers/net/ena/ena_ethdev.h |  1 +
+ 2 files changed, 29 insertions(+), 12 deletions(-)
+
+diff --git a/drivers/net/ena/ena_ethdev.c b/drivers/net/ena/ena_ethdev.c
+index 9e462099f..87c95b2e7 100644
+--- a/drivers/net/ena/ena_ethdev.c
++++ b/drivers/net/ena/ena_ethdev.c
+@@ -760,6 +760,10 @@ static void ena_rx_queue_release(void *queue)
+ 		rte_free(ring->rx_buffer_info);
+ 	ring->rx_buffer_info = NULL;
+ 
++	if (ring->rx_refill_buffer)
++		rte_free(ring->rx_refill_buffer);
++	ring->rx_refill_buffer = NULL;
++
+ 	if (ring->empty_rx_reqs)
+ 		rte_free(ring->empty_rx_reqs);
+ 	ring->empty_rx_reqs = NULL;
+@@ -1302,6 +1306,17 @@ static int ena_rx_queue_setup(struct rte_eth_dev *dev,
+ 		return -ENOMEM;
+ 	}
+ 
++	rxq->rx_refill_buffer = rte_zmalloc("rxq->rx_refill_buffer",
++					    sizeof(struct rte_mbuf *) * nb_desc,
++					    RTE_CACHE_LINE_SIZE);
++
++	if (!rxq->rx_refill_buffer) {
++		RTE_LOG(ERR, PMD, "failed to alloc mem for rx refill buffer\n");
++		rte_free(rxq->rx_buffer_info);
++		rxq->rx_buffer_info = NULL;
++		return -ENOMEM;
++	}
++
+ 	rxq->empty_rx_reqs = rte_zmalloc("rxq->empty_rx_reqs",
+ 					 sizeof(uint16_t) * nb_desc,
+ 					 RTE_CACHE_LINE_SIZE);
+@@ -1309,6 +1324,8 @@ static int ena_rx_queue_setup(struct rte_eth_dev *dev,
+ 		RTE_LOG(ERR, PMD, "failed to alloc mem for empty rx reqs\n");
+ 		rte_free(rxq->rx_buffer_info);
+ 		rxq->rx_buffer_info = NULL;
++		rte_free(rxq->rx_refill_buffer);
++		rxq->rx_refill_buffer = NULL;
+ 		return -ENOMEM;
+ 	}
+ 
+@@ -1330,7 +1347,7 @@ static int ena_populate_rx_queue(struct ena_ring *rxq, unsigned int count)
+ 	uint16_t ring_mask = ring_size - 1;
+ 	uint16_t next_to_use = rxq->next_to_use;
+ 	uint16_t in_use, req_id;
+-	struct rte_mbuf **mbufs = &rxq->rx_buffer_info[0];
++	struct rte_mbuf **mbufs = rxq->rx_refill_buffer;
+ 
+ 	if (unlikely(!count))
+ 		return 0;
+@@ -1338,13 +1355,8 @@ static int ena_populate_rx_queue(struct ena_ring *rxq, unsigned int count)
+ 	in_use = rxq->next_to_use - rxq->next_to_clean;
+ 	ena_assert_msg(((in_use + count) < ring_size), "bad ring state");
+ 
+-	count = RTE_MIN(count,
+-			(uint16_t)(ring_size - (next_to_use & ring_mask)));
+-
+ 	/* get resources for incoming packets */
+-	rc = rte_mempool_get_bulk(rxq->mb_pool,
+-				  (void **)(&mbufs[next_to_use & ring_mask]),
+-				  count);
++	rc = rte_mempool_get_bulk(rxq->mb_pool, (void **)mbufs, count);
+ 	if (unlikely(rc < 0)) {
+ 		rte_atomic64_inc(&rxq->adapter->drv_stats->rx_nombuf);
+ 		PMD_RX_LOG(DEBUG, "there are no enough free buffers");
+@@ -1353,15 +1365,17 @@ static int ena_populate_rx_queue(struct ena_ring *rxq, unsigned int count)
+ 
+ 	for (i = 0; i < count; i++) {
+ 		uint16_t next_to_use_masked = next_to_use & ring_mask;
+-		struct rte_mbuf *mbuf = mbufs[next_to_use_masked];
++		struct rte_mbuf *mbuf = mbufs[i];
+ 		struct ena_com_buf ebuf;
+ 
+-		rte_prefetch0(mbufs[((next_to_use + 4) & ring_mask)]);
++		if (likely((i + 4) < count))
++			rte_prefetch0(mbufs[i + 4]);
+ 
+ 		req_id = rxq->empty_rx_reqs[next_to_use_masked];
+ 		rc = validate_rx_req_id(rxq, req_id);
+ 		if (unlikely(rc < 0))
+ 			break;
++		rxq->rx_buffer_info[req_id] = mbuf;
+ 
+ 		/* prepare physical address for DMA transaction */
+ 		ebuf.paddr = mbuf->buf_iova + RTE_PKTMBUF_HEADROOM;
+@@ -1370,17 +1384,19 @@ static int ena_populate_rx_queue(struct ena_ring *rxq, unsigned int count)
+ 		rc = ena_com_add_single_rx_desc(rxq->ena_com_io_sq,
+ 						&ebuf, req_id);
+ 		if (unlikely(rc)) {
+-			rte_mempool_put_bulk(rxq->mb_pool, (void **)(&mbuf),
+-					     count - i);
+ 			RTE_LOG(WARNING, PMD, "failed adding rx desc\n");
++			rxq->rx_buffer_info[req_id] = NULL;
+ 			break;
+ 		}
+ 		next_to_use++;
+ 	}
+ 
+-	if (unlikely(i < count))
++	if (unlikely(i < count)) {
+ 		RTE_LOG(WARNING, PMD, "refilled rx qid %d with only %d "
+ 			"buffers (from %d)\n", rxq->id, i, count);
++		rte_mempool_put_bulk(rxq->mb_pool, (void **)(&mbufs[i]),
++				     count - i);
++	}
+ 
+ 	/* When we submitted free recources to device... */
+ 	if (likely(i > 0)) {
+diff --git a/drivers/net/ena/ena_ethdev.h b/drivers/net/ena/ena_ethdev.h
+index 2dc8129e0..322e90ace 100644
+--- a/drivers/net/ena/ena_ethdev.h
++++ b/drivers/net/ena/ena_ethdev.h
+@@ -87,6 +87,7 @@ struct ena_ring {
+ 		struct ena_tx_buffer *tx_buffer_info; /* contex of tx packet */
+ 		struct rte_mbuf **rx_buffer_info; /* contex of rx packet */
+ 	};
++	struct rte_mbuf **rx_refill_buffer;
+ 	unsigned int ring_size; /* number of tx/rx_buffer_info's entries */
+ 
+ 	struct ena_com_io_cq *ena_com_io_cq;
+-- 
+2.14.1
+


### PR DESCRIPTION
The new patches were added for v16.04, v16.11, v17.02, v17.05, v17.08,
v17.11, v18.02 and v18.05:
  * Check pointer before memster of the in the coherent memory
    allocation routine
  * Allocate node memory using rte_zmalloc_socket(), instead of
    rte_memzone_reserve()
  * Fix GENMASK_ULL macro to prevent from causing undefined behavior
    in specific case
  * The fixed link speed is no longer set by the PMD
  * Prevent RSS configuration from causing SIGFPE if the Rx queue number
    is 0 and the RSS is enabled
  * Fix passing RSS hash to mbuf

For the v18.08 the below patches were added:
  * The HW IO rings are being recreated on start and stop
  * Fix passing RSS hash to mbuf
  * Fix for Rx OOO completion