### PR TITLE
fbsd/ena: fix MODULE_PNP_INFO call for FreeBSD 11

### DIFF
--- a/kernel/fbsd/ena/ena.c
+++ b/kernel/fbsd/ena/ena.c
@@ -4658,7 +4658,11 @@ static driver_t ena_driver = {
 devclass_t ena_devclass;
 DRIVER_MODULE(ena, pci, ena_driver, ena_devclass, 0, 0);
 MODULE_PNP_INFO("U16:vendor;U16:device", pci, ena, ena_vendor_info_array,
+#if __FreeBSD_version > 1200084
     nitems(ena_vendor_info_array) - 1);
+#else
+    sizeof(ena_vendor_info_array[0]), nitems(ena_vendor_info_array) - 1);
+#endif
 MODULE_DEPEND(ena, pci, 1, 1, 1);
 MODULE_DEPEND(ena, ether, 1, 1, 1);
 


### PR DESCRIPTION
The API of the MODULE_PNP_INFO has changed in the FreeBSD 13.0 release.
It was MFCed to the stable/12 system, but stable/11 is still missing it.

This patch will also fix the compilation for the FreeBSD 12 release and
all 11.* releases and won't break anything for newer versions.

Signed-off-by: Michal Krawczyk <mk@semihalf.com>

*Issue #, if available:* #111 

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
