### PR TITLE
[Bug Fix] efa: Fix module load issue on non-systemd based systems

### DIFF
--- a/kernel/linux/efa/RELEASENOTES.md
+++ b/kernel/linux/efa/RELEASENOTES.md
@@ -13,6 +13,10 @@ The driver was tested on the following distributions:
 * CentOS 7.4
 * CentOS 7.6
 
+## r0.9.2 release notes
+
+* Bug fix module load issue
+
 ## r0.9.1 release notes
 
 * Bug fix in EFA spec file

--- a/kernel/linux/efa/conf/dkms.conf
+++ b/kernel/linux/efa/conf/dkms.conf
@@ -1,5 +1,5 @@
 PACKAGE_NAME="efa"
-PACKAGE_VERSION="0.9.1"
+PACKAGE_VERSION="0.9.2"
 CLEAN="make clean"
 MAKE="make KERNEL_VERSION=${kernelver}"
 BUILT_MODULE_NAME[0]="efa"

--- a/kernel/linux/efa/efa_main.c
+++ b/kernel/linux/efa/efa_main.c
@@ -23,7 +23,7 @@ static const struct pci_device_id efa_pci_tbl[] = {
 
 #define DRV_MODULE_VER_MAJOR           0
 #define DRV_MODULE_VER_MINOR           9
-#define DRV_MODULE_VER_SUBMINOR        1
+#define DRV_MODULE_VER_SUBMINOR        2
 
 #ifndef DRV_MODULE_VERSION
 #define DRV_MODULE_VERSION \

--- a/kernel/linux/efa/rpm/Makefile
+++ b/kernel/linux/efa/rpm/Makefile
@@ -1,7 +1,7 @@
 # Makefile for creating rpm of the Amazon EFA driver
 
 NAME	= efa
-VERSION	= 0.9.1
+VERSION	= 0.9.2
 
 TOPDIR  := $(shell git rev-parse --show-toplevel)
 TAG	= master

--- a/kernel/linux/efa/rpm/efa.spec
+++ b/kernel/linux/efa/rpm/efa.spec
@@ -1,3 +1,5 @@
+# Copyright 2019 Amazon.com, Inc. or its affiliates. All rights reserved
+
 %define name			efa
 %define debug_package		%{nil}
 
@@ -37,6 +39,7 @@ dkms remove -m %{name} -v %{driver_version} --all
 cd kernel/linux/efa
 mkdir -p %{buildroot}%{install_path}
 install -D -m 644 conf/efa.conf		%{buildroot}/etc/modules-load.d/efa.conf
+install -D -m 644 conf/efa-modprobe.conf	%{buildroot}/etc/modprobe.d/efa.conf
 install -m 644 conf/dkms.conf		%{buildroot}%{install_path}
 install -m 644 efa_com.c		%{buildroot}%{install_path}
 install -m 644 efa_com_cmd.c		%{buildroot}%{install_path}
@@ -60,8 +63,13 @@ install -m 644 RELEASENOTES.md		%{buildroot}%{install_path}
 %files
 %{install_path}
 /etc/modules-load.d/efa.conf
+/etc/modprobe.d/efa.conf
 
 %changelog
+* Tue May 7 2019 Jie Zhang <zhngaj@amazon.com> - 0.9.2
+- Add a separate configuration file to load ib_uverbs as a soft dependency module
+  on non-systemd based systems
+
 * Tue Apr 2 2019 Robert Wespetal <wesper@amazon.com> - 0.9.1
 - Update EFA post install script to install module for all kernels
 

--- a/linux/kernel/efa_module/conf/efa-modprobe.conf
+++ b/linux/kernel/efa_module/conf/efa-modprobe.conf
@@ -1,0 +1,3 @@
+# Copyright 2019 Amazon.com, Inc. or its affiliates. All rights reserved
+
+softdep efa pre: ib_uverbs


### PR DESCRIPTION
Add a configuration file to pre-load ib_uverbs as a soft dependency
module of efa kernel module on non-systemd based systems

Change-Id: I0447d8e3c09be3834495a7f0f9cea1ef53472b6f
Signed-off-by: Jie Zhang <zhngaj@amazon.com>

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
