### PR TITLE
Allow parallel build.

### DIFF
--- a/kernel/linux/efa/Makefile
+++ b/kernel/linux/efa/Makefile
@@ -16,10 +16,10 @@ KERNEL_VERSION ?= $(shell uname -r)
 
 ccflags-y += -Wfatal-errors
 modules:
-	make -C /lib/modules/$(KERNEL_VERSION)/build M=$(CURDIR) modules
+	$(MAKE) -C /lib/modules/$(KERNEL_VERSION)/build M=$(CURDIR) modules
 
 install: modules
-	make -C /lib/modules/$(KERNEL_VERSION)/build M=$(CURDIR) modules_install
+	$(MAKE) -C /lib/modules/$(KERNEL_VERSION)/build M=$(CURDIR) modules_install
 
 clean:
-	make -C /lib/modules/$(KERNEL_VERSION)/build M=$(CURDIR) clean
+	$(MAKE)-C /lib/modules/$(KERNEL_VERSION)/build M=$(CURDIR) clean

--- a/kernel/linux/ena/Makefile
+++ b/kernel/linux/ena/Makefile
@@ -35,7 +35,7 @@ ifdef UBUNTU_ABI
 endif
 
 all:
-	make -C /lib/modules/$(BUILD_KERNEL)/build M=$(CURDIR) modules
+	$(MAKE) -C /lib/modules/$(BUILD_KERNEL)/build M=$(CURDIR) modules
 
 clean:
-	make -C /lib/modules/$(BUILD_KERNEL)/build M=$(CURDIR) clean
+	$(MAKE) -C /lib/modules/$(BUILD_KERNEL)/build M=$(CURDIR) clean


### PR DESCRIPTION
This resolves the warning:
'make[1]: warning: jobserver unavailable: using -j1.  Add '+' to parent make rule.'

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.