### PR TITLE
fbsd/ena: update ENA FreeBSD driver to v2.1.0

### DIFF
--- a/kernel/fbsd/ena/Makefile
+++ b/kernel/fbsd/ena/Makefile
@@ -40,12 +40,17 @@ KMOD    = if_ena
 
 # Shared source
 SRCS    = device_if.h bus_if.h pci_if.h
-SRCS	+= ena.c ena_com.c ena_eth_com.c ena_sysctl.c
+SRCS	+= ena_com.c ena_eth_com.c
+SRCS	+= ena.c ena_sysctl.c ena_datapath.c ena_netmap.c
 
 CFLAGS  += -DSMP -O2
 
 # Enable debug messages and sysctls
 # CFLAGS  += -DENA_DEBUG
+
+# Add netmap support in the driver.
+# Uncomment this only if the netmap is enabled in the kernel.
+# CFLAGS += -DDEV_NETMAP
 
 clean:
 	rm -f opt_bdg.h device_if.h bus_if.h pci_if.h setdef* *_StripErr

--- a/kernel/fbsd/ena/README
+++ b/kernel/fbsd/ena/README
@@ -3,7 +3,7 @@ FreeBSD kernel driver for Elastic Network Adapter (ENA) family:
 
 Version:
 ========
-v2.0.0
+v2.1.0
 
 Supported FreeBSD Versions:
 ===========================
@@ -139,6 +139,17 @@ ena_eth_io_defs.h - Definition of ENA data path interface.
 ena_common_defs.h - Common definitions for ena_com layer.
 ena_regs_defs.h   - Definition of ENA PCI memory-mapped (MMIO) registers.
 ena_plat.h        - Platform dependent code for FreeBSD.
+
+Overview:
+=========
+
+The driver is supporting the netmap framework. In order to use it, the Makefile
+of the module should be modified and it needs uncommenting of the line:
+# CFLAGS += -DDEV_NETMAP
+
+The kernel must be also built with DEV_NETMAP option in order to be able to use
+the driver with the netmap support, which is default for amd64 but not for
+aarch64.
 
 Management Interface:
 =====================

--- a/kernel/fbsd/ena/RELEASENOTES.md
+++ b/kernel/fbsd/ena/RELEASENOTES.md
@@ -1,0 +1,240 @@
+# ENA FreeBSD Kernel Driver Release Notes
+
+## Supported Kernel Versions and Distributions
+
+ENA driver is supported on all FreeBSD releases starting from 11.2
+
+The driver was verified on the following distributions:
+
+**Releases:**
+* FreeBSD 11.3
+* FreeBSD 12.0
+
+**Development:**
+* stable/11 - r352773
+* stable/12 - r352266
+* HEAD - r352778
+
+## r2.1.0 release notes
+**New Features**
+* Add netmap support.
+* Add LLQ support for the aarch64 by enabling WC.
+
+**Bug Fixes**
+* Fix infinite missing keep alive reset loop in case the reset routine
+  takes too long because of the host being overloaded.
+
+**Minor Changes**
+* Split controller and datapath code into separate files.
+
+## r2.0.0 release notes
+**New Features**
+* LLQ (Low Latency Queue) feature was added. New placement policy
+  enables storing Tx descriptor rings and packet headers in the device
+  memory. LLQs improve average and tail latencies. As part of LLQs
+  enablement new admin capability was defined, device memory was mapped
+  as write-combined and the transmit processing flow was updated.
+* Rx checksum offloads can now be used on some of the HW.
+* Optimization of the locks on both Tx and Rx paths. Rx locks were
+  removed and Tx locks were optimized by adding queue management (stop
+  and start).
+* Additional Tx doorbells checks were added - supported only by some of
+  the hardware.
+
+**Bug Fixes**
+* Suppress excessive error printouts in Tx hot path.
+* Fix validation of the Rx OOO completion.
+* Prevent double activation of admin interrupt (issue on A1).
+* The reset is being triggered if too many Rx descriptors were received.
+* The vaddr and paddr must be zeroed if allocation of the coherent
+  memory fails using bus_dma_* API.
+* The error is being set if allocation of IO interrupts fails.
+* Driver now correctly supports partial MSI-x allocation - previously
+  it was assuming, that the OS will always give enough MSI-x if the
+  allocation won't return error.
+* The ifp must be released detached before the last ena_down is called,
+  to make sure ena_up will not be called once the ifp is released.
+* The ifp should be allocated at the very end of the attach() function,
+  as ifp cleanup is not working properly from the attach context.
+* The validation of the Tx req_id was fixed.
+* Error handling upon ENA reset is now fixed - it was causing memory
+  leak and device failure.
+* Tx offloads for fragmented pkt headers are fixed.
+* Add check for msix_entries in case reset fails to prevent NULL pointer
+  reference in ena_up().
+* The driver is now checking for missing MSI-x.
+* DMA synchronization calls were added to the Tx and Rx paths.
+
+**Minor Changes**
+* Add module PNP information.
+* Update HAL to the newest version for ENAv2 driver.
+* Logging of the ENA admin errors.
+* Kernel RSS support was removed, as it was not compatible with ENA
+  device.
+* The host info structure is now receiving information about number of
+  CPUs on the host as well as bdf (hints for the device).
+* Rx refill threshold was limited, due to maximum number of Rx ring
+  increased to 8k.
+* ENA reset is now split into restore and destroy stages.
+* New line characters in printouts were fixed.
+* Make the reset triggering safer, by checking if the reset was already
+  triggered.
+* Checking for missing Tx completion was reworked for better readability
+  and compatibility with above feature.
+* AENQ notification handler was added.
+* Device state is now being tracked using bitfields.
+
+## r0.8.1 release notes
+**Bug Fixes**
+* Fix a mutex not owned ASSERT panic in ENA control path
+* Skip setting MTU for ENA if it is not changing
+* Do not pass header length to the NIC, as extracting it from the mbuf
+  can be complicated in some cases
+* Change BIT macro to work on unsigned value
+
+## r0.8.0 release notes
+**New Features**
+* Update ena_com HAL to newest version
+* Add reset reasons when triggering reset of the device
+* Cover code with branch predictioning statements
+* Rework counting of HW statistics
+* Add RX OOO completion
+* Check for RX ring state to prevent from stall - run rx cleanup in
+  another thread if ring was stalled
+* Allow logging system to be dynamically adjusted from the userspace
+  from sysctl (hw.ena.log_level)
+* Read max MTU value from the device
+* Allow usage of more RX descriptors than 1
+
+**Bug Fixes**
+* Reset device after attach fails
+* In the reset task. free management irq after calling ena_down. Admin
+  queue can still be used before ena_down is called, or when it is being
+  handled
+* Do not reset device if ena_reset_task fails
+* Move call of the ena_com_dev_reset() to the ena_down() routine - it
+  should be called only if interface was up
+* Fix error handling in attach
+* Destroy admin queue resources after freeing interrupts (resources are
+  used by the interrupt handler)
+* Fix error handling in many places of the driver
+* Lock drbr_free() call - it must be called with lock acquired
+* Allow partial MSI-x allocation - update number of queues respectively
+* Fix checking for the value of the DF flag
+* Fix warnings that appeared when compiling driver with gcc
+* Fix comparing L3 type with L4 enum on setting RX hash
+* Fix calculating IO queues number
+* Fix setting AENQ group to indicate only implemented handlers
+
+**Minor Changes**
+* Use different function for checking empty space on the sq ring
+  (ena-com API change)
+* Fix typo on ENA_TX_CLEANUP_THRESHOLD
+* Change checking for EPERM with EOPNOTSUPP - change in the ena-com API
+* Remove deprecated debugging methods
+* Style fixes to align driver with FreeBSD style guide
+* Remove deprecated and unsused counters
+* Remove unsused macros and fields from ENA header file
+* Update README file
+* Remove NULL checks for malloc with M_WAITOK
+* Do not check conditions explicitly for bool variables
+
+## r0.7.1 release notes
+**New Features**
+* Add mbuf collapse feature in case the mbuf has more segments than the device
+  can handle
+
+**Bug Fixes**
+* Remove unsused statement from the platform file to enable gcc
+  compilation with standard warning flags
+* Fix error check for Rx mbuf allocation
+* Fix creation of the DMA tags and TSO settings
+* Call drbr_advance() before leaving Tx routine to prevent panic
+* Unmask all IO irqs after driver state is set as running, otherwise the
+  interrupts can stay masked if they were in that state during interface
+  initialization routine
+* Acquire locks before calling drbr_flush() as it is required by the API
+* Add missing lock upon initialization of the interface
+* Add additional locks when releasing Tx resources and bufs
+* Move hw stats updating routine to separate task to prevent from sleeping while
+  unsleepable lock is held
+* Add error handling if init of the reset task fails
+* Add locks before each ena_up and ena_down call
+
+**Minor Changes**
+* Remove Rx mutex as it is no longer needed
+
+## r0.7.0 release notes
+**New Features**
+* Acquire dma transaction width from the NIC
+* Allow to control level of printouts from the Makefile
+* Add watchdog service which is running periodically checks for:
+  * missing keep alive
+  * admin queue state
+  * missing tx completions
+  * if one of above fails, the reset is triggered
+  * additional sysctl statistics were added
+* Add reset task
+* Add fast path for the TX - if drbr is empty, send packet in current thread
+  instead of creating task
+* Add additional TX cleanup calls on TX path if queue is almost full
+* Use single ithread routine for cleanup of both TX and RX queues - it
+  allows synchronization of the TX and RX queues
+* Add host info feature - driver is sending information about OS to
+  the device
+
+**Bug Fixes**
+* Initialize part of the io queues resources during attach to prevent from
+  race condition during ena_down() call
+* Fix freeing RX counters twice
+* Unmask all irqs when creating queues - this fixes issue with missing MSI-x
+  when reloading interface during heavy network traffic
+* Add locks in ioctl call to prevent from resource concurrency when handling
+  simultaneous up/down of the interface
+* If sending packet to the NIC failed, leave transmitting loop instead of
+  trying until success - this could cause infinite loop
+* Fixed RSS handling mechanism by properly assigning flag to the mbuf
+  depending on type of the packet
+* Defer creation of the RSS to allow load ENA driver during boot
+* Fix error handling paths:
+  * ena_enable_msix: possible memory leak if pci_alloc_msix fails
+  * ena_create_io_queues: memory already allocated for part of
+    tx/rx queues is not released on error
+  * ena_setup_rx_resources: lack of error check after initialization of
+    enqueue task
+  * ena_request_mgmnt_irq: ignored fail of irq resource activation
+  * ena_sysctl_(dump|update)_stats: ignored errors returned by functions
+  * ena_reset_task: kernel page fault happens after failed reset
+* Add locks in qflush to prevent race with ena_start_xmit()
+* Add additional checks for driver status to prevent driver from hanging
+  in the infinite loop on TX path
+* Add error checks after malloc with M_NOWAIT
+* Add lock for the reset task to prevent conflict with ioctl
+* Move BPF_MTAP to track packet only if it was successfully sent to the NIC
+
+**Minor Changes**
+* Update README instructions for installing driver
+* Update description of the RX and TX path to reflect current state of
+  the driver
+* Update license to the 2-clause BSD
+* Move macros describing version of the driver to the ena.h file
+* Change printouts levels meaning and place from which some of them
+  are called
+* Use one RX buffer size for all MTU settings
+* Remove link speed change code - feature is not supported by the device
+* Align version system with Linux driver
+* Upgrade ena_com to 1.1.4.1
+* Reduce amount of DMA tags in use - one per type of the queue instead
+  one per queue
+* Remove transmit modes
+* Remove vlan support
+* Check for number of fragments before doing DMA mapping
+* Synchronize device initialization routine with Linux driver
+* Simplify TX cleanup routine loop
+* Reword descriptions of the sysctls
+* Remove references to NETMAP
+* Added budget to TX cleanup
+
+## r0.6.0 release notes
+
+Initial commit of the FreeBSD driver.

--- a/kernel/fbsd/ena/ena.c
+++ b/kernel/fbsd/ena/ena.c
@@ -76,8 +76,13 @@ __FBSDID("$FreeBSD$");
 #include <vm/vm.h>
 #include <vm/pmap.h>
 
+#include "ena_datapath.h"
 #include "ena.h"
 #include "ena_sysctl.h"
+
+#ifdef DEV_NETMAP
+#include "ena_netmap.h"
+#endif /* DEV_NETMAP */
 
 /*********************************************************
  *  Function prototypes
@@ -98,11 +103,11 @@ static int	ena_setup_tx_dma_tag(struct ena_adapter *);
 static int	ena_free_tx_dma_tag(struct ena_adapter *);
 static int	ena_setup_rx_dma_tag(struct ena_adapter *);
 static int	ena_free_rx_dma_tag(struct ena_adapter *);
+static void	ena_release_all_tx_dmamap(struct ena_ring *);
 static int	ena_setup_tx_resources(struct ena_adapter *, int);
 static void	ena_free_tx_resources(struct ena_adapter *, int);
 static int	ena_setup_all_tx_resources(struct ena_adapter *);
 static void	ena_free_all_tx_resources(struct ena_adapter *);
-static inline int validate_rx_req_id(struct ena_ring *, uint16_t);
 static int	ena_setup_rx_resources(struct ena_adapter *, unsigned int);
 static void	ena_free_rx_resources(struct ena_adapter *, unsigned int);
 static int	ena_setup_all_rx_resources(struct ena_adapter *);
@@ -111,7 +116,6 @@ static inline int ena_alloc_rx_mbuf(struct ena_adapter *, struct ena_ring *,
     struct ena_rx_buffer *);
 static void	ena_free_rx_mbuf(struct ena_adapter *, struct ena_ring *,
     struct ena_rx_buffer *);
-static int	ena_refill_rx_bufs(struct ena_ring *, uint32_t);
 static void	ena_free_rx_bufs(struct ena_adapter *, unsigned int);
 static void	ena_refill_all_rx_bufs(struct ena_adapter *);
 static void	ena_free_all_rx_bufs(struct ena_adapter *);
@@ -121,16 +125,6 @@ static void	ena_destroy_all_tx_queues(struct ena_adapter *);
 static void	ena_destroy_all_rx_queues(struct ena_adapter *);
 static void	ena_destroy_all_io_queues(struct ena_adapter *);
 static int	ena_create_io_queues(struct ena_adapter *);
-static int	ena_tx_cleanup(struct ena_ring *);
-static int	ena_rx_cleanup(struct ena_ring *);
-static inline int validate_tx_req_id(struct ena_ring *, uint16_t);
-static void	ena_rx_hash_mbuf(struct ena_ring *, struct ena_com_rx_ctx *,
-    struct mbuf *);
-static struct mbuf* ena_rx_mbuf(struct ena_ring *, struct ena_com_rx_buf_info *,
-    struct ena_com_rx_ctx *, uint16_t *);
-static inline void ena_rx_checksum(struct ena_ring *, struct ena_com_rx_ctx *,
-    struct mbuf *);
-static void	ena_cleanup(void *arg, int pending);
 static int	ena_handle_msix(void *);
 static int	ena_enable_msix(struct ena_adapter *);
 static void	ena_setup_mgmnt_intr(struct ena_adapter *);
@@ -144,8 +138,6 @@ static void	ena_disable_msix(struct ena_adapter *);
 static void	ena_unmask_all_io_irqs(struct ena_adapter *);
 static int	ena_rss_configure(struct ena_adapter *);
 static int	ena_up_complete(struct ena_adapter *);
-static int	ena_up(struct ena_adapter *);
-static void	ena_down(struct ena_adapter *);
 static uint64_t	ena_get_counter(if_t, ift_counter);
 static int	ena_media_change(if_t);
 static void	ena_media_status(if_t, struct ifmediareq *);
@@ -156,15 +148,6 @@ static void	ena_update_host_info(struct ena_admin_host_info *, if_t);
 static void	ena_update_hwassist(struct ena_adapter *);
 static int	ena_setup_ifnet(device_t, struct ena_adapter *,
     struct ena_com_dev_get_features_ctx *);
-static void	ena_tx_csum(struct ena_com_tx_ctx *, struct mbuf *);
-static int	ena_check_and_collapse_mbuf(struct ena_ring *tx_ring,
-    struct mbuf **mbuf);
-static void	ena_dmamap_llq(void *, bus_dma_segment_t *, int, int);
-static int	ena_xmit_mbuf(struct ena_ring *, struct mbuf **);
-static void	ena_start_xmit(struct ena_ring *);
-static int	ena_mq_start(if_t, struct mbuf *);
-static void	ena_deferred_mq_start(void *, int);
-static void	ena_qflush(if_t);
 static int	ena_enable_wc(struct resource *);
 static int	ena_set_queues_placement_policy(device_t, struct ena_com_dev *,
     struct ena_admin_feature_llq_desc *, struct ena_llq_configurations *);
@@ -549,6 +532,44 @@ ena_free_rx_dma_tag(struct ena_adapter *adapter)
 	return (ret);
 }
 
+static void
+ena_release_all_tx_dmamap(struct ena_ring *tx_ring)
+{
+	struct ena_adapter *adapter = tx_ring->adapter;
+	struct ena_tx_buffer *tx_info;
+	bus_dma_tag_t tx_tag = adapter->tx_buf_tag;;
+	int i;
+#ifdef DEV_NETMAP
+	struct ena_netmap_tx_info *nm_info;
+	int j;
+#endif /* DEV_NETMAP */
+
+	for (i = 0; i < tx_ring->ring_size; ++i) {
+		tx_info = &tx_ring->tx_buffer_info[i];
+#ifdef DEV_NETMAP
+		if (adapter->ifp->if_capenable & IFCAP_NETMAP) {
+			nm_info = &tx_info->nm_info;
+			for (j = 0; j < ENA_PKT_MAX_BUFS; ++j) {
+				if (nm_info->map_seg[j] != NULL) {
+					bus_dmamap_destroy(tx_tag,
+					    nm_info->map_seg[j]);
+					nm_info->map_seg[j] = NULL;
+				}
+			}
+		}
+#endif /* DEV_NETMAP */
+		if (tx_info->map_head != NULL) {
+			bus_dmamap_destroy(tx_tag, tx_info->map_head);
+			tx_info->map_head = NULL;
+		}
+
+		if (tx_info->map_seg != NULL) {
+			bus_dmamap_destroy(tx_tag, tx_info->map_seg);
+			tx_info->map_seg = NULL;
+		}
+	}
+}
+
 /**
  * ena_setup_tx_resources - allocate Tx resources (Descriptors)
  * @adapter: network interface device structure
@@ -562,6 +583,12 @@ ena_setup_tx_resources(struct ena_adapter *adapter, int qid)
 	struct ena_que *que = &adapter->que[qid];
 	struct ena_ring *tx_ring = que->tx_ring;
 	int size, i, err;
+#ifdef DEV_NETMAP
+	bus_dmamap_t *map;
+	int j;
+
+	ena_netmap_reset_tx_ring(adapter, qid);
+#endif /* DEV_NETMAP */
 
 	size = sizeof(struct ena_tx_buffer) * tx_ring->ring_size;
 
@@ -605,7 +632,7 @@ ena_setup_tx_resources(struct ena_adapter *adapter, int qid)
 			ena_trace(ENA_ALERT,
 			    "Unable to create Tx DMA map_head for buffer %d\n",
 			    i);
-			goto err_buf_info_unmap;
+			goto err_map_release;
 		}
 		tx_ring->tx_buffer_info[i].seg_mapped = false;
 
@@ -615,9 +642,24 @@ ena_setup_tx_resources(struct ena_adapter *adapter, int qid)
 			ena_trace(ENA_ALERT,
 			    "Unable to create Tx DMA map_seg for buffer %d\n",
 			    i);
-			goto err_buf_info_head_unmap;
+			goto err_map_release;
 		}
 		tx_ring->tx_buffer_info[i].head_mapped = false;
+
+#ifdef DEV_NETMAP
+		if (adapter->ifp->if_capenable & IFCAP_NETMAP) {
+			map = tx_ring->tx_buffer_info[i].nm_info.map_seg;
+			for (j = 0; j < ENA_PKT_MAX_BUFS; j++) {
+				err = bus_dmamap_create(adapter->tx_buf_tag, 0,
+				    &map[j]);
+				if (unlikely(err != 0)) {
+					ena_trace(ENA_ALERT, "Unable to create "
+					    "Tx DMA for buffer %d %d\n", i, j);
+					goto err_map_release;
+				}
+			}
+		}
+#endif /* DEV_NETMAP */
 	}
 
 	/* Allocate taskqueues */
@@ -628,7 +670,7 @@ ena_setup_tx_resources(struct ena_adapter *adapter, int qid)
 		ena_trace(ENA_ALERT,
 		    "Unable to create taskqueue for enqueue task\n");
 		i = tx_ring->ring_size;
-		goto err_buf_info_unmap;
+		goto err_map_release;
 	}
 
 	tx_ring->running = true;
@@ -638,17 +680,8 @@ ena_setup_tx_resources(struct ena_adapter *adapter, int qid)
 
 	return (0);
 
-err_buf_info_head_unmap:
-	bus_dmamap_destroy(adapter->tx_buf_tag,
-	    tx_ring->tx_buffer_info[i].map_head);
-err_buf_info_unmap:
-	while (i--) {
-		bus_dmamap_destroy(adapter->tx_buf_tag,
-		    tx_ring->tx_buffer_info[i].map_head);
-		bus_dmamap_destroy(adapter->tx_buf_tag,
-		    tx_ring->tx_buffer_info[i].map_seg);
-	}
-	free(tx_ring->push_buf_intermediate_buf, M_DEVBUF);
+err_map_release:
+	ena_release_all_tx_dmamap(tx_ring);
 err_tx_ids_free:
 	free(tx_ring->free_tx_ids, M_DEVBUF);
 	tx_ring->free_tx_ids = NULL;
@@ -670,6 +703,10 @@ static void
 ena_free_tx_resources(struct ena_adapter *adapter, int qid)
 {
 	struct ena_ring *tx_ring = &adapter->tx_ring[qid];
+#ifdef DEV_NETMAP
+	struct ena_netmap_tx_info *nm_info;
+	int j;
+#endif /* DEV_NETMAP */
 
 	while (taskqueue_cancel(tx_ring->enqueue_tq, &tx_ring->enqueue_task,
 	    NULL))
@@ -704,6 +741,24 @@ ena_free_tx_resources(struct ena_adapter *adapter, int qid)
 		}
 		bus_dmamap_destroy(adapter->tx_buf_tag,
 		    tx_ring->tx_buffer_info[i].map_seg);
+
+#ifdef DEV_NETMAP
+		if (adapter->ifp->if_capenable & IFCAP_NETMAP) {
+			nm_info = &tx_ring->tx_buffer_info[i].nm_info;
+			for (j = 0; j < ENA_PKT_MAX_BUFS; j++) {
+				if (nm_info->socket_buf_idx[j] != 0) {
+					bus_dmamap_sync(adapter->tx_buf_tag,
+					    nm_info->map_seg[j],
+					    BUS_DMASYNC_POSTWRITE);
+					ena_netmap_unload(adapter,
+					    nm_info->map_seg[j]);
+				}
+				bus_dmamap_destroy(adapter->tx_buf_tag,
+				    nm_info->map_seg[j]);
+				nm_info->socket_buf_idx[j] = 0;
+			}
+		}
+#endif /* DEV_NETMAP */
 
 		m_freem(tx_ring->tx_buffer_info[i].mbuf);
 		tx_ring->tx_buffer_info[i].mbuf = NULL;
@@ -766,25 +821,6 @@ ena_free_all_tx_resources(struct ena_adapter *adapter)
 		ena_free_tx_resources(adapter, i);
 }
 
-static inline int
-validate_rx_req_id(struct ena_ring *rx_ring, uint16_t req_id)
-{
-	if (likely(req_id < rx_ring->ring_size))
-		return (0);
-
-	device_printf(rx_ring->adapter->pdev, "Invalid rx req_id: %hu\n",
-	    req_id);
-	counter_u64_add(rx_ring->rx_stats.bad_req_id, 1);
-
-	/* Trigger device reset */
-	if (likely(!ENA_FLAG_ISSET(ENA_FLAG_TRIGGER_RESET, rx_ring->adapter))) {
-		rx_ring->adapter->reset_reason = ENA_REGS_RESET_INV_RX_REQ_ID;
-		ENA_FLAG_SET_ATOMIC(ENA_FLAG_TRIGGER_RESET, rx_ring->adapter);
-	}
-
-	return (EFAULT);
-}
-
 /**
  * ena_setup_rx_resources - allocate Rx resources (Descriptors)
  * @adapter: network interface device structure
@@ -800,6 +836,11 @@ ena_setup_rx_resources(struct ena_adapter *adapter, unsigned int qid)
 	int size, err, i;
 
 	size = sizeof(struct ena_rx_buffer) * rx_ring->ring_size;
+
+#ifdef DEV_NETMAP
+	ena_netmap_reset_rx_ring(adapter, qid);
+	rx_ring->initialized = false;
+#endif /* DEV_NETMAP */
 
 	/*
 	 * Alloc extra element so in rx path
@@ -1024,7 +1065,7 @@ ena_free_rx_mbuf(struct ena_adapter *adapter, struct ena_ring *rx_ring,
  * @num: number of descriptors to refill
  * Refills the ring with newly allocated DMA-mapped mbufs for receiving
  **/
-static int
+int
 ena_refill_rx_bufs(struct ena_ring *rx_ring, uint32_t num)
 {
 	struct ena_adapter *adapter = rx_ring->adapter;
@@ -1045,8 +1086,12 @@ ena_refill_rx_bufs(struct ena_ring *rx_ring, uint32_t num)
 
 		req_id = rx_ring->free_rx_ids[next_to_use];
 		rx_info = &rx_ring->rx_buffer_info[req_id];
-
-		rc = ena_alloc_rx_mbuf(adapter, rx_ring, rx_info);
+#ifdef DEV_NETMAP
+		if (ena_rx_ring_in_netmap(adapter, rx_ring->qid))
+			rc = ena_netmap_alloc_rx_slot(adapter, rx_ring, rx_info);
+		else
+#endif /* DEV_NETMAP */
+			rc = ena_alloc_rx_mbuf(adapter, rx_ring, rx_info);
 		if (unlikely(rc != 0)) {
 			ena_trace(ENA_WARNING,
 			    "failed to alloc buffer for rx queue %d\n",
@@ -1091,6 +1136,14 @@ ena_free_rx_bufs(struct ena_adapter *adapter, unsigned int qid)
 
 		if (rx_info->mbuf != NULL)
 			ena_free_rx_mbuf(adapter, rx_ring, rx_info);
+#ifdef DEV_NETMAP
+		if (((if_getflags(adapter->ifp) & IFF_DYING) == 0) &&
+		    (adapter->ifp->if_capenable & IFCAP_NETMAP)) {
+			if (rx_info->netmap_buf_idx != 0)
+				ena_netmap_free_rx_slot(adapter, rx_ring,
+				    rx_info);
+		}
+#endif /* DEV_NETMAP */
 	}
 }
 
@@ -1109,10 +1162,12 @@ ena_refill_all_rx_bufs(struct ena_adapter *adapter)
 		rx_ring = &adapter->rx_ring[i];
 		bufs_num = rx_ring->ring_size - 1;
 		rc = ena_refill_rx_bufs(rx_ring, bufs_num);
-
 		if (unlikely(rc != bufs_num))
 			ena_trace(ENA_WARNING, "refilling Queue %d failed. "
 			    "Allocated %d buffers from: %d\n", i, rc, bufs_num);
+#ifdef DEV_NETMAP
+		rx_ring->initialized = true;
+#endif /* DEV_NETMAP */
 	}
 }
 
@@ -1227,30 +1282,6 @@ ena_destroy_all_io_queues(struct ena_adapter *adapter)
 	ena_destroy_all_rx_queues(adapter);
 }
 
-static inline int
-validate_tx_req_id(struct ena_ring *tx_ring, uint16_t req_id)
-{
-	struct ena_adapter *adapter = tx_ring->adapter;
-	struct ena_tx_buffer *tx_info = NULL;
-
-	if (likely(req_id < tx_ring->ring_size)) {
-		tx_info = &tx_ring->tx_buffer_info[req_id];
-		if (tx_info->mbuf != NULL)
-			return (0);
-		device_printf(adapter->pdev,
-		    "tx_info doesn't have valid mbuf\n");
-	}
-
-	device_printf(adapter->pdev, "Invalid req_id: %hu\n", req_id);
-	counter_u64_add(tx_ring->tx_stats.bad_req_id, 1);
-
-	/* Trigger device reset */
-	adapter->reset_reason = ENA_REGS_RESET_INV_TX_REQ_ID;
-	ENA_FLAG_SET_ATOMIC(ENA_FLAG_TRIGGER_RESET, adapter);
-
-	return (EFAULT);
-}
-
 static int
 ena_create_io_queues(struct ena_adapter *adapter)
 {
@@ -1344,475 +1375,6 @@ err_tx:
 	return (ENXIO);
 }
 
-/**
- * ena_tx_cleanup - clear sent packets and corresponding descriptors
- * @tx_ring: ring for which we want to clean packets
- *
- * Once packets are sent, we ask the device in a loop for no longer used
- * descriptors. We find the related mbuf chain in a map (index in an array)
- * and free it, then update ring state.
- * This is performed in "endless" loop, updating ring pointers every
- * TX_COMMIT. The first check of free descriptor is performed before the actual
- * loop, then repeated at the loop end.
- **/
-static int
-ena_tx_cleanup(struct ena_ring *tx_ring)
-{
-	struct ena_adapter *adapter;
-	struct ena_com_io_cq* io_cq;
-	uint16_t next_to_clean;
-	uint16_t req_id;
-	uint16_t ena_qid;
-	unsigned int total_done = 0;
-	int rc;
-	int commit = TX_COMMIT;
-	int budget = TX_BUDGET;
-	int work_done;
-	bool above_thresh;
-
-	adapter = tx_ring->que->adapter;
-	ena_qid = ENA_IO_TXQ_IDX(tx_ring->que->id);
-	io_cq = &adapter->ena_dev->io_cq_queues[ena_qid];
-	next_to_clean = tx_ring->next_to_clean;
-
-	do {
-		struct ena_tx_buffer *tx_info;
-		struct mbuf *mbuf;
-
-		rc = ena_com_tx_comp_req_id_get(io_cq, &req_id);
-		if (unlikely(rc != 0))
-			break;
-
-		rc = validate_tx_req_id(tx_ring, req_id);
-		if (unlikely(rc != 0))
-			break;
-
-		tx_info = &tx_ring->tx_buffer_info[req_id];
-
-		mbuf = tx_info->mbuf;
-
-		tx_info->mbuf = NULL;
-		bintime_clear(&tx_info->timestamp);
-
-		/* Map is no longer required */
-		if (tx_info->head_mapped == true) {
-			bus_dmamap_sync(adapter->tx_buf_tag, tx_info->map_head,
-			    BUS_DMASYNC_POSTWRITE);
-			bus_dmamap_unload(adapter->tx_buf_tag,
-			    tx_info->map_head);
-			tx_info->head_mapped = false;
-		}
-		if (tx_info->seg_mapped == true) {
-			bus_dmamap_sync(adapter->tx_buf_tag, tx_info->map_seg,
-			    BUS_DMASYNC_POSTWRITE);
-			bus_dmamap_unload(adapter->tx_buf_tag,
-			    tx_info->map_seg);
-			tx_info->seg_mapped = false;
-		}
-
-		ena_trace(ENA_DBG | ENA_TXPTH, "tx: q %d mbuf %p completed\n",
-		    tx_ring->qid, mbuf);
-
-		m_freem(mbuf);
-
-		total_done += tx_info->tx_descs;
-
-		tx_ring->free_tx_ids[next_to_clean] = req_id;
-		next_to_clean = ENA_TX_RING_IDX_NEXT(next_to_clean,
-		    tx_ring->ring_size);
-
-		if (unlikely(--commit == 0)) {
-			commit = TX_COMMIT;
-			/* update ring state every TX_COMMIT descriptor */
-			tx_ring->next_to_clean = next_to_clean;
-			ena_com_comp_ack(
-			    &adapter->ena_dev->io_sq_queues[ena_qid],
-			    total_done);
-			ena_com_update_dev_comp_head(io_cq);
-			total_done = 0;
-		}
-	} while (likely(--budget));
-
-	work_done = TX_BUDGET - budget;
-
-	ena_trace(ENA_DBG | ENA_TXPTH, "tx: q %d done. total pkts: %d\n",
-	tx_ring->qid, work_done);
-
-	/* If there is still something to commit update ring state */
-	if (likely(commit != TX_COMMIT)) {
-		tx_ring->next_to_clean = next_to_clean;
-		ena_com_comp_ack(&adapter->ena_dev->io_sq_queues[ena_qid],
-		    total_done);
-		ena_com_update_dev_comp_head(io_cq);
-	}
-
-	/*
-	 * Need to make the rings circular update visible to
-	 * ena_xmit_mbuf() before checking for tx_ring->running.
-	 */
-	mb();
-
-	above_thresh = ena_com_sq_have_enough_space(tx_ring->ena_com_io_sq,
-	    ENA_TX_RESUME_THRESH);
-	if (unlikely(!tx_ring->running && above_thresh)) {
-		ENA_RING_MTX_LOCK(tx_ring);
-		above_thresh =
-		    ena_com_sq_have_enough_space(tx_ring->ena_com_io_sq,
-		    ENA_TX_RESUME_THRESH);
-		if (!tx_ring->running && above_thresh) {
-			tx_ring->running = true;
-			counter_u64_add(tx_ring->tx_stats.queue_wakeup, 1);
-			taskqueue_enqueue(tx_ring->enqueue_tq,
-			    &tx_ring->enqueue_task);
-		}
-		ENA_RING_MTX_UNLOCK(tx_ring);
-	}
-
-	return (work_done);
-}
-
-static void
-ena_rx_hash_mbuf(struct ena_ring *rx_ring, struct ena_com_rx_ctx *ena_rx_ctx,
-    struct mbuf *mbuf)
-{
-	struct ena_adapter *adapter = rx_ring->adapter;
-
-	if (likely(ENA_FLAG_ISSET(ENA_FLAG_RSS_ACTIVE, adapter))) {
-		mbuf->m_pkthdr.flowid = ena_rx_ctx->hash;
-
-		if (ena_rx_ctx->frag &&
-		    (ena_rx_ctx->l3_proto != ENA_ETH_IO_L3_PROTO_UNKNOWN)) {
-			M_HASHTYPE_SET(mbuf, M_HASHTYPE_OPAQUE_HASH);
-			return;
-		}
-
-		switch (ena_rx_ctx->l3_proto) {
-		case ENA_ETH_IO_L3_PROTO_IPV4:
-			switch (ena_rx_ctx->l4_proto) {
-			case ENA_ETH_IO_L4_PROTO_TCP:
-				M_HASHTYPE_SET(mbuf, M_HASHTYPE_RSS_TCP_IPV4);
-				break;
-			case ENA_ETH_IO_L4_PROTO_UDP:
-				M_HASHTYPE_SET(mbuf, M_HASHTYPE_RSS_UDP_IPV4);
-				break;
-			default:
-				M_HASHTYPE_SET(mbuf, M_HASHTYPE_RSS_IPV4);
-			}
-			break;
-		case ENA_ETH_IO_L3_PROTO_IPV6:
-			switch (ena_rx_ctx->l4_proto) {
-			case ENA_ETH_IO_L4_PROTO_TCP:
-				M_HASHTYPE_SET(mbuf, M_HASHTYPE_RSS_TCP_IPV6);
-				break;
-			case ENA_ETH_IO_L4_PROTO_UDP:
-				M_HASHTYPE_SET(mbuf, M_HASHTYPE_RSS_UDP_IPV6);
-				break;
-			default:
-				M_HASHTYPE_SET(mbuf, M_HASHTYPE_RSS_IPV6);
-			}
-			break;
-		case ENA_ETH_IO_L3_PROTO_UNKNOWN:
-			M_HASHTYPE_SET(mbuf, M_HASHTYPE_NONE);
-			break;
-		default:
-			M_HASHTYPE_SET(mbuf, M_HASHTYPE_OPAQUE_HASH);
-		}
-	} else {
-		mbuf->m_pkthdr.flowid = rx_ring->qid;
-		M_HASHTYPE_SET(mbuf, M_HASHTYPE_NONE);
-	}
-}
-
-/**
- * ena_rx_mbuf - assemble mbuf from descriptors
- * @rx_ring: ring for which we want to clean packets
- * @ena_bufs: buffer info
- * @ena_rx_ctx: metadata for this packet(s)
- * @next_to_clean: ring pointer, will be updated only upon success
- *
- **/
-static struct mbuf*
-ena_rx_mbuf(struct ena_ring *rx_ring, struct ena_com_rx_buf_info *ena_bufs,
-    struct ena_com_rx_ctx *ena_rx_ctx, uint16_t *next_to_clean)
-{
-	struct mbuf *mbuf;
-	struct ena_rx_buffer *rx_info;
-	struct ena_adapter *adapter;
-	unsigned int descs = ena_rx_ctx->descs;
-	int rc;
-	uint16_t ntc, len, req_id, buf = 0;
-
-	ntc = *next_to_clean;
-	adapter = rx_ring->adapter;
-
-	len = ena_bufs[buf].len;
-	req_id = ena_bufs[buf].req_id;
-	rc = validate_rx_req_id(rx_ring, req_id);
-	if (unlikely(rc != 0))
-		return (NULL);
-
-	rx_info = &rx_ring->rx_buffer_info[req_id];
-	if (unlikely(rx_info->mbuf == NULL)) {
-		device_printf(adapter->pdev, "NULL mbuf in rx_info");
-		return (NULL);
-	}
-
-	ena_trace(ENA_DBG | ENA_RXPTH, "rx_info %p, mbuf %p, paddr %jx\n",
-	    rx_info, rx_info->mbuf, (uintmax_t)rx_info->ena_buf.paddr);
-
-	bus_dmamap_sync(adapter->rx_buf_tag, rx_info->map,
-	    BUS_DMASYNC_POSTREAD);
-	mbuf = rx_info->mbuf;
-	mbuf->m_flags |= M_PKTHDR;
-	mbuf->m_pkthdr.len = len;
-	mbuf->m_len = len;
-	mbuf->m_pkthdr.rcvif = rx_ring->que->adapter->ifp;
-
-	/* Fill mbuf with hash key and it's interpretation for optimization */
-	ena_rx_hash_mbuf(rx_ring, ena_rx_ctx, mbuf);
-
-	ena_trace(ENA_DBG | ENA_RXPTH, "rx mbuf 0x%p, flags=0x%x, len: %d\n",
-	    mbuf, mbuf->m_flags, mbuf->m_pkthdr.len);
-
-	/* DMA address is not needed anymore, unmap it */
-	bus_dmamap_unload(rx_ring->adapter->rx_buf_tag, rx_info->map);
-
-	rx_info->mbuf = NULL;
-	rx_ring->free_rx_ids[ntc] = req_id;
-	ntc = ENA_RX_RING_IDX_NEXT(ntc, rx_ring->ring_size);
-
-	/*
-	 * While we have more than 1 descriptors for one rcvd packet, append
-	 * other mbufs to the main one
-	 */
-	while (--descs) {
-		++buf;
-		len = ena_bufs[buf].len;
-		req_id = ena_bufs[buf].req_id;
-		rc = validate_rx_req_id(rx_ring, req_id);
-		if (unlikely(rc != 0)) {
-			/*
-			 * If the req_id is invalid, then the device will be
-			 * reset. In that case we must free all mbufs that
-			 * were already gathered.
-			 */
-			m_freem(mbuf);
-			return (NULL);
-		}
-		rx_info = &rx_ring->rx_buffer_info[req_id];
-
-		if (unlikely(rx_info->mbuf == NULL)) {
-			device_printf(adapter->pdev, "NULL mbuf in rx_info");
-			/*
-			 * If one of the required mbufs was not allocated yet,
-			 * we can break there.
-			 * All earlier used descriptors will be reallocated
-			 * later and not used mbufs can be reused.
-			 * The next_to_clean pointer will not be updated in case
-			 * of an error, so caller should advance it manually
-			 * in error handling routine to keep it up to date
-			 * with hw ring.
-			 */
-			m_freem(mbuf);
-			return (NULL);
-		}
-
-		bus_dmamap_sync(adapter->rx_buf_tag, rx_info->map,
-		    BUS_DMASYNC_POSTREAD);
-		if (unlikely(m_append(mbuf, len, rx_info->mbuf->m_data) == 0)) {
-			counter_u64_add(rx_ring->rx_stats.mbuf_alloc_fail, 1);
-			ena_trace(ENA_WARNING, "Failed to append Rx mbuf %p\n",
-			    mbuf);
-		}
-
-		ena_trace(ENA_DBG | ENA_RXPTH,
-		    "rx mbuf updated. len %d\n", mbuf->m_pkthdr.len);
-
-		/* Free already appended mbuf, it won't be useful anymore */
-		bus_dmamap_unload(rx_ring->adapter->rx_buf_tag, rx_info->map);
-		m_freem(rx_info->mbuf);
-		rx_info->mbuf = NULL;
-
-		rx_ring->free_rx_ids[ntc] = req_id;
-		ntc = ENA_RX_RING_IDX_NEXT(ntc, rx_ring->ring_size);
-	}
-
-	*next_to_clean = ntc;
-
-	return (mbuf);
-}
-
-/**
- * ena_rx_checksum - indicate in mbuf if hw indicated a good cksum
- **/
-static inline void
-ena_rx_checksum(struct ena_ring *rx_ring, struct ena_com_rx_ctx *ena_rx_ctx,
-    struct mbuf *mbuf)
-{
-
-	/* if IP and error */
-	if (unlikely((ena_rx_ctx->l3_proto == ENA_ETH_IO_L3_PROTO_IPV4) &&
-	    ena_rx_ctx->l3_csum_err)) {
-		/* ipv4 checksum error */
-		mbuf->m_pkthdr.csum_flags = 0;
-		counter_u64_add(rx_ring->rx_stats.bad_csum, 1);
-		ena_trace(ENA_DBG, "RX IPv4 header checksum error\n");
-		return;
-	}
-
-	/* if TCP/UDP */
-	if ((ena_rx_ctx->l4_proto == ENA_ETH_IO_L4_PROTO_TCP) ||
-	    (ena_rx_ctx->l4_proto == ENA_ETH_IO_L4_PROTO_UDP)) {
-		if (ena_rx_ctx->l4_csum_err) {
-			/* TCP/UDP checksum error */
-			mbuf->m_pkthdr.csum_flags = 0;
-			counter_u64_add(rx_ring->rx_stats.bad_csum, 1);
-			ena_trace(ENA_DBG, "RX L4 checksum error\n");
-		} else {
-			mbuf->m_pkthdr.csum_flags = CSUM_IP_CHECKED;
-			mbuf->m_pkthdr.csum_flags |= CSUM_IP_VALID;
-		}
-	}
-}
-
-/**
- * ena_rx_cleanup - handle rx irq
- * @arg: ring for which irq is being handled
- **/
-static int
-ena_rx_cleanup(struct ena_ring *rx_ring)
-{
-	struct ena_adapter *adapter;
-	struct mbuf *mbuf;
-	struct ena_com_rx_ctx ena_rx_ctx;
-	struct ena_com_io_cq* io_cq;
-	struct ena_com_io_sq* io_sq;
-	if_t ifp;
-	uint16_t ena_qid;
-	uint16_t next_to_clean;
-	uint32_t refill_required;
-	uint32_t refill_threshold;
-	uint32_t do_if_input = 0;
-	unsigned int qid;
-	int rc, i;
-	int budget = RX_BUDGET;
-
-	adapter = rx_ring->que->adapter;
-	ifp = adapter->ifp;
-	qid = rx_ring->que->id;
-	ena_qid = ENA_IO_RXQ_IDX(qid);
-	io_cq = &adapter->ena_dev->io_cq_queues[ena_qid];
-	io_sq = &adapter->ena_dev->io_sq_queues[ena_qid];
-	next_to_clean = rx_ring->next_to_clean;
-
-	ena_trace(ENA_DBG, "rx: qid %d\n", qid);
-
-	do {
-		ena_rx_ctx.ena_bufs = rx_ring->ena_bufs;
-		ena_rx_ctx.max_bufs = adapter->max_rx_sgl_size;
-		ena_rx_ctx.descs = 0;
-		bus_dmamap_sync(io_cq->cdesc_addr.mem_handle.tag,
-		    io_cq->cdesc_addr.mem_handle.map, BUS_DMASYNC_POSTREAD);
-		rc = ena_com_rx_pkt(io_cq, io_sq, &ena_rx_ctx);
-
-		if (unlikely(rc != 0))
-			goto error;
-
-		if (unlikely(ena_rx_ctx.descs == 0))
-			break;
-
-		ena_trace(ENA_DBG | ENA_RXPTH, "rx: q %d got packet from ena. "
-		    "descs #: %d l3 proto %d l4 proto %d hash: %x\n",
-		    rx_ring->qid, ena_rx_ctx.descs, ena_rx_ctx.l3_proto,
-		    ena_rx_ctx.l4_proto, ena_rx_ctx.hash);
-
-		/* Receive mbuf from the ring */
-		mbuf = ena_rx_mbuf(rx_ring, rx_ring->ena_bufs,
-		    &ena_rx_ctx, &next_to_clean);
-		bus_dmamap_sync(io_cq->cdesc_addr.mem_handle.tag,
-		    io_cq->cdesc_addr.mem_handle.map, BUS_DMASYNC_PREREAD);
-		/* Exit if we failed to retrieve a buffer */
-		if (unlikely(mbuf == NULL)) {
-			for (i = 0; i < ena_rx_ctx.descs; ++i) {
-				rx_ring->free_rx_ids[next_to_clean] =
-				    rx_ring->ena_bufs[i].req_id;
-				next_to_clean =
-				    ENA_RX_RING_IDX_NEXT(next_to_clean,
-				    rx_ring->ring_size);
-
-			}
-			break;
-		}
-
-		if (((ifp->if_capenable & IFCAP_RXCSUM) != 0) ||
-		    ((ifp->if_capenable & IFCAP_RXCSUM_IPV6) != 0)) {
-			ena_rx_checksum(rx_ring, &ena_rx_ctx, mbuf);
-		}
-
-		counter_enter();
-		counter_u64_add_protected(rx_ring->rx_stats.bytes,
-		    mbuf->m_pkthdr.len);
-		counter_u64_add_protected(adapter->hw_stats.rx_bytes,
-		    mbuf->m_pkthdr.len);
-		counter_exit();
-		/*
-		 * LRO is only for IP/TCP packets and TCP checksum of the packet
-		 * should be computed by hardware.
-		 */
-		do_if_input = 1;
-		if (((ifp->if_capenable & IFCAP_LRO) != 0)  &&
-		    ((mbuf->m_pkthdr.csum_flags & CSUM_IP_VALID) != 0) &&
-		    (ena_rx_ctx.l4_proto == ENA_ETH_IO_L4_PROTO_TCP)) {
-			/*
-			 * Send to the stack if:
-			 *  - LRO not enabled, or
-			 *  - no LRO resources, or
-			 *  - lro enqueue fails
-			 */
-			if ((rx_ring->lro.lro_cnt != 0) &&
-			    (tcp_lro_rx(&rx_ring->lro, mbuf, 0) == 0))
-					do_if_input = 0;
-		}
-		if (do_if_input != 0) {
-			ena_trace(ENA_DBG | ENA_RXPTH,
-			    "calling if_input() with mbuf %p\n", mbuf);
-			(*ifp->if_input)(ifp, mbuf);
-		}
-
-		counter_enter();
-		counter_u64_add_protected(rx_ring->rx_stats.cnt, 1);
-		counter_u64_add_protected(adapter->hw_stats.rx_packets, 1);
-		counter_exit();
-	} while (--budget);
-
-	rx_ring->next_to_clean = next_to_clean;
-
-	refill_required = ena_com_free_desc(io_sq);
-	refill_threshold = min_t(int,
-	    rx_ring->ring_size / ENA_RX_REFILL_THRESH_DIVIDER,
-	    ENA_RX_REFILL_THRESH_PACKET);
-
-	if (refill_required > refill_threshold) {
-		ena_com_update_dev_comp_head(rx_ring->ena_com_io_cq);
-		ena_refill_rx_bufs(rx_ring, refill_required);
-	}
-
-	tcp_lro_flush_all(&rx_ring->lro);
-
-	return (RX_BUDGET - budget);
-
-error:
-	counter_u64_add(rx_ring->rx_stats.bad_desc_num, 1);
-
-	/* Too many desc from the device. Trigger reset */
-	if (likely(!ENA_FLAG_ISSET(ENA_FLAG_TRIGGER_RESET, adapter))) {
-		adapter->reset_reason = ENA_REGS_RESET_TOO_MANY_RX_DESCS;
-		ENA_FLAG_SET_ATOMIC(ENA_FLAG_TRIGGER_RESET, adapter);
-	}
-
-	return (0);
-}
-
 /*********************************************************************
  *
  *  MSIX & Interrupt Service routine
@@ -1831,52 +1393,6 @@ ena_intr_msix_mgmnt(void *arg)
 	ena_com_admin_q_comp_intr_handler(adapter->ena_dev);
 	if (likely(ENA_FLAG_ISSET(ENA_FLAG_DEVICE_RUNNING, adapter)))
 		ena_com_aenq_intr_handler(adapter->ena_dev, arg);
-}
-
-static void
-ena_cleanup(void *arg, int pending)
-{
-	struct ena_que	*que = arg;
-	struct ena_adapter *adapter = que->adapter;
-	if_t ifp = adapter->ifp;
-	struct ena_ring *tx_ring;
-	struct ena_ring *rx_ring;
-	struct ena_com_io_cq* io_cq;
-	struct ena_eth_io_intr_reg intr_reg;
-	int qid, ena_qid;
-	int txc, rxc, i;
-
-	if (unlikely((if_getdrvflags(ifp) & IFF_DRV_RUNNING) == 0))
-		return;
-
-	ena_trace(ENA_DBG, "MSI-X TX/RX routine\n");
-
-	tx_ring = que->tx_ring;
-	rx_ring = que->rx_ring;
-	qid = que->id;
-	ena_qid = ENA_IO_TXQ_IDX(qid);
-	io_cq = &adapter->ena_dev->io_cq_queues[ena_qid];
-
-	tx_ring->first_interrupt = true;
-	rx_ring->first_interrupt = true;
-
-	for (i = 0; i < CLEAN_BUDGET; ++i) {
-		rxc = ena_rx_cleanup(rx_ring);
-		txc = ena_tx_cleanup(tx_ring);
-
-		if (unlikely((if_getdrvflags(ifp) & IFF_DRV_RUNNING) == 0))
-			return;
-
-		if ((txc != TX_BUDGET) && (rxc != RX_BUDGET))
-		       break;
-	}
-
-	/* Signal that work is done and unmask interrupt */
-	ena_com_update_intr_reg(&intr_reg,
-	    RX_IRQ_INTERVAL,
-	    TX_IRQ_INTERVAL,
-	    true);
-	ena_com_unmask_intr(io_cq, &intr_reg);
 }
 
 /**
@@ -2289,7 +1805,7 @@ ena_up_complete(struct ena_adapter *adapter)
 	return (0);
 }
 
-static int
+int
 ena_up(struct ena_adapter *adapter)
 {
 	int rc = 0;
@@ -2350,8 +1866,14 @@ ena_up(struct ena_adapter *adapter)
 		if_setdrvflagbits(adapter->ifp, IFF_DRV_RUNNING,
 		    IFF_DRV_OACTIVE);
 
-		callout_reset_sbt(&adapter->timer_service, SBT_1S, SBT_1S,
-		    ena_timer_service, (void *)adapter, 0);
+		/* Activate timer service only if the device is running.
+		 * If this flag is not set, it means that the driver is being
+		 * reset and timer service will be activated afterwards.
+		 */
+		if (ENA_FLAG_ISSET(ENA_FLAG_DEVICE_RUNNING, adapter)) {
+			callout_reset_sbt(&adapter->timer_service, SBT_1S,
+			    SBT_1S, ena_timer_service, (void *)adapter, 0);
+		}
 
 		ENA_FLAG_SET_ATOMIC(ENA_FLAG_DEV_UP, adapter);
 
@@ -2660,7 +2182,7 @@ ena_setup_ifnet(device_t pdev, struct ena_adapter *adapter,
 	return (0);
 }
 
-static void
+void
 ena_down(struct ena_adapter *adapter)
 {
 	int rc;
@@ -2693,578 +2215,6 @@ ena_down(struct ena_adapter *adapter)
 
 		counter_u64_add(adapter->dev_stats.interface_down, 1);
 	}
-}
-
-static void
-ena_tx_csum(struct ena_com_tx_ctx *ena_tx_ctx, struct mbuf *mbuf)
-{
-	struct ena_com_tx_meta *ena_meta;
-	struct ether_vlan_header *eh;
-	struct mbuf *mbuf_next;
-	u32 mss;
-	bool offload;
-	uint16_t etype;
-	int ehdrlen;
-	struct ip *ip;
-	int iphlen;
-	struct tcphdr *th;
-	int offset;
-
-	offload = false;
-	ena_meta = &ena_tx_ctx->ena_meta;
-	mss = mbuf->m_pkthdr.tso_segsz;
-
-	if (mss != 0)
-		offload = true;
-
-	if ((mbuf->m_pkthdr.csum_flags & CSUM_TSO) != 0)
-		offload = true;
-
-	if ((mbuf->m_pkthdr.csum_flags & CSUM_OFFLOAD) != 0)
-		offload = true;
-
-	if (!offload) {
-		ena_tx_ctx->meta_valid = 0;
-		return;
-	}
-
-	/* Determine where frame payload starts. */
-	eh = mtod(mbuf, struct ether_vlan_header *);
-	if (eh->evl_encap_proto == htons(ETHERTYPE_VLAN)) {
-		etype = ntohs(eh->evl_proto);
-		ehdrlen = ETHER_HDR_LEN + ETHER_VLAN_ENCAP_LEN;
-	} else {
-		etype = ntohs(eh->evl_encap_proto);
-		ehdrlen = ETHER_HDR_LEN;
-	}
-
-	mbuf_next = m_getptr(mbuf, ehdrlen, &offset);
-	ip = (struct ip *)(mtodo(mbuf_next, offset));
-	iphlen = ip->ip_hl << 2;
-
-	mbuf_next = m_getptr(mbuf, iphlen + ehdrlen, &offset);
-	th = (struct tcphdr *)(mtodo(mbuf_next, offset));
-
-	if ((mbuf->m_pkthdr.csum_flags & CSUM_IP) != 0) {
-		ena_tx_ctx->l3_csum_enable = 1;
-	}
-	if ((mbuf->m_pkthdr.csum_flags & CSUM_TSO) != 0) {
-		ena_tx_ctx->tso_enable = 1;
-		ena_meta->l4_hdr_len = (th->th_off);
-	}
-
-	switch (etype) {
-	case ETHERTYPE_IP:
-		ena_tx_ctx->l3_proto = ENA_ETH_IO_L3_PROTO_IPV4;
-		if ((ip->ip_off & htons(IP_DF)) != 0)
-			ena_tx_ctx->df = 1;
-		break;
-	case ETHERTYPE_IPV6:
-		ena_tx_ctx->l3_proto = ENA_ETH_IO_L3_PROTO_IPV6;
-
-	default:
-		break;
-	}
-
-	if (ip->ip_p == IPPROTO_TCP) {
-		ena_tx_ctx->l4_proto = ENA_ETH_IO_L4_PROTO_TCP;
-		if ((mbuf->m_pkthdr.csum_flags &
-		    (CSUM_IP_TCP | CSUM_IP6_TCP)) != 0)
-			ena_tx_ctx->l4_csum_enable = 1;
-		else
-			ena_tx_ctx->l4_csum_enable = 0;
-	} else if (ip->ip_p == IPPROTO_UDP) {
-		ena_tx_ctx->l4_proto = ENA_ETH_IO_L4_PROTO_UDP;
-		if ((mbuf->m_pkthdr.csum_flags &
-		    (CSUM_IP_UDP | CSUM_IP6_UDP)) != 0)
-			ena_tx_ctx->l4_csum_enable = 1;
-		else
-			ena_tx_ctx->l4_csum_enable = 0;
-	} else {
-		ena_tx_ctx->l4_proto = ENA_ETH_IO_L4_PROTO_UNKNOWN;
-		ena_tx_ctx->l4_csum_enable = 0;
-	}
-
-	ena_meta->mss = mss;
-	ena_meta->l3_hdr_len = iphlen;
-	ena_meta->l3_hdr_offset = ehdrlen;
-	ena_tx_ctx->meta_valid = 1;
-}
-
-static int
-ena_check_and_collapse_mbuf(struct ena_ring *tx_ring, struct mbuf **mbuf)
-{
-	struct ena_adapter *adapter;
-	struct mbuf *collapsed_mbuf;
-	int num_frags;
-
-	adapter = tx_ring->adapter;
-	num_frags = ena_mbuf_count(*mbuf);
-
-	/* One segment must be reserved for configuration descriptor. */
-	if (num_frags < adapter->max_tx_sgl_size)
-		return (0);
-	counter_u64_add(tx_ring->tx_stats.collapse, 1);
-
-	collapsed_mbuf = m_collapse(*mbuf, M_NOWAIT,
-	    adapter->max_tx_sgl_size - 1);
-	if (unlikely(collapsed_mbuf == NULL)) {
-		counter_u64_add(tx_ring->tx_stats.collapse_err, 1);
-		return (ENOMEM);
-	}
-
-	/* If mbuf was collapsed succesfully, original mbuf is released. */
-	*mbuf = collapsed_mbuf;
-
-	return (0);
-}
-
-static void
-ena_dmamap_llq(void *arg, bus_dma_segment_t *segs, int nseg, int error)
-{
-	struct ena_com_buf *ena_buf = arg;
-
-	if (unlikely(error != 0)) {
-		ena_buf->paddr = 0;
-		return;
-	}
-
-	KASSERT(nseg == 1, ("Invalid num of segments for LLQ dma"));
-
-	ena_buf->paddr = segs->ds_addr;
-	ena_buf->len = segs->ds_len;
-}
-
-static int
-ena_tx_map_mbuf(struct ena_ring *tx_ring, struct ena_tx_buffer *tx_info,
-    struct mbuf *mbuf, void **push_hdr, u16 *header_len)
-{
-	struct ena_adapter *adapter = tx_ring->adapter;
-	struct ena_com_buf *ena_buf;
-	bus_dma_segment_t segs[ENA_BUS_DMA_SEGS];
-	uint32_t mbuf_head_len, frag_len;
-	uint16_t push_len = 0;
-	uint16_t delta = 0;
-	int i, rc, nsegs;
-
-	mbuf_head_len = mbuf->m_len;
-	tx_info->mbuf = mbuf;
-	ena_buf = tx_info->bufs;
-
-	if (tx_ring->tx_mem_queue_type == ENA_ADMIN_PLACEMENT_POLICY_DEV) {
-		/*
-		 * When the device is LLQ mode, the driver will copy
-		 * the header into the device memory space.
-		 * the ena_com layer assumes the header is in a linear
-		 * memory space.
-		 * This assumption might be wrong since part of the header
-		 * can be in the fragmented buffers.
-		 * First check if header fits in the mbuf. If not, copy it to
-		 * separate buffer that will be holding linearized data.
-		 */
-		push_len = min_t(uint32_t, mbuf->m_pkthdr.len,
-		    tx_ring->tx_max_header_size);
-		*header_len = push_len;
-		/* If header is in linear space, just point into mbuf's data. */
-		if (likely(push_len <= mbuf_head_len)) {
-			*push_hdr = mbuf->m_data;
-		/*
-		 * Otherwise, copy whole portion of header from multiple mbufs
-		 * to intermediate buffer.
-		 */
-		} else {
-			m_copydata(mbuf, 0, push_len,
-			    tx_ring->push_buf_intermediate_buf);
-			*push_hdr = tx_ring->push_buf_intermediate_buf;
-
-			counter_u64_add(tx_ring->tx_stats.llq_buffer_copy, 1);
-			delta = push_len - mbuf_head_len;
-		}
-
-		ena_trace(ENA_DBG | ENA_TXPTH,
-		    "mbuf: %p header_buf->vaddr: %p push_len: %d\n",
-		    mbuf, *push_hdr, push_len);
-
-		/*
-		* If header was in linear memory space, map for the dma rest of the data
-		* in the first mbuf of the mbuf chain.
-		*/
-		if (mbuf_head_len > push_len) {
-			rc = bus_dmamap_load(adapter->tx_buf_tag,
-			    tx_info->map_head,
-			mbuf->m_data + push_len, mbuf_head_len - push_len,
-			ena_dmamap_llq, ena_buf, BUS_DMA_NOWAIT);
-			if (unlikely((rc != 0) || (ena_buf->paddr == 0)))
-				goto single_dma_error;
-
-			ena_buf++;
-			tx_info->num_of_bufs++;
-
-			tx_info->head_mapped = true;
-		}
-		mbuf = mbuf->m_next;
-	} else {
-		*push_hdr = NULL;
-		/*
-		* header_len is just a hint for the device. Because FreeBSD is not
-		* giving us information about packet header length and it is not
-		* guaranteed that all packet headers will be in the 1st mbuf, setting
-		* header_len to 0 is making the device ignore this value and resolve
-		* header on it's own.
-		*/
-		*header_len = 0;
-	}
-
-	/*
-	 * If header is in non linear space (delta > 0), then skip mbufs
-	 * containing header and map the last one containing both header and the
-	 * packet data.
-	 * The first segment is already counted in.
-	 * If LLQ is not supported, the loop will be skipped.
-	 */
-	while (delta > 0) {
-		frag_len = mbuf->m_len;
-
-		/*
-		 * If whole segment contains header just move to the
-		 * next one and reduce delta.
-		 */
-		if (unlikely(delta >= frag_len)) {
-			delta -= frag_len;
-		} else {
-			/*
-			 * Map rest of the packet data that was contained in
-			 * the mbuf.
-			 */
-			rc = bus_dmamap_load(adapter->tx_buf_tag,
-			    tx_info->map_head, mbuf->m_data + delta,
-			    frag_len - delta, ena_dmamap_llq, ena_buf,
-			    BUS_DMA_NOWAIT);
-			if (unlikely((rc != 0) || (ena_buf->paddr == 0)))
-				goto single_dma_error;
-
-			ena_buf++;
-			tx_info->num_of_bufs++;
-			tx_info->head_mapped = true;
-
-			delta = 0;
-		}
-
-		mbuf = mbuf->m_next;
-	}
-
-	if (mbuf == NULL) {
-		return (0);
-	}
-
-	/* Map rest of the mbufs */
-	rc = bus_dmamap_load_mbuf_sg(adapter->tx_buf_tag, tx_info->map_seg, mbuf,
-	    segs, &nsegs, BUS_DMA_NOWAIT);
-	if (unlikely((rc != 0) || (nsegs == 0))) {
-		ena_trace(ENA_WARNING,
-		    "dmamap load failed! err: %d nsegs: %d\n", rc, nsegs);
-		goto dma_error;
-	}
-
-	for (i = 0; i < nsegs; i++) {
-		ena_buf->len = segs[i].ds_len;
-		ena_buf->paddr = segs[i].ds_addr;
-		ena_buf++;
-	}
-	tx_info->num_of_bufs += nsegs;
-	tx_info->seg_mapped = true;
-
-	return (0);
-
-dma_error:
-	if (tx_info->head_mapped == true)
-		bus_dmamap_unload(adapter->tx_buf_tag, tx_info->map_head);
-single_dma_error:
-	counter_u64_add(tx_ring->tx_stats.dma_mapping_err, 1);
-	tx_info->mbuf = NULL;
-	return (rc);
-}
-
-static int
-ena_xmit_mbuf(struct ena_ring *tx_ring, struct mbuf **mbuf)
-{
-	struct ena_adapter *adapter;
-	struct ena_tx_buffer *tx_info;
-	struct ena_com_tx_ctx ena_tx_ctx;
-	struct ena_com_dev *ena_dev;
-	struct ena_com_io_sq* io_sq;
-	void *push_hdr;
-	uint16_t next_to_use;
-	uint16_t req_id;
-	uint16_t ena_qid;
-	uint16_t header_len;
-	int rc;
-	int nb_hw_desc;
-
-	ena_qid = ENA_IO_TXQ_IDX(tx_ring->que->id);
-	adapter = tx_ring->que->adapter;
-	ena_dev = adapter->ena_dev;
-	io_sq = &ena_dev->io_sq_queues[ena_qid];
-
-	rc = ena_check_and_collapse_mbuf(tx_ring, mbuf);
-	if (unlikely(rc != 0)) {
-		ena_trace(ENA_WARNING,
-		    "Failed to collapse mbuf! err: %d\n", rc);
-		return (rc);
-	}
-
-	ena_trace(ENA_DBG | ENA_TXPTH, "Tx: %d bytes\n", (*mbuf)->m_pkthdr.len);
-
-	next_to_use = tx_ring->next_to_use;
-	req_id = tx_ring->free_tx_ids[next_to_use];
-	tx_info = &tx_ring->tx_buffer_info[req_id];
-	tx_info->num_of_bufs = 0;
-
-	rc = ena_tx_map_mbuf(tx_ring, tx_info, *mbuf, &push_hdr, &header_len);
-	if (unlikely(rc != 0)) {
-		ena_trace(ENA_WARNING, "Failed to map TX mbuf\n");
-		return (rc);
-	}
-	memset(&ena_tx_ctx, 0x0, sizeof(struct ena_com_tx_ctx));
-	ena_tx_ctx.ena_bufs = tx_info->bufs;
-	ena_tx_ctx.push_header = push_hdr;
-	ena_tx_ctx.num_bufs = tx_info->num_of_bufs;
-	ena_tx_ctx.req_id = req_id;
-	ena_tx_ctx.header_len = header_len;
-
-	/* Set flags and meta data */
-	ena_tx_csum(&ena_tx_ctx, *mbuf);
-
-	if (tx_ring->acum_pkts == DB_THRESHOLD ||
-	    ena_com_is_doorbell_needed(tx_ring->ena_com_io_sq, &ena_tx_ctx)) {
-		ena_trace(ENA_DBG | ENA_TXPTH,
-		    "llq tx max burst size of queue %d achieved, writing doorbell to send burst\n",
-		    tx_ring->que->id);
-		wmb();
-		ena_com_write_sq_doorbell(tx_ring->ena_com_io_sq);
-		counter_u64_add(tx_ring->tx_stats.doorbells, 1);
-		tx_ring->acum_pkts = 0;
-	}
-
-	/* Prepare the packet's descriptors and send them to device */
-	rc = ena_com_prepare_tx(io_sq, &ena_tx_ctx, &nb_hw_desc);
-	if (unlikely(rc != 0)) {
-		if (likely(rc == ENA_COM_NO_MEM)) {
-			ena_trace(ENA_DBG | ENA_TXPTH,
-			    "tx ring[%d] if out of space\n", tx_ring->que->id);
-		} else {
-			device_printf(adapter->pdev,
-			    "failed to prepare tx bufs\n");
-		}
-		counter_u64_add(tx_ring->tx_stats.prepare_ctx_err, 1);
-		goto dma_error;
-	}
-
-	counter_enter();
-	counter_u64_add_protected(tx_ring->tx_stats.cnt, 1);
-	counter_u64_add_protected(tx_ring->tx_stats.bytes,
-	    (*mbuf)->m_pkthdr.len);
-
-	counter_u64_add_protected(adapter->hw_stats.tx_packets, 1);
-	counter_u64_add_protected(adapter->hw_stats.tx_bytes,
-	    (*mbuf)->m_pkthdr.len);
-	counter_exit();
-
-	tx_info->tx_descs = nb_hw_desc;
-	getbinuptime(&tx_info->timestamp);
-	tx_info->print_once = true;
-
-	tx_ring->next_to_use = ENA_TX_RING_IDX_NEXT(next_to_use,
-	    tx_ring->ring_size);
-
-	/* stop the queue when no more space available, the packet can have up
-	 * to sgl_size + 2. one for the meta descriptor and one for header
-	 * (if the header is larger than tx_max_header_size).
-	 */
-	if (unlikely(!ena_com_sq_have_enough_space(tx_ring->ena_com_io_sq,
-	    adapter->max_tx_sgl_size + 2))) {
-		ena_trace(ENA_DBG | ENA_TXPTH, "Stop queue %d\n",
-		    tx_ring->que->id);
-
-		tx_ring->running = false;
-		counter_u64_add(tx_ring->tx_stats.queue_stop, 1);
-
-		/* There is a rare condition where this function decides to
-		 * stop the queue but meanwhile tx_cleanup() updates
-		 * next_to_completion and terminates.
-		 * The queue will remain stopped forever.
-		 * To solve this issue this function performs mb(), checks
-		 * the wakeup condition and wakes up the queue if needed.
-		 */
-		mb();
-
-		if (ena_com_sq_have_enough_space(tx_ring->ena_com_io_sq,
-		    ENA_TX_RESUME_THRESH)) {
-			tx_ring->running = true;
-			counter_u64_add(tx_ring->tx_stats.queue_wakeup, 1);
-		}
-	}
-
-	if (tx_info->head_mapped == true)
-		bus_dmamap_sync(adapter->tx_buf_tag, tx_info->map_head,
-		    BUS_DMASYNC_PREWRITE);
-	if (tx_info->seg_mapped == true)
-		bus_dmamap_sync(adapter->tx_buf_tag, tx_info->map_seg,
-		    BUS_DMASYNC_PREWRITE);
-
-	return (0);
-
-dma_error:
-	tx_info->mbuf = NULL;
-	if (tx_info->seg_mapped == true) {
-		bus_dmamap_unload(adapter->tx_buf_tag, tx_info->map_seg);
-		tx_info->seg_mapped = false;
-	}
-	if (tx_info->head_mapped == true) {
-		bus_dmamap_unload(adapter->tx_buf_tag, tx_info->map_head);
-		tx_info->head_mapped = false;
-	}
-
-	return (rc);
-}
-
-static void
-ena_start_xmit(struct ena_ring *tx_ring)
-{
-	struct mbuf *mbuf;
-	struct ena_adapter *adapter = tx_ring->adapter;
-	struct ena_com_io_sq* io_sq;
-	int ena_qid;
-	int ret = 0;
-
-	if (unlikely((if_getdrvflags(adapter->ifp) & IFF_DRV_RUNNING) == 0))
-		return;
-
-	if (unlikely(!ENA_FLAG_ISSET(ENA_FLAG_LINK_UP, adapter)))
-		return;
-
-	ena_qid = ENA_IO_TXQ_IDX(tx_ring->que->id);
-	io_sq = &adapter->ena_dev->io_sq_queues[ena_qid];
-
-	while ((mbuf = drbr_peek(adapter->ifp, tx_ring->br)) != NULL) {
-		ena_trace(ENA_DBG | ENA_TXPTH, "\ndequeued mbuf %p with flags %#x and"
-		    " header csum flags %#jx\n",
-		    mbuf, mbuf->m_flags, (uint64_t)mbuf->m_pkthdr.csum_flags);
-
-		if (unlikely(!tx_ring->running)) {
-			drbr_putback(adapter->ifp, tx_ring->br, mbuf);
-			break;
-		}
-
-		if (unlikely((ret = ena_xmit_mbuf(tx_ring, &mbuf)) != 0)) {
-			if (ret == ENA_COM_NO_MEM) {
-				drbr_putback(adapter->ifp, tx_ring->br, mbuf);
-			} else if (ret == ENA_COM_NO_SPACE) {
-				drbr_putback(adapter->ifp, tx_ring->br, mbuf);
-			} else {
-				m_freem(mbuf);
-				drbr_advance(adapter->ifp, tx_ring->br);
-			}
-
-			break;
-		}
-
-		drbr_advance(adapter->ifp, tx_ring->br);
-
-		if (unlikely((if_getdrvflags(adapter->ifp) &
-		    IFF_DRV_RUNNING) == 0))
-			return;
-
-		tx_ring->acum_pkts++;
-
-		BPF_MTAP(adapter->ifp, mbuf);
-	}
-
-	if (likely(tx_ring->acum_pkts != 0)) {
-		wmb();
-		/* Trigger the dma engine */
-		ena_com_write_sq_doorbell(io_sq);
-		counter_u64_add(tx_ring->tx_stats.doorbells, 1);
-		tx_ring->acum_pkts = 0;
-	}
-
-	if (unlikely(!tx_ring->running))
-		taskqueue_enqueue(tx_ring->que->cleanup_tq,
-		    &tx_ring->que->cleanup_task);
-}
-
-static void
-ena_deferred_mq_start(void *arg, int pending)
-{
-	struct ena_ring *tx_ring = (struct ena_ring *)arg;
-	struct ifnet *ifp = tx_ring->adapter->ifp;
-
-	while (!drbr_empty(ifp, tx_ring->br) &&
-	    tx_ring->running &&
-	    (if_getdrvflags(ifp) & IFF_DRV_RUNNING) != 0) {
-		ENA_RING_MTX_LOCK(tx_ring);
-		ena_start_xmit(tx_ring);
-		ENA_RING_MTX_UNLOCK(tx_ring);
-	}
-}
-
-static int
-ena_mq_start(if_t ifp, struct mbuf *m)
-{
-	struct ena_adapter *adapter = ifp->if_softc;
-	struct ena_ring *tx_ring;
-	int ret, is_drbr_empty;
-	uint32_t i;
-
-	if (unlikely((if_getdrvflags(adapter->ifp) & IFF_DRV_RUNNING) == 0))
-		return (ENODEV);
-
-	/* Which queue to use */
-	/*
-	 * If everything is setup correctly, it should be the
-	 * same bucket that the current CPU we're on is.
-	 * It should improve performance.
-	 */
-	if (M_HASHTYPE_GET(m) != M_HASHTYPE_NONE) {
-		i = m->m_pkthdr.flowid % adapter->num_queues;
-	} else {
-		i = curcpu % adapter->num_queues;
-	}
-	tx_ring = &adapter->tx_ring[i];
-
-	/* Check if drbr is empty before putting packet */
-	is_drbr_empty = drbr_empty(ifp, tx_ring->br);
-	ret = drbr_enqueue(ifp, tx_ring->br, m);
-	if (unlikely(ret != 0)) {
-		taskqueue_enqueue(tx_ring->enqueue_tq, &tx_ring->enqueue_task);
-		return (ret);
-	}
-
-	if (is_drbr_empty && (ENA_RING_MTX_TRYLOCK(tx_ring) != 0)) {
-		ena_start_xmit(tx_ring);
-		ENA_RING_MTX_UNLOCK(tx_ring);
-	} else {
-		taskqueue_enqueue(tx_ring->enqueue_tq, &tx_ring->enqueue_task);
-	}
-
-	return (0);
-}
-
-static void
-ena_qflush(if_t ifp)
-{
-	struct ena_adapter *adapter = ifp->if_softc;
-	struct ena_ring *tx_ring = adapter->tx_ring;
-	int i;
-
-	for(i = 0; i < adapter->num_queues; ++i, ++tx_ring)
-		if (!drbr_empty(ifp, tx_ring->br)) {
-			ENA_RING_MTX_LOCK(tx_ring);
-			drbr_flush(ifp, tx_ring->br);
-			ENA_RING_MTX_UNLOCK(tx_ring);
-		}
-
-	if_qflush(ifp);
 }
 
 static int
@@ -3309,7 +2259,7 @@ ena_calc_io_queue_num(struct ena_adapter *adapter,
 static int
 ena_enable_wc(struct resource *res)
 {
-#if defined(__i386) || defined(__amd64)
+#if defined(__i386) || defined(__amd64) || defined(__aarch64__)
 	vm_offset_t va;
 	vm_size_t len;
 	int rc;
@@ -3317,7 +2267,7 @@ ena_enable_wc(struct resource *res)
 	va = (vm_offset_t)rman_get_virtual(res);
 	len = rman_get_size(res);
 	/* Enable write combining */
-	rc = pmap_change_attr(va, len, PAT_WRITE_COMBINING);
+	rc = pmap_change_attr(va, len, VM_MEMATTR_WRITE_COMBINING);
 	if (unlikely(rc != 0)) {
 		ena_trace(ENA_ALERT, "pmap_change_attr failed, %d\n", rc);
 		return (rc);
@@ -4095,7 +3045,7 @@ ena_timer_service(void *data)
 	callout_schedule_sbt(&adapter->timer_service, SBT_1S, SBT_1S, 0);
 }
 
-static void
+void
 ena_destroy_device(struct ena_adapter *adapter, bool graceful)
 {
 	if_t ifp = adapter->ifp;
@@ -4167,7 +3117,7 @@ ena_device_validate_params(struct ena_adapter *adapter,
 	return 0;
 }
 
-static int
+int
 ena_restore_device(struct ena_adapter *adapter)
 {
 	struct ena_com_dev_get_features_ctx get_feat_ctx;
@@ -4222,9 +3172,20 @@ ena_restore_device(struct ena_adapter *adapter)
 		}
 	}
 
+	/* Indicate that device is running again and ready to work */
 	ENA_FLAG_SET_ATOMIC(ENA_FLAG_DEVICE_RUNNING, adapter);
-	callout_reset_sbt(&adapter->timer_service, SBT_1S, SBT_1S,
-	    ena_timer_service, (void *)adapter, 0);
+
+	if (ENA_FLAG_ISSET(ENA_FLAG_DEV_UP_BEFORE_RESET, adapter)) {
+		/*
+		 * As the AENQ handlers weren't executed during reset because
+		 * the flag ENA_FLAG_DEVICE_RUNNING was turned off, the
+		 * timestamp must be updated again That will prevent next reset
+		 * caused by missing keep alive.
+		 */
+		adapter->keep_alive_timestamp = getsbinuptime();
+		callout_reset_sbt(&adapter->timer_service, SBT_1S, SBT_1S,
+		    ena_timer_service, (void *)adapter, 0);
+	}
 
 	device_printf(dev,
 	    "Device reset completed successfully, Driver info: %s\n", ena_version);
@@ -4352,14 +3313,6 @@ ena_attach(device_t pdev)
 
 	set_default_llq_configurations(&llq_config);
 
-#if defined(__arm__) || defined(__aarch64__)
-	/*
-	 * Force LLQ disable, as the driver is not supporting WC enablement
-	 * on the ARM architecture. Using LLQ without WC would affect
-	 * performance in a negative way.
-	 */
-	ena_dev->supported_features &= ~(1 << ENA_ADMIN_LLQ);
-#endif
 	rc = ena_set_queues_placement_policy(pdev, ena_dev, &get_feat_ctx.llq,
 	     &llq_config);
 	if (unlikely(rc != 0)) {
@@ -4460,12 +3413,24 @@ ena_attach(device_t pdev)
 	    sizeof(struct ena_hw_stats));
 	ena_sysctl_add_nodes(adapter);
 
+#ifdef DEV_NETMAP
+	rc = ena_netmap_attach(adapter);
+	if (rc != 0) {
+		device_printf(pdev, "netmap attach failed: %d\n", rc);
+		goto err_detach;
+	}
+#endif /* DEV_NETMAP */
+
 	/* Tell the stack that the interface is not active */
 	if_setdrvflagbits(adapter->ifp, IFF_DRV_OACTIVE, IFF_DRV_RUNNING);
 	ENA_FLAG_SET_ATOMIC(ENA_FLAG_DEVICE_RUNNING, adapter);
 
 	return (0);
 
+#ifdef DEV_NETMAP
+err_detach:
+	ether_ifdetach(adapter->ifp);
+#endif /* DEV_NETMAP */
 err_msix_free:
 	ena_com_dev_reset(adapter->ena_dev, ENA_REGS_RESET_INIT_ERR);
 	ena_free_mgmnt_irq(adapter);
@@ -4520,6 +3485,10 @@ ena_detach(device_t pdev)
 	ena_down(adapter);
 	ena_destroy_device(adapter, true);
 	sx_unlock(&adapter->ioctl_sx);
+
+#ifdef DEV_NETMAP
+	netmap_detach(adapter->ifp);
+#endif /* DEV_NETMAP */
 
 	ena_free_all_io_rings_resources(adapter);
 
@@ -4665,5 +3634,8 @@ MODULE_PNP_INFO("U16:vendor;U16:device", pci, ena, ena_vendor_info_array,
 #endif
 MODULE_DEPEND(ena, pci, 1, 1, 1);
 MODULE_DEPEND(ena, ether, 1, 1, 1);
+#ifdef DEV_NETMAP
+MODULE_DEPEND(ena, netmap, 1, 1, 1);
+#endif /* DEV_NETMAP */
 
 /*********************************************************************/

--- a/kernel/fbsd/ena/ena.h
+++ b/kernel/fbsd/ena/ena.h
@@ -40,7 +40,7 @@
 #include "ena_com/ena_eth_com.h"
 
 #define DRV_MODULE_VER_MAJOR	2
-#define DRV_MODULE_VER_MINOR	0
+#define DRV_MODULE_VER_MINOR	1
 #define DRV_MODULE_VER_SUBMINOR 0
 
 #define DRV_MODULE_NAME		"ena"
@@ -226,6 +226,14 @@ struct ena_calc_queue_size_ctx {
 	uint16_t max_rx_sgl_size;
 };
 
+#ifdef DEV_NETMAP
+struct ena_netmap_tx_info {
+	uint32_t socket_buf_idx[ENA_PKT_MAX_BUFS];
+	bus_dmamap_t map_seg[ENA_PKT_MAX_BUFS];
+	unsigned int sockets_used;
+};
+#endif
+
 struct ena_tx_buffer {
 	struct mbuf *mbuf;
 	/* # of ena desc for this specific mbuf
@@ -245,6 +253,10 @@ struct ena_tx_buffer {
 	struct bintime timestamp;
 	bool print_once;
 
+#ifdef DEV_NETMAP
+	struct ena_netmap_tx_info nm_info;
+#endif /* DEV_NETMAP */
+
 	struct ena_com_buf bufs[ENA_PKT_MAX_BUFS];
 } __aligned(CACHE_LINE_SIZE);
 
@@ -252,6 +264,9 @@ struct ena_rx_buffer {
 	struct mbuf *mbuf;
 	bus_dmamap_t map;
 	struct ena_com_buf ena_buf;
+#ifdef DEV_NETMAP
+	uint32_t netmap_buf_idx;
+#endif /* DEV_NETMAP */
 } __aligned(CACHE_LINE_SIZE);
 
 struct ena_stats_tx {
@@ -351,6 +366,10 @@ struct ena_ring {
 
 	/* Used for LLQ */
 	uint8_t *push_buf_intermediate_buf;
+
+#ifdef DEV_NETMAP
+	bool initialized;
+#endif /* DEV_NETMAP */
 } __aligned(CACHE_LINE_SIZE);
 
 struct ena_stats_dev {
@@ -463,6 +482,32 @@ static inline int ena_mbuf_count(struct mbuf *mbuf)
 		++count;
 
 	return count;
+}
+
+int	ena_up(struct ena_adapter *);
+void	ena_down(struct ena_adapter *);
+int	ena_restore_device(struct ena_adapter *);
+void	ena_destroy_device(struct ena_adapter *, bool);
+int	ena_refill_rx_bufs(struct ena_ring *, uint32_t);
+inline int validate_rx_req_id(struct ena_ring *, uint16_t);
+
+inline int
+validate_rx_req_id(struct ena_ring *rx_ring, uint16_t req_id)
+{
+	if (likely(req_id < rx_ring->ring_size))
+		return (0);
+
+	device_printf(rx_ring->adapter->pdev, "Invalid rx req_id: %hu\n",
+	    req_id);
+	counter_u64_add(rx_ring->rx_stats.bad_req_id, 1);
+
+	/* Trigger device reset */
+	if (likely(!ENA_FLAG_ISSET(ENA_FLAG_TRIGGER_RESET, rx_ring->adapter))) {
+		rx_ring->adapter->reset_reason = ENA_REGS_RESET_INV_RX_REQ_ID;
+		ENA_FLAG_SET_ATOMIC(ENA_FLAG_TRIGGER_RESET, rx_ring->adapter);
+	}
+
+	return (EFAULT);
 }
 
 #endif /* !(ENA_H) */

--- a/kernel/fbsd/ena/ena_com/ena_plat.h
+++ b/kernel/fbsd/ena/ena_com/ena_plat.h
@@ -103,6 +103,7 @@ extern struct ena_bus_space ebs;
 #define ENA_RSC 	(1 << 6) /* Goes with TXPTH or RXPTH, free/alloc res. */
 #define ENA_IOQ 	(1 << 7) /* Detailed info about IO queues. 	      */
 #define ENA_ADMQ	(1 << 8) /* Detailed info about admin queue. 	      */
+#define ENA_NETMAP	(1 << 9) /* Detailed info about netmap. 	      */
 
 extern int ena_log_level;
 

--- a/kernel/fbsd/ena/ena_datapath.c
+++ b/kernel/fbsd/ena/ena_datapath.c
@@ -1,0 +1,1189 @@
+/*-
+ * BSD LICENSE
+ *
+ * Copyright (c) 2015-2019 Amazon.com, Inc. or its affiliates.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+#include <sys/cdefs.h>
+__FBSDID("$FreeBSD$");
+
+#include "ena.h"
+#include "ena_datapath.h"
+#ifdef DEV_NETMAP
+#include "ena_netmap.h"
+#endif /* DEV_NETMAP */
+
+/*********************************************************************
+ *  Static functions prototypes
+ *********************************************************************/
+
+static int	ena_tx_cleanup(struct ena_ring *);
+static int	ena_rx_cleanup(struct ena_ring *);
+static inline int validate_tx_req_id(struct ena_ring *, uint16_t);
+static void	ena_rx_hash_mbuf(struct ena_ring *, struct ena_com_rx_ctx *,
+    struct mbuf *);
+static struct mbuf* ena_rx_mbuf(struct ena_ring *, struct ena_com_rx_buf_info *,
+    struct ena_com_rx_ctx *, uint16_t *);
+static inline void ena_rx_checksum(struct ena_ring *, struct ena_com_rx_ctx *,
+    struct mbuf *);
+static void	ena_tx_csum(struct ena_com_tx_ctx *, struct mbuf *);
+static int	ena_check_and_collapse_mbuf(struct ena_ring *tx_ring,
+    struct mbuf **mbuf);
+static void	ena_dmamap_llq(void *, bus_dma_segment_t *, int, int);
+static int	ena_xmit_mbuf(struct ena_ring *, struct mbuf **);
+static void	ena_start_xmit(struct ena_ring *);
+
+/*********************************************************************
+ *  Global functions
+ *********************************************************************/
+
+void
+ena_cleanup(void *arg, int pending)
+{
+	struct ena_que	*que = arg;
+	struct ena_adapter *adapter = que->adapter;
+	if_t ifp = adapter->ifp;
+	struct ena_ring *tx_ring;
+	struct ena_ring *rx_ring;
+	struct ena_com_io_cq* io_cq;
+	struct ena_eth_io_intr_reg intr_reg;
+	int qid, ena_qid;
+	int txc, rxc, i;
+
+	if (unlikely((if_getdrvflags(ifp) & IFF_DRV_RUNNING) == 0))
+		return;
+
+	ena_trace(ENA_DBG, "MSI-X TX/RX routine\n");
+
+	tx_ring = que->tx_ring;
+	rx_ring = que->rx_ring;
+	qid = que->id;
+	ena_qid = ENA_IO_TXQ_IDX(qid);
+	io_cq = &adapter->ena_dev->io_cq_queues[ena_qid];
+
+	tx_ring->first_interrupt = true;
+	rx_ring->first_interrupt = true;
+
+	for (i = 0; i < CLEAN_BUDGET; ++i) {
+		rxc = ena_rx_cleanup(rx_ring);
+		txc = ena_tx_cleanup(tx_ring);
+
+		if (unlikely((if_getdrvflags(ifp) & IFF_DRV_RUNNING) == 0))
+			return;
+
+		if ((txc != TX_BUDGET) && (rxc != RX_BUDGET))
+		       break;
+	}
+
+	/* Signal that work is done and unmask interrupt */
+	ena_com_update_intr_reg(&intr_reg,
+	    RX_IRQ_INTERVAL,
+	    TX_IRQ_INTERVAL,
+	    true);
+	ena_com_unmask_intr(io_cq, &intr_reg);
+}
+
+void
+ena_deferred_mq_start(void *arg, int pending)
+{
+	struct ena_ring *tx_ring = (struct ena_ring *)arg;
+	struct ifnet *ifp = tx_ring->adapter->ifp;
+
+	while (!drbr_empty(ifp, tx_ring->br) &&
+	    tx_ring->running &&
+	    (if_getdrvflags(ifp) & IFF_DRV_RUNNING) != 0) {
+		ENA_RING_MTX_LOCK(tx_ring);
+		ena_start_xmit(tx_ring);
+		ENA_RING_MTX_UNLOCK(tx_ring);
+	}
+}
+
+int
+ena_mq_start(if_t ifp, struct mbuf *m)
+{
+	struct ena_adapter *adapter = ifp->if_softc;
+	struct ena_ring *tx_ring;
+	int ret, is_drbr_empty;
+	uint32_t i;
+
+	if (unlikely((if_getdrvflags(adapter->ifp) & IFF_DRV_RUNNING) == 0))
+		return (ENODEV);
+
+	/* Which queue to use */
+	/*
+	 * If everything is setup correctly, it should be the
+	 * same bucket that the current CPU we're on is.
+	 * It should improve performance.
+	 */
+	if (M_HASHTYPE_GET(m) != M_HASHTYPE_NONE) {
+		i = m->m_pkthdr.flowid % adapter->num_queues;
+	} else {
+		i = curcpu % adapter->num_queues;
+	}
+	tx_ring = &adapter->tx_ring[i];
+
+	/* Check if drbr is empty before putting packet */
+	is_drbr_empty = drbr_empty(ifp, tx_ring->br);
+	ret = drbr_enqueue(ifp, tx_ring->br, m);
+	if (unlikely(ret != 0)) {
+		taskqueue_enqueue(tx_ring->enqueue_tq, &tx_ring->enqueue_task);
+		return (ret);
+	}
+
+	if (is_drbr_empty && (ENA_RING_MTX_TRYLOCK(tx_ring) != 0)) {
+		ena_start_xmit(tx_ring);
+		ENA_RING_MTX_UNLOCK(tx_ring);
+	} else {
+		taskqueue_enqueue(tx_ring->enqueue_tq, &tx_ring->enqueue_task);
+	}
+
+	return (0);
+}
+
+void
+ena_qflush(if_t ifp)
+{
+	struct ena_adapter *adapter = ifp->if_softc;
+	struct ena_ring *tx_ring = adapter->tx_ring;
+	int i;
+
+	for(i = 0; i < adapter->num_queues; ++i, ++tx_ring)
+		if (!drbr_empty(ifp, tx_ring->br)) {
+			ENA_RING_MTX_LOCK(tx_ring);
+			drbr_flush(ifp, tx_ring->br);
+			ENA_RING_MTX_UNLOCK(tx_ring);
+		}
+
+	if_qflush(ifp);
+}
+
+/*********************************************************************
+ *  Static functions
+ *********************************************************************/
+
+static inline int
+validate_tx_req_id(struct ena_ring *tx_ring, uint16_t req_id)
+{
+	struct ena_adapter *adapter = tx_ring->adapter;
+	struct ena_tx_buffer *tx_info = NULL;
+
+	if (likely(req_id < tx_ring->ring_size)) {
+		tx_info = &tx_ring->tx_buffer_info[req_id];
+		if (tx_info->mbuf != NULL)
+			return (0);
+		device_printf(adapter->pdev,
+		    "tx_info doesn't have valid mbuf\n");
+	}
+
+	device_printf(adapter->pdev, "Invalid req_id: %hu\n", req_id);
+	counter_u64_add(tx_ring->tx_stats.bad_req_id, 1);
+
+	/* Trigger device reset */
+	adapter->reset_reason = ENA_REGS_RESET_INV_TX_REQ_ID;
+	ENA_FLAG_SET_ATOMIC(ENA_FLAG_TRIGGER_RESET, adapter);
+
+	return (EFAULT);
+}
+
+/**
+ * ena_tx_cleanup - clear sent packets and corresponding descriptors
+ * @tx_ring: ring for which we want to clean packets
+ *
+ * Once packets are sent, we ask the device in a loop for no longer used
+ * descriptors. We find the related mbuf chain in a map (index in an array)
+ * and free it, then update ring state.
+ * This is performed in "endless" loop, updating ring pointers every
+ * TX_COMMIT. The first check of free descriptor is performed before the actual
+ * loop, then repeated at the loop end.
+ **/
+static int
+ena_tx_cleanup(struct ena_ring *tx_ring)
+{
+	struct ena_adapter *adapter;
+	struct ena_com_io_cq* io_cq;
+	uint16_t next_to_clean;
+	uint16_t req_id;
+	uint16_t ena_qid;
+	unsigned int total_done = 0;
+	int rc;
+	int commit = TX_COMMIT;
+	int budget = TX_BUDGET;
+	int work_done;
+	bool above_thresh;
+
+	adapter = tx_ring->que->adapter;
+	ena_qid = ENA_IO_TXQ_IDX(tx_ring->que->id);
+	io_cq = &adapter->ena_dev->io_cq_queues[ena_qid];
+	next_to_clean = tx_ring->next_to_clean;
+
+#ifdef DEV_NETMAP
+	if (netmap_tx_irq(adapter->ifp, tx_ring->qid) != NM_IRQ_PASS)
+		return (0);
+#endif /* DEV_NETMAP */
+
+	do {
+		struct ena_tx_buffer *tx_info;
+		struct mbuf *mbuf;
+
+		rc = ena_com_tx_comp_req_id_get(io_cq, &req_id);
+		if (unlikely(rc != 0))
+			break;
+
+		rc = validate_tx_req_id(tx_ring, req_id);
+		if (unlikely(rc != 0))
+			break;
+
+		tx_info = &tx_ring->tx_buffer_info[req_id];
+
+		mbuf = tx_info->mbuf;
+
+		tx_info->mbuf = NULL;
+		bintime_clear(&tx_info->timestamp);
+
+		/* Map is no longer required */
+		if (tx_info->head_mapped == true) {
+			bus_dmamap_sync(adapter->tx_buf_tag, tx_info->map_head,
+			    BUS_DMASYNC_POSTWRITE);
+			bus_dmamap_unload(adapter->tx_buf_tag,
+			    tx_info->map_head);
+			tx_info->head_mapped = false;
+		}
+		if (tx_info->seg_mapped == true) {
+			bus_dmamap_sync(adapter->tx_buf_tag, tx_info->map_seg,
+			    BUS_DMASYNC_POSTWRITE);
+			bus_dmamap_unload(adapter->tx_buf_tag,
+			    tx_info->map_seg);
+			tx_info->seg_mapped = false;
+		}
+
+		ena_trace(ENA_DBG | ENA_TXPTH, "tx: q %d mbuf %p completed\n",
+		    tx_ring->qid, mbuf);
+
+		m_freem(mbuf);
+
+		total_done += tx_info->tx_descs;
+
+		tx_ring->free_tx_ids[next_to_clean] = req_id;
+		next_to_clean = ENA_TX_RING_IDX_NEXT(next_to_clean,
+		    tx_ring->ring_size);
+
+		if (unlikely(--commit == 0)) {
+			commit = TX_COMMIT;
+			/* update ring state every TX_COMMIT descriptor */
+			tx_ring->next_to_clean = next_to_clean;
+			ena_com_comp_ack(
+			    &adapter->ena_dev->io_sq_queues[ena_qid],
+			    total_done);
+			ena_com_update_dev_comp_head(io_cq);
+			total_done = 0;
+		}
+	} while (likely(--budget));
+
+	work_done = TX_BUDGET - budget;
+
+	ena_trace(ENA_DBG | ENA_TXPTH, "tx: q %d done. total pkts: %d\n",
+	tx_ring->qid, work_done);
+
+	/* If there is still something to commit update ring state */
+	if (likely(commit != TX_COMMIT)) {
+		tx_ring->next_to_clean = next_to_clean;
+		ena_com_comp_ack(&adapter->ena_dev->io_sq_queues[ena_qid],
+		    total_done);
+		ena_com_update_dev_comp_head(io_cq);
+	}
+
+	/*
+	 * Need to make the rings circular update visible to
+	 * ena_xmit_mbuf() before checking for tx_ring->running.
+	 */
+	mb();
+
+	above_thresh = ena_com_sq_have_enough_space(tx_ring->ena_com_io_sq,
+	    ENA_TX_RESUME_THRESH);
+	if (unlikely(!tx_ring->running && above_thresh)) {
+		ENA_RING_MTX_LOCK(tx_ring);
+		above_thresh =
+		    ena_com_sq_have_enough_space(tx_ring->ena_com_io_sq,
+		    ENA_TX_RESUME_THRESH);
+		if (!tx_ring->running && above_thresh) {
+			tx_ring->running = true;
+			counter_u64_add(tx_ring->tx_stats.queue_wakeup, 1);
+			taskqueue_enqueue(tx_ring->enqueue_tq,
+			    &tx_ring->enqueue_task);
+		}
+		ENA_RING_MTX_UNLOCK(tx_ring);
+	}
+
+	return (work_done);
+}
+
+static void
+ena_rx_hash_mbuf(struct ena_ring *rx_ring, struct ena_com_rx_ctx *ena_rx_ctx,
+    struct mbuf *mbuf)
+{
+	struct ena_adapter *adapter = rx_ring->adapter;
+
+	if (likely(ENA_FLAG_ISSET(ENA_FLAG_RSS_ACTIVE, adapter))) {
+		mbuf->m_pkthdr.flowid = ena_rx_ctx->hash;
+
+		if (ena_rx_ctx->frag &&
+		    (ena_rx_ctx->l3_proto != ENA_ETH_IO_L3_PROTO_UNKNOWN)) {
+			M_HASHTYPE_SET(mbuf, M_HASHTYPE_OPAQUE_HASH);
+			return;
+		}
+
+		switch (ena_rx_ctx->l3_proto) {
+		case ENA_ETH_IO_L3_PROTO_IPV4:
+			switch (ena_rx_ctx->l4_proto) {
+			case ENA_ETH_IO_L4_PROTO_TCP:
+				M_HASHTYPE_SET(mbuf, M_HASHTYPE_RSS_TCP_IPV4);
+				break;
+			case ENA_ETH_IO_L4_PROTO_UDP:
+				M_HASHTYPE_SET(mbuf, M_HASHTYPE_RSS_UDP_IPV4);
+				break;
+			default:
+				M_HASHTYPE_SET(mbuf, M_HASHTYPE_RSS_IPV4);
+			}
+			break;
+		case ENA_ETH_IO_L3_PROTO_IPV6:
+			switch (ena_rx_ctx->l4_proto) {
+			case ENA_ETH_IO_L4_PROTO_TCP:
+				M_HASHTYPE_SET(mbuf, M_HASHTYPE_RSS_TCP_IPV6);
+				break;
+			case ENA_ETH_IO_L4_PROTO_UDP:
+				M_HASHTYPE_SET(mbuf, M_HASHTYPE_RSS_UDP_IPV6);
+				break;
+			default:
+				M_HASHTYPE_SET(mbuf, M_HASHTYPE_RSS_IPV6);
+			}
+			break;
+		case ENA_ETH_IO_L3_PROTO_UNKNOWN:
+			M_HASHTYPE_SET(mbuf, M_HASHTYPE_NONE);
+			break;
+		default:
+			M_HASHTYPE_SET(mbuf, M_HASHTYPE_OPAQUE_HASH);
+		}
+	} else {
+		mbuf->m_pkthdr.flowid = rx_ring->qid;
+		M_HASHTYPE_SET(mbuf, M_HASHTYPE_NONE);
+	}
+}
+
+/**
+ * ena_rx_mbuf - assemble mbuf from descriptors
+ * @rx_ring: ring for which we want to clean packets
+ * @ena_bufs: buffer info
+ * @ena_rx_ctx: metadata for this packet(s)
+ * @next_to_clean: ring pointer, will be updated only upon success
+ *
+ **/
+static struct mbuf*
+ena_rx_mbuf(struct ena_ring *rx_ring, struct ena_com_rx_buf_info *ena_bufs,
+    struct ena_com_rx_ctx *ena_rx_ctx, uint16_t *next_to_clean)
+{
+	struct mbuf *mbuf;
+	struct ena_rx_buffer *rx_info;
+	struct ena_adapter *adapter;
+	unsigned int descs = ena_rx_ctx->descs;
+	int rc;
+	uint16_t ntc, len, req_id, buf = 0;
+
+	ntc = *next_to_clean;
+	adapter = rx_ring->adapter;
+
+	len = ena_bufs[buf].len;
+	req_id = ena_bufs[buf].req_id;
+	rc = validate_rx_req_id(rx_ring, req_id);
+	if (unlikely(rc != 0))
+		return (NULL);
+
+	rx_info = &rx_ring->rx_buffer_info[req_id];
+	if (unlikely(rx_info->mbuf == NULL)) {
+		device_printf(adapter->pdev, "NULL mbuf in rx_info");
+		return (NULL);
+	}
+
+	ena_trace(ENA_DBG | ENA_RXPTH, "rx_info %p, mbuf %p, paddr %jx\n",
+	    rx_info, rx_info->mbuf, (uintmax_t)rx_info->ena_buf.paddr);
+
+	bus_dmamap_sync(adapter->rx_buf_tag, rx_info->map,
+	    BUS_DMASYNC_POSTREAD);
+	mbuf = rx_info->mbuf;
+	mbuf->m_flags |= M_PKTHDR;
+	mbuf->m_pkthdr.len = len;
+	mbuf->m_len = len;
+	mbuf->m_pkthdr.rcvif = rx_ring->que->adapter->ifp;
+
+	/* Fill mbuf with hash key and it's interpretation for optimization */
+	ena_rx_hash_mbuf(rx_ring, ena_rx_ctx, mbuf);
+
+	ena_trace(ENA_DBG | ENA_RXPTH, "rx mbuf 0x%p, flags=0x%x, len: %d\n",
+	    mbuf, mbuf->m_flags, mbuf->m_pkthdr.len);
+
+	/* DMA address is not needed anymore, unmap it */
+	bus_dmamap_unload(rx_ring->adapter->rx_buf_tag, rx_info->map);
+
+	rx_info->mbuf = NULL;
+	rx_ring->free_rx_ids[ntc] = req_id;
+	ntc = ENA_RX_RING_IDX_NEXT(ntc, rx_ring->ring_size);
+
+	/*
+	 * While we have more than 1 descriptors for one rcvd packet, append
+	 * other mbufs to the main one
+	 */
+	while (--descs) {
+		++buf;
+		len = ena_bufs[buf].len;
+		req_id = ena_bufs[buf].req_id;
+		rc = validate_rx_req_id(rx_ring, req_id);
+		if (unlikely(rc != 0)) {
+			/*
+			 * If the req_id is invalid, then the device will be
+			 * reset. In that case we must free all mbufs that
+			 * were already gathered.
+			 */
+			m_freem(mbuf);
+			return (NULL);
+		}
+		rx_info = &rx_ring->rx_buffer_info[req_id];
+
+		if (unlikely(rx_info->mbuf == NULL)) {
+			device_printf(adapter->pdev, "NULL mbuf in rx_info");
+			/*
+			 * If one of the required mbufs was not allocated yet,
+			 * we can break there.
+			 * All earlier used descriptors will be reallocated
+			 * later and not used mbufs can be reused.
+			 * The next_to_clean pointer will not be updated in case
+			 * of an error, so caller should advance it manually
+			 * in error handling routine to keep it up to date
+			 * with hw ring.
+			 */
+			m_freem(mbuf);
+			return (NULL);
+		}
+
+		bus_dmamap_sync(adapter->rx_buf_tag, rx_info->map,
+		    BUS_DMASYNC_POSTREAD);
+		if (unlikely(m_append(mbuf, len, rx_info->mbuf->m_data) == 0)) {
+			counter_u64_add(rx_ring->rx_stats.mbuf_alloc_fail, 1);
+			ena_trace(ENA_WARNING, "Failed to append Rx mbuf %p\n",
+			    mbuf);
+		}
+
+		ena_trace(ENA_DBG | ENA_RXPTH,
+		    "rx mbuf updated. len %d\n", mbuf->m_pkthdr.len);
+
+		/* Free already appended mbuf, it won't be useful anymore */
+		bus_dmamap_unload(rx_ring->adapter->rx_buf_tag, rx_info->map);
+		m_freem(rx_info->mbuf);
+		rx_info->mbuf = NULL;
+
+		rx_ring->free_rx_ids[ntc] = req_id;
+		ntc = ENA_RX_RING_IDX_NEXT(ntc, rx_ring->ring_size);
+	}
+
+	*next_to_clean = ntc;
+
+	return (mbuf);
+}
+
+/**
+ * ena_rx_checksum - indicate in mbuf if hw indicated a good cksum
+ **/
+static inline void
+ena_rx_checksum(struct ena_ring *rx_ring, struct ena_com_rx_ctx *ena_rx_ctx,
+    struct mbuf *mbuf)
+{
+
+	/* if IP and error */
+	if (unlikely((ena_rx_ctx->l3_proto == ENA_ETH_IO_L3_PROTO_IPV4) &&
+	    ena_rx_ctx->l3_csum_err)) {
+		/* ipv4 checksum error */
+		mbuf->m_pkthdr.csum_flags = 0;
+		counter_u64_add(rx_ring->rx_stats.bad_csum, 1);
+		ena_trace(ENA_DBG, "RX IPv4 header checksum error\n");
+		return;
+	}
+
+	/* if TCP/UDP */
+	if ((ena_rx_ctx->l4_proto == ENA_ETH_IO_L4_PROTO_TCP) ||
+	    (ena_rx_ctx->l4_proto == ENA_ETH_IO_L4_PROTO_UDP)) {
+		if (ena_rx_ctx->l4_csum_err) {
+			/* TCP/UDP checksum error */
+			mbuf->m_pkthdr.csum_flags = 0;
+			counter_u64_add(rx_ring->rx_stats.bad_csum, 1);
+			ena_trace(ENA_DBG, "RX L4 checksum error\n");
+		} else {
+			mbuf->m_pkthdr.csum_flags = CSUM_IP_CHECKED;
+			mbuf->m_pkthdr.csum_flags |= CSUM_IP_VALID;
+		}
+	}
+}
+
+/**
+ * ena_rx_cleanup - handle rx irq
+ * @arg: ring for which irq is being handled
+ **/
+static int
+ena_rx_cleanup(struct ena_ring *rx_ring)
+{
+	struct ena_adapter *adapter;
+	struct mbuf *mbuf;
+	struct ena_com_rx_ctx ena_rx_ctx;
+	struct ena_com_io_cq* io_cq;
+	struct ena_com_io_sq* io_sq;
+	if_t ifp;
+	uint16_t ena_qid;
+	uint16_t next_to_clean;
+	uint32_t refill_required;
+	uint32_t refill_threshold;
+	uint32_t do_if_input = 0;
+	unsigned int qid;
+	int rc, i;
+	int budget = RX_BUDGET;
+#ifdef DEV_NETMAP
+	int done;
+#endif /* DEV_NETMAP */
+
+	adapter = rx_ring->que->adapter;
+	ifp = adapter->ifp;
+	qid = rx_ring->que->id;
+	ena_qid = ENA_IO_RXQ_IDX(qid);
+	io_cq = &adapter->ena_dev->io_cq_queues[ena_qid];
+	io_sq = &adapter->ena_dev->io_sq_queues[ena_qid];
+	next_to_clean = rx_ring->next_to_clean;
+
+#ifdef DEV_NETMAP
+	if (netmap_rx_irq(adapter->ifp, rx_ring->qid, &done) != NM_IRQ_PASS)
+		return (0);
+#endif /* DEV_NETMAP */
+
+	ena_trace(ENA_DBG, "rx: qid %d\n", qid);
+
+	do {
+		ena_rx_ctx.ena_bufs = rx_ring->ena_bufs;
+		ena_rx_ctx.max_bufs = adapter->max_rx_sgl_size;
+		ena_rx_ctx.descs = 0;
+		bus_dmamap_sync(io_cq->cdesc_addr.mem_handle.tag,
+		    io_cq->cdesc_addr.mem_handle.map, BUS_DMASYNC_POSTREAD);
+		rc = ena_com_rx_pkt(io_cq, io_sq, &ena_rx_ctx);
+
+		if (unlikely(rc != 0))
+			goto error;
+
+		if (unlikely(ena_rx_ctx.descs == 0))
+			break;
+
+		ena_trace(ENA_DBG | ENA_RXPTH, "rx: q %d got packet from ena. "
+		    "descs #: %d l3 proto %d l4 proto %d hash: %x\n",
+		    rx_ring->qid, ena_rx_ctx.descs, ena_rx_ctx.l3_proto,
+		    ena_rx_ctx.l4_proto, ena_rx_ctx.hash);
+
+		/* Receive mbuf from the ring */
+		mbuf = ena_rx_mbuf(rx_ring, rx_ring->ena_bufs,
+		    &ena_rx_ctx, &next_to_clean);
+		bus_dmamap_sync(io_cq->cdesc_addr.mem_handle.tag,
+		    io_cq->cdesc_addr.mem_handle.map, BUS_DMASYNC_PREREAD);
+		/* Exit if we failed to retrieve a buffer */
+		if (unlikely(mbuf == NULL)) {
+			for (i = 0; i < ena_rx_ctx.descs; ++i) {
+				rx_ring->free_rx_ids[next_to_clean] =
+				    rx_ring->ena_bufs[i].req_id;
+				next_to_clean =
+				    ENA_RX_RING_IDX_NEXT(next_to_clean,
+				    rx_ring->ring_size);
+
+			}
+			break;
+		}
+
+		if (((ifp->if_capenable & IFCAP_RXCSUM) != 0) ||
+		    ((ifp->if_capenable & IFCAP_RXCSUM_IPV6) != 0)) {
+			ena_rx_checksum(rx_ring, &ena_rx_ctx, mbuf);
+		}
+
+		counter_enter();
+		counter_u64_add_protected(rx_ring->rx_stats.bytes,
+		    mbuf->m_pkthdr.len);
+		counter_u64_add_protected(adapter->hw_stats.rx_bytes,
+		    mbuf->m_pkthdr.len);
+		counter_exit();
+		/*
+		 * LRO is only for IP/TCP packets and TCP checksum of the packet
+		 * should be computed by hardware.
+		 */
+		do_if_input = 1;
+		if (((ifp->if_capenable & IFCAP_LRO) != 0)  &&
+		    ((mbuf->m_pkthdr.csum_flags & CSUM_IP_VALID) != 0) &&
+		    (ena_rx_ctx.l4_proto == ENA_ETH_IO_L4_PROTO_TCP)) {
+			/*
+			 * Send to the stack if:
+			 *  - LRO not enabled, or
+			 *  - no LRO resources, or
+			 *  - lro enqueue fails
+			 */
+			if ((rx_ring->lro.lro_cnt != 0) &&
+			    (tcp_lro_rx(&rx_ring->lro, mbuf, 0) == 0))
+					do_if_input = 0;
+		}
+		if (do_if_input != 0) {
+			ena_trace(ENA_DBG | ENA_RXPTH,
+			    "calling if_input() with mbuf %p\n", mbuf);
+			(*ifp->if_input)(ifp, mbuf);
+		}
+
+		counter_enter();
+		counter_u64_add_protected(rx_ring->rx_stats.cnt, 1);
+		counter_u64_add_protected(adapter->hw_stats.rx_packets, 1);
+		counter_exit();
+	} while (--budget);
+
+	rx_ring->next_to_clean = next_to_clean;
+
+	refill_required = ena_com_free_desc(io_sq);
+	refill_threshold = min_t(int,
+	    rx_ring->ring_size / ENA_RX_REFILL_THRESH_DIVIDER,
+	    ENA_RX_REFILL_THRESH_PACKET);
+
+	if (refill_required > refill_threshold) {
+		ena_com_update_dev_comp_head(rx_ring->ena_com_io_cq);
+		ena_refill_rx_bufs(rx_ring, refill_required);
+	}
+
+	tcp_lro_flush_all(&rx_ring->lro);
+
+	return (RX_BUDGET - budget);
+
+error:
+	counter_u64_add(rx_ring->rx_stats.bad_desc_num, 1);
+
+	/* Too many desc from the device. Trigger reset */
+	if (likely(!ENA_FLAG_ISSET(ENA_FLAG_TRIGGER_RESET, adapter))) {
+		adapter->reset_reason = ENA_REGS_RESET_TOO_MANY_RX_DESCS;
+		ENA_FLAG_SET_ATOMIC(ENA_FLAG_TRIGGER_RESET, adapter);
+	}
+
+	return (0);
+}
+
+static void
+ena_tx_csum(struct ena_com_tx_ctx *ena_tx_ctx, struct mbuf *mbuf)
+{
+	struct ena_com_tx_meta *ena_meta;
+	struct ether_vlan_header *eh;
+	struct mbuf *mbuf_next;
+	u32 mss;
+	bool offload;
+	uint16_t etype;
+	int ehdrlen;
+	struct ip *ip;
+	int iphlen;
+	struct tcphdr *th;
+	int offset;
+
+	offload = false;
+	ena_meta = &ena_tx_ctx->ena_meta;
+	mss = mbuf->m_pkthdr.tso_segsz;
+
+	if (mss != 0)
+		offload = true;
+
+	if ((mbuf->m_pkthdr.csum_flags & CSUM_TSO) != 0)
+		offload = true;
+
+	if ((mbuf->m_pkthdr.csum_flags & CSUM_OFFLOAD) != 0)
+		offload = true;
+
+	if (!offload) {
+		ena_tx_ctx->meta_valid = 0;
+		return;
+	}
+
+	/* Determine where frame payload starts. */
+	eh = mtod(mbuf, struct ether_vlan_header *);
+	if (eh->evl_encap_proto == htons(ETHERTYPE_VLAN)) {
+		etype = ntohs(eh->evl_proto);
+		ehdrlen = ETHER_HDR_LEN + ETHER_VLAN_ENCAP_LEN;
+	} else {
+		etype = ntohs(eh->evl_encap_proto);
+		ehdrlen = ETHER_HDR_LEN;
+	}
+
+	mbuf_next = m_getptr(mbuf, ehdrlen, &offset);
+	ip = (struct ip *)(mtodo(mbuf_next, offset));
+	iphlen = ip->ip_hl << 2;
+
+	mbuf_next = m_getptr(mbuf, iphlen + ehdrlen, &offset);
+	th = (struct tcphdr *)(mtodo(mbuf_next, offset));
+
+	if ((mbuf->m_pkthdr.csum_flags & CSUM_IP) != 0) {
+		ena_tx_ctx->l3_csum_enable = 1;
+	}
+	if ((mbuf->m_pkthdr.csum_flags & CSUM_TSO) != 0) {
+		ena_tx_ctx->tso_enable = 1;
+		ena_meta->l4_hdr_len = (th->th_off);
+	}
+
+	switch (etype) {
+	case ETHERTYPE_IP:
+		ena_tx_ctx->l3_proto = ENA_ETH_IO_L3_PROTO_IPV4;
+		if ((ip->ip_off & htons(IP_DF)) != 0)
+			ena_tx_ctx->df = 1;
+		break;
+	case ETHERTYPE_IPV6:
+		ena_tx_ctx->l3_proto = ENA_ETH_IO_L3_PROTO_IPV6;
+
+	default:
+		break;
+	}
+
+	if (ip->ip_p == IPPROTO_TCP) {
+		ena_tx_ctx->l4_proto = ENA_ETH_IO_L4_PROTO_TCP;
+		if ((mbuf->m_pkthdr.csum_flags &
+		    (CSUM_IP_TCP | CSUM_IP6_TCP)) != 0)
+			ena_tx_ctx->l4_csum_enable = 1;
+		else
+			ena_tx_ctx->l4_csum_enable = 0;
+	} else if (ip->ip_p == IPPROTO_UDP) {
+		ena_tx_ctx->l4_proto = ENA_ETH_IO_L4_PROTO_UDP;
+		if ((mbuf->m_pkthdr.csum_flags &
+		    (CSUM_IP_UDP | CSUM_IP6_UDP)) != 0)
+			ena_tx_ctx->l4_csum_enable = 1;
+		else
+			ena_tx_ctx->l4_csum_enable = 0;
+	} else {
+		ena_tx_ctx->l4_proto = ENA_ETH_IO_L4_PROTO_UNKNOWN;
+		ena_tx_ctx->l4_csum_enable = 0;
+	}
+
+	ena_meta->mss = mss;
+	ena_meta->l3_hdr_len = iphlen;
+	ena_meta->l3_hdr_offset = ehdrlen;
+	ena_tx_ctx->meta_valid = 1;
+}
+
+static int
+ena_check_and_collapse_mbuf(struct ena_ring *tx_ring, struct mbuf **mbuf)
+{
+	struct ena_adapter *adapter;
+	struct mbuf *collapsed_mbuf;
+	int num_frags;
+
+	adapter = tx_ring->adapter;
+	num_frags = ena_mbuf_count(*mbuf);
+
+	/* One segment must be reserved for configuration descriptor. */
+	if (num_frags < adapter->max_tx_sgl_size)
+		return (0);
+	counter_u64_add(tx_ring->tx_stats.collapse, 1);
+
+	collapsed_mbuf = m_collapse(*mbuf, M_NOWAIT,
+	    adapter->max_tx_sgl_size - 1);
+	if (unlikely(collapsed_mbuf == NULL)) {
+		counter_u64_add(tx_ring->tx_stats.collapse_err, 1);
+		return (ENOMEM);
+	}
+
+	/* If mbuf was collapsed succesfully, original mbuf is released. */
+	*mbuf = collapsed_mbuf;
+
+	return (0);
+}
+
+static void
+ena_dmamap_llq(void *arg, bus_dma_segment_t *segs, int nseg, int error)
+{
+	struct ena_com_buf *ena_buf = arg;
+
+	if (unlikely(error != 0)) {
+		ena_buf->paddr = 0;
+		return;
+	}
+
+	KASSERT(nseg == 1, ("Invalid num of segments for LLQ dma"));
+
+	ena_buf->paddr = segs->ds_addr;
+	ena_buf->len = segs->ds_len;
+}
+
+static int
+ena_tx_map_mbuf(struct ena_ring *tx_ring, struct ena_tx_buffer *tx_info,
+    struct mbuf *mbuf, void **push_hdr, u16 *header_len)
+{
+	struct ena_adapter *adapter = tx_ring->adapter;
+	struct ena_com_buf *ena_buf;
+	bus_dma_segment_t segs[ENA_BUS_DMA_SEGS];
+	uint32_t mbuf_head_len, frag_len;
+	uint16_t push_len = 0;
+	uint16_t delta = 0;
+	int i, rc, nsegs;
+
+	mbuf_head_len = mbuf->m_len;
+	tx_info->mbuf = mbuf;
+	ena_buf = tx_info->bufs;
+
+	if (tx_ring->tx_mem_queue_type == ENA_ADMIN_PLACEMENT_POLICY_DEV) {
+		/*
+		 * When the device is LLQ mode, the driver will copy
+		 * the header into the device memory space.
+		 * the ena_com layer assumes the header is in a linear
+		 * memory space.
+		 * This assumption might be wrong since part of the header
+		 * can be in the fragmented buffers.
+		 * First check if header fits in the mbuf. If not, copy it to
+		 * separate buffer that will be holding linearized data.
+		 */
+		push_len = min_t(uint32_t, mbuf->m_pkthdr.len,
+		    tx_ring->tx_max_header_size);
+		*header_len = push_len;
+		/* If header is in linear space, just point into mbuf's data. */
+		if (likely(push_len <= mbuf_head_len)) {
+			*push_hdr = mbuf->m_data;
+		/*
+		 * Otherwise, copy whole portion of header from multiple mbufs
+		 * to intermediate buffer.
+		 */
+		} else {
+			m_copydata(mbuf, 0, push_len,
+			    tx_ring->push_buf_intermediate_buf);
+			*push_hdr = tx_ring->push_buf_intermediate_buf;
+
+			counter_u64_add(tx_ring->tx_stats.llq_buffer_copy, 1);
+			delta = push_len - mbuf_head_len;
+		}
+
+		ena_trace(ENA_DBG | ENA_TXPTH,
+		    "mbuf: %p header_buf->vaddr: %p push_len: %d\n",
+		    mbuf, *push_hdr, push_len);
+
+		/*
+		* If header was in linear memory space, map for the dma rest of the data
+		* in the first mbuf of the mbuf chain.
+		*/
+		if (mbuf_head_len > push_len) {
+			rc = bus_dmamap_load(adapter->tx_buf_tag,
+			    tx_info->map_head,
+			mbuf->m_data + push_len, mbuf_head_len - push_len,
+			ena_dmamap_llq, ena_buf, BUS_DMA_NOWAIT);
+			if (unlikely((rc != 0) || (ena_buf->paddr == 0)))
+				goto single_dma_error;
+
+			ena_buf++;
+			tx_info->num_of_bufs++;
+
+			tx_info->head_mapped = true;
+		}
+		mbuf = mbuf->m_next;
+	} else {
+		*push_hdr = NULL;
+		/*
+		* header_len is just a hint for the device. Because FreeBSD is not
+		* giving us information about packet header length and it is not
+		* guaranteed that all packet headers will be in the 1st mbuf, setting
+		* header_len to 0 is making the device ignore this value and resolve
+		* header on it's own.
+		*/
+		*header_len = 0;
+	}
+
+	/*
+	 * If header is in non linear space (delta > 0), then skip mbufs
+	 * containing header and map the last one containing both header and the
+	 * packet data.
+	 * The first segment is already counted in.
+	 * If LLQ is not supported, the loop will be skipped.
+	 */
+	while (delta > 0) {
+		frag_len = mbuf->m_len;
+
+		/*
+		 * If whole segment contains header just move to the
+		 * next one and reduce delta.
+		 */
+		if (unlikely(delta >= frag_len)) {
+			delta -= frag_len;
+		} else {
+			/*
+			 * Map rest of the packet data that was contained in
+			 * the mbuf.
+			 */
+			rc = bus_dmamap_load(adapter->tx_buf_tag,
+			    tx_info->map_head, mbuf->m_data + delta,
+			    frag_len - delta, ena_dmamap_llq, ena_buf,
+			    BUS_DMA_NOWAIT);
+			if (unlikely((rc != 0) || (ena_buf->paddr == 0)))
+				goto single_dma_error;
+
+			ena_buf++;
+			tx_info->num_of_bufs++;
+			tx_info->head_mapped = true;
+
+			delta = 0;
+		}
+
+		mbuf = mbuf->m_next;
+	}
+
+	if (mbuf == NULL) {
+		return (0);
+	}
+
+	/* Map rest of the mbufs */
+	rc = bus_dmamap_load_mbuf_sg(adapter->tx_buf_tag, tx_info->map_seg, mbuf,
+	    segs, &nsegs, BUS_DMA_NOWAIT);
+	if (unlikely((rc != 0) || (nsegs == 0))) {
+		ena_trace(ENA_WARNING,
+		    "dmamap load failed! err: %d nsegs: %d\n", rc, nsegs);
+		goto dma_error;
+	}
+
+	for (i = 0; i < nsegs; i++) {
+		ena_buf->len = segs[i].ds_len;
+		ena_buf->paddr = segs[i].ds_addr;
+		ena_buf++;
+	}
+	tx_info->num_of_bufs += nsegs;
+	tx_info->seg_mapped = true;
+
+	return (0);
+
+dma_error:
+	if (tx_info->head_mapped == true)
+		bus_dmamap_unload(adapter->tx_buf_tag, tx_info->map_head);
+single_dma_error:
+	counter_u64_add(tx_ring->tx_stats.dma_mapping_err, 1);
+	tx_info->mbuf = NULL;
+	return (rc);
+}
+
+static int
+ena_xmit_mbuf(struct ena_ring *tx_ring, struct mbuf **mbuf)
+{
+	struct ena_adapter *adapter;
+	struct ena_tx_buffer *tx_info;
+	struct ena_com_tx_ctx ena_tx_ctx;
+	struct ena_com_dev *ena_dev;
+	struct ena_com_io_sq* io_sq;
+	void *push_hdr;
+	uint16_t next_to_use;
+	uint16_t req_id;
+	uint16_t ena_qid;
+	uint16_t header_len;
+	int rc;
+	int nb_hw_desc;
+
+	ena_qid = ENA_IO_TXQ_IDX(tx_ring->que->id);
+	adapter = tx_ring->que->adapter;
+	ena_dev = adapter->ena_dev;
+	io_sq = &ena_dev->io_sq_queues[ena_qid];
+
+	rc = ena_check_and_collapse_mbuf(tx_ring, mbuf);
+	if (unlikely(rc != 0)) {
+		ena_trace(ENA_WARNING,
+		    "Failed to collapse mbuf! err: %d\n", rc);
+		return (rc);
+	}
+
+	ena_trace(ENA_DBG | ENA_TXPTH, "Tx: %d bytes\n", (*mbuf)->m_pkthdr.len);
+
+	next_to_use = tx_ring->next_to_use;
+	req_id = tx_ring->free_tx_ids[next_to_use];
+	tx_info = &tx_ring->tx_buffer_info[req_id];
+	tx_info->num_of_bufs = 0;
+
+	rc = ena_tx_map_mbuf(tx_ring, tx_info, *mbuf, &push_hdr, &header_len);
+	if (unlikely(rc != 0)) {
+		ena_trace(ENA_WARNING, "Failed to map TX mbuf\n");
+		return (rc);
+	}
+	memset(&ena_tx_ctx, 0x0, sizeof(struct ena_com_tx_ctx));
+	ena_tx_ctx.ena_bufs = tx_info->bufs;
+	ena_tx_ctx.push_header = push_hdr;
+	ena_tx_ctx.num_bufs = tx_info->num_of_bufs;
+	ena_tx_ctx.req_id = req_id;
+	ena_tx_ctx.header_len = header_len;
+
+	/* Set flags and meta data */
+	ena_tx_csum(&ena_tx_ctx, *mbuf);
+
+	if (tx_ring->acum_pkts == DB_THRESHOLD ||
+	    ena_com_is_doorbell_needed(tx_ring->ena_com_io_sq, &ena_tx_ctx)) {
+		ena_trace(ENA_DBG | ENA_TXPTH,
+		    "llq tx max burst size of queue %d achieved, writing doorbell to send burst\n",
+		    tx_ring->que->id);
+		wmb();
+		ena_com_write_sq_doorbell(tx_ring->ena_com_io_sq);
+		counter_u64_add(tx_ring->tx_stats.doorbells, 1);
+		tx_ring->acum_pkts = 0;
+	}
+
+	/* Prepare the packet's descriptors and send them to device */
+	rc = ena_com_prepare_tx(io_sq, &ena_tx_ctx, &nb_hw_desc);
+	if (unlikely(rc != 0)) {
+		if (likely(rc == ENA_COM_NO_MEM)) {
+			ena_trace(ENA_DBG | ENA_TXPTH,
+			    "tx ring[%d] if out of space\n", tx_ring->que->id);
+		} else {
+			device_printf(adapter->pdev,
+			    "failed to prepare tx bufs\n");
+		}
+		counter_u64_add(tx_ring->tx_stats.prepare_ctx_err, 1);
+		goto dma_error;
+	}
+
+	counter_enter();
+	counter_u64_add_protected(tx_ring->tx_stats.cnt, 1);
+	counter_u64_add_protected(tx_ring->tx_stats.bytes,
+	    (*mbuf)->m_pkthdr.len);
+
+	counter_u64_add_protected(adapter->hw_stats.tx_packets, 1);
+	counter_u64_add_protected(adapter->hw_stats.tx_bytes,
+	    (*mbuf)->m_pkthdr.len);
+	counter_exit();
+
+	tx_info->tx_descs = nb_hw_desc;
+	getbinuptime(&tx_info->timestamp);
+	tx_info->print_once = true;
+
+	tx_ring->next_to_use = ENA_TX_RING_IDX_NEXT(next_to_use,
+	    tx_ring->ring_size);
+
+	/* stop the queue when no more space available, the packet can have up
+	 * to sgl_size + 2. one for the meta descriptor and one for header
+	 * (if the header is larger than tx_max_header_size).
+	 */
+	if (unlikely(!ena_com_sq_have_enough_space(tx_ring->ena_com_io_sq,
+	    adapter->max_tx_sgl_size + 2))) {
+		ena_trace(ENA_DBG | ENA_TXPTH, "Stop queue %d\n",
+		    tx_ring->que->id);
+
+		tx_ring->running = false;
+		counter_u64_add(tx_ring->tx_stats.queue_stop, 1);
+
+		/* There is a rare condition where this function decides to
+		 * stop the queue but meanwhile tx_cleanup() updates
+		 * next_to_completion and terminates.
+		 * The queue will remain stopped forever.
+		 * To solve this issue this function performs mb(), checks
+		 * the wakeup condition and wakes up the queue if needed.
+		 */
+		mb();
+
+		if (ena_com_sq_have_enough_space(tx_ring->ena_com_io_sq,
+		    ENA_TX_RESUME_THRESH)) {
+			tx_ring->running = true;
+			counter_u64_add(tx_ring->tx_stats.queue_wakeup, 1);
+		}
+	}
+
+	if (tx_info->head_mapped == true)
+		bus_dmamap_sync(adapter->tx_buf_tag, tx_info->map_head,
+		    BUS_DMASYNC_PREWRITE);
+	if (tx_info->seg_mapped == true)
+		bus_dmamap_sync(adapter->tx_buf_tag, tx_info->map_seg,
+		    BUS_DMASYNC_PREWRITE);
+
+	return (0);
+
+dma_error:
+	tx_info->mbuf = NULL;
+	if (tx_info->seg_mapped == true) {
+		bus_dmamap_unload(adapter->tx_buf_tag, tx_info->map_seg);
+		tx_info->seg_mapped = false;
+	}
+	if (tx_info->head_mapped == true) {
+		bus_dmamap_unload(adapter->tx_buf_tag, tx_info->map_head);
+		tx_info->head_mapped = false;
+	}
+
+	return (rc);
+}
+
+static void
+ena_start_xmit(struct ena_ring *tx_ring)
+{
+	struct mbuf *mbuf;
+	struct ena_adapter *adapter = tx_ring->adapter;
+	struct ena_com_io_sq* io_sq;
+	int ena_qid;
+	int ret = 0;
+
+	if (unlikely((if_getdrvflags(adapter->ifp) & IFF_DRV_RUNNING) == 0))
+		return;
+
+	if (unlikely(!ENA_FLAG_ISSET(ENA_FLAG_LINK_UP, adapter)))
+		return;
+
+	ena_qid = ENA_IO_TXQ_IDX(tx_ring->que->id);
+	io_sq = &adapter->ena_dev->io_sq_queues[ena_qid];
+
+	while ((mbuf = drbr_peek(adapter->ifp, tx_ring->br)) != NULL) {
+		ena_trace(ENA_DBG | ENA_TXPTH, "\ndequeued mbuf %p with flags %#x and"
+		    " header csum flags %#jx\n",
+		    mbuf, mbuf->m_flags, (uint64_t)mbuf->m_pkthdr.csum_flags);
+
+		if (unlikely(!tx_ring->running)) {
+			drbr_putback(adapter->ifp, tx_ring->br, mbuf);
+			break;
+		}
+
+		if (unlikely((ret = ena_xmit_mbuf(tx_ring, &mbuf)) != 0)) {
+			if (ret == ENA_COM_NO_MEM) {
+				drbr_putback(adapter->ifp, tx_ring->br, mbuf);
+			} else if (ret == ENA_COM_NO_SPACE) {
+				drbr_putback(adapter->ifp, tx_ring->br, mbuf);
+			} else {
+				m_freem(mbuf);
+				drbr_advance(adapter->ifp, tx_ring->br);
+			}
+
+			break;
+		}
+
+		drbr_advance(adapter->ifp, tx_ring->br);
+
+		if (unlikely((if_getdrvflags(adapter->ifp) &
+		    IFF_DRV_RUNNING) == 0))
+			return;
+
+		tx_ring->acum_pkts++;
+
+		BPF_MTAP(adapter->ifp, mbuf);
+	}
+
+	if (likely(tx_ring->acum_pkts != 0)) {
+		wmb();
+		/* Trigger the dma engine */
+		ena_com_write_sq_doorbell(io_sq);
+		counter_u64_add(tx_ring->tx_stats.doorbells, 1);
+		tx_ring->acum_pkts = 0;
+	}
+
+	if (unlikely(!tx_ring->running))
+		taskqueue_enqueue(tx_ring->que->cleanup_tq,
+		    &tx_ring->que->cleanup_task);
+}

--- a/kernel/fbsd/ena/ena_datapath.h
+++ b/kernel/fbsd/ena/ena_datapath.h
@@ -1,0 +1,42 @@
+/*-
+ * BSD LICENSE
+ *
+ * Copyright (c) 2015-2019 Amazon.com, Inc. or its affiliates.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ * $FreeBSD$
+ *
+ */
+
+#ifndef ENA_TXRX_H
+#define ENA_TXRX_H
+
+void	ena_cleanup(void *, int);
+void	ena_qflush(if_t);
+int	ena_mq_start(if_t, struct mbuf *);
+void	ena_deferred_mq_start(void *, int);
+
+#endif /* ENA_TXRX_H */

--- a/kernel/fbsd/ena/ena_netmap.c
+++ b/kernel/fbsd/ena/ena_netmap.c
@@ -1,0 +1,1095 @@
+/*-
+ * BSD LICENSE
+ *
+ * Copyright (c) 2015-2019 Amazon.com, Inc. or its affiliates.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+#include <sys/cdefs.h>
+__FBSDID("$FreeBSD$");
+
+#ifdef DEV_NETMAP
+
+#include "ena.h"
+#include "ena_netmap.h"
+
+#define ENA_NETMAP_MORE_FRAMES		1
+#define ENA_NETMAP_NO_MORE_FRAMES	0
+#define ENA_MAX_FRAMES			16384
+
+struct ena_netmap_ctx {
+	struct netmap_kring *kring;
+	struct ena_adapter *adapter;
+	struct netmap_adapter *na;
+	struct netmap_slot *slots;
+	struct ena_ring *ring;
+	struct ena_com_io_cq *io_cq;
+	struct ena_com_io_sq *io_sq;
+	u_int nm_i;
+	uint16_t nt;
+	uint16_t lim;
+};
+
+/* Netmap callbacks */
+static int ena_netmap_reg(struct netmap_adapter *, int);
+static int ena_netmap_txsync(struct netmap_kring *, int);
+static int ena_netmap_rxsync(struct netmap_kring *, int);
+
+/* Helper functions */
+static int	ena_netmap_tx_frames(struct ena_netmap_ctx *);
+static int	ena_netmap_tx_frame(struct ena_netmap_ctx *);
+static inline uint16_t ena_netmap_count_slots(struct ena_netmap_ctx *);
+static inline uint16_t ena_netmap_packet_len(struct netmap_slot *, u_int,
+    uint16_t);
+static int	ena_netmap_copy_data(struct netmap_adapter *,
+    struct netmap_slot *, u_int, uint16_t, uint16_t, void *);
+static int	ena_netmap_map_single_slot(struct netmap_adapter *,
+    struct netmap_slot *, bus_dma_tag_t, bus_dmamap_t, void **, uint64_t *);
+static int	ena_netmap_tx_map_slots(struct ena_netmap_ctx *,
+    struct ena_tx_buffer *, void **, uint16_t *, uint16_t *);
+static void	ena_netmap_unmap_last_socket_chain(struct ena_netmap_ctx *,
+    struct ena_tx_buffer *);
+static void	ena_netmap_tx_cleanup(struct ena_netmap_ctx *);
+static uint16_t	ena_netmap_tx_clean_one(struct ena_netmap_ctx *,
+    uint16_t);
+static inline int validate_tx_req_id(struct ena_ring *, uint16_t);
+static int ena_netmap_rx_frames(struct ena_netmap_ctx *);
+static int ena_netmap_rx_frame(struct ena_netmap_ctx *);
+static int ena_netmap_rx_load_desc(struct ena_netmap_ctx *, uint16_t,
+    int *);
+static void ena_netmap_rx_cleanup(struct ena_netmap_ctx *);
+static void ena_netmap_fill_ctx(struct netmap_kring *,
+    struct ena_netmap_ctx *, uint16_t);
+
+int
+ena_netmap_attach(struct ena_adapter *adapter)
+{
+	struct netmap_adapter na;
+
+	ena_trace(ENA_NETMAP, "netmap attach\n");
+
+	bzero(&na, sizeof(na));
+	na.na_flags = NAF_MOREFRAG;
+	na.ifp = adapter->ifp;
+	na.num_tx_desc = adapter->tx_ring_size;
+	na.num_rx_desc = adapter->rx_ring_size;
+	na.num_tx_rings = adapter->num_queues;
+	na.num_rx_rings = adapter->num_queues;
+	na.rx_buf_maxsize = adapter->buf_ring_size;
+	na.nm_txsync = ena_netmap_txsync;
+	na.nm_rxsync = ena_netmap_rxsync;
+	na.nm_register = ena_netmap_reg;
+
+	return (netmap_attach(&na));
+}
+
+int
+ena_netmap_alloc_rx_slot(struct ena_adapter *adapter,
+    struct ena_ring *rx_ring, struct ena_rx_buffer *rx_info)
+{
+	struct netmap_adapter *na = NA(adapter->ifp);
+	struct netmap_kring *kring;
+	struct netmap_ring *ring;
+	struct netmap_slot *slot;
+	void *addr;
+	uint64_t paddr;
+	int nm_i, qid, head, lim, rc;
+
+	/* if previously allocated frag is not used */
+	if (unlikely(rx_info->netmap_buf_idx != 0))
+		return (0);
+
+	qid = rx_ring->qid;
+	kring = na->rx_rings[qid];
+	nm_i = kring->nr_hwcur;
+	head = kring->rhead;
+
+	ena_trace(ENA_NETMAP | ENA_DBG, "nr_hwcur: %d, nr_hwtail: %d, "
+	    "rhead: %d, rcur: %d, rtail: %d\n", kring->nr_hwcur,
+	    kring->nr_hwtail, kring->rhead, kring->rcur, kring->rtail);
+
+	if ((nm_i == head) && rx_ring->initialized) {
+		ena_trace(ENA_NETMAP, "No free slots in netmap ring\n");
+		return (ENOMEM);
+	}
+
+	ring = kring->ring;
+	if (ring == NULL) {
+		device_printf(adapter->pdev, "Rx ring %d is NULL\n", qid);
+		return (EFAULT);
+	}
+	slot = &ring->slot[nm_i];
+
+	addr = PNMB(na, slot, &paddr);
+	if (addr == NETMAP_BUF_BASE(na)) {
+		device_printf(adapter->pdev, "Bad buff in slot\n");
+		return (EFAULT);
+	}
+
+	rc = netmap_load_map(na, adapter->rx_buf_tag, rx_info->map, addr);
+	if (rc != 0) {
+		ena_trace(ENA_WARNING, "DMA mapping error\n");
+		return (rc);
+	}
+	bus_dmamap_sync(adapter->rx_buf_tag, rx_info->map, BUS_DMASYNC_PREREAD);
+
+	rx_info->ena_buf.paddr = paddr;
+	rx_info->ena_buf.len = ring->nr_buf_size;
+	rx_info->mbuf = NULL;
+	rx_info->netmap_buf_idx = slot->buf_idx;
+
+	slot->buf_idx = 0;
+
+	lim = kring->nkr_num_slots - 1;
+	kring->nr_hwcur = nm_next(nm_i, lim);
+
+	return (0);
+}
+
+void
+ena_netmap_free_rx_slot(struct ena_adapter *adapter,
+    struct ena_ring *rx_ring, struct ena_rx_buffer *rx_info)
+{
+	struct netmap_adapter *na;
+	struct netmap_kring *kring;
+	struct netmap_slot *slot;
+	int nm_i, qid, lim;
+
+	na = NA(adapter->ifp);
+	if (na == NULL) {
+		device_printf(adapter->pdev, "netmap adapter is NULL\n");
+		return;
+	}
+
+	if (na->rx_rings == NULL) {
+		device_printf(adapter->pdev, "netmap rings are NULL\n");
+		return;
+	}
+
+	qid = rx_ring->qid;
+	kring = na->rx_rings[qid];
+	if (kring == NULL) {
+		device_printf(adapter->pdev,
+		    "netmap kernel ring %d is NULL\n", qid);
+		return;
+	}
+
+	lim = kring->nkr_num_slots - 1;
+	nm_i = nm_prev(kring->nr_hwcur, lim);
+
+	if (kring->nr_mode != NKR_NETMAP_ON)
+		return;
+
+	bus_dmamap_sync(adapter->rx_buf_tag, rx_info->map,
+	    BUS_DMASYNC_POSTREAD);
+	netmap_unload_map(na, adapter->rx_buf_tag, rx_info->map);
+
+	KASSERT(kring->ring == NULL, ("Netmap Rx ring is NULL\n"));
+
+	slot = &kring->ring->slot[nm_i];
+
+	ENA_ASSERT(slot->buf_idx == 0, "Overwrite slot buf\n");
+	slot->buf_idx = rx_info->netmap_buf_idx;
+	slot->flags = NS_BUF_CHANGED;
+
+	rx_info->netmap_buf_idx = 0;
+	kring->nr_hwcur = nm_i;
+}
+
+static bool
+ena_ring_in_netmap(struct ena_adapter *adapter, int qid, enum txrx x)
+{
+	struct netmap_adapter *na;
+	struct netmap_kring *kring;
+
+	if (adapter->ifp->if_capenable & IFCAP_NETMAP) {
+		na = NA(adapter->ifp);
+		kring = (x == NR_RX) ? na->rx_rings[qid] : na->tx_rings[qid];
+		if (kring->nr_mode == NKR_NETMAP_ON)
+			return true;
+	}
+	return false;
+}
+
+bool
+ena_tx_ring_in_netmap(struct ena_adapter *adapter, int qid)
+{
+	return ena_ring_in_netmap(adapter, qid, NR_TX);
+}
+
+bool
+ena_rx_ring_in_netmap(struct ena_adapter *adapter, int qid)
+{
+	return ena_ring_in_netmap(adapter, qid, NR_RX);
+}
+
+static void
+ena_netmap_reset_ring(struct ena_adapter *adapter, int qid, enum txrx x)
+{
+	if (!ena_ring_in_netmap(adapter, qid, x))
+		return;
+
+	netmap_reset(NA(adapter->ifp), x, qid, 0);
+	ena_trace(ENA_NETMAP, "%s ring %d is in netmap mode\n",
+	    (x == NR_TX) ? "Tx" : "Rx", qid);
+}
+
+void
+ena_netmap_reset_rx_ring(struct ena_adapter *adapter, int qid)
+{
+	ena_netmap_reset_ring(adapter, qid, NR_RX);
+}
+
+void
+ena_netmap_reset_tx_ring(struct ena_adapter *adapter, int qid)
+{
+	ena_netmap_reset_ring(adapter, qid, NR_TX);
+}
+
+static int
+ena_netmap_reg(struct netmap_adapter *na, int onoff)
+{
+	struct ifnet *ifp = na->ifp;
+	struct ena_adapter* adapter = ifp->if_softc;
+	struct netmap_kring *kring;
+	enum txrx t;
+	int rc, i;
+
+	sx_xlock(&adapter->ioctl_sx);
+	ENA_FLAG_CLEAR_ATOMIC(ENA_FLAG_TRIGGER_RESET, adapter);
+	ena_down(adapter);
+
+	if (onoff) {
+		ena_trace(ENA_NETMAP, "netmap on\n");
+		for_rx_tx(t) {
+			for (i = 0; i <= nma_get_nrings(na, t); i++) {
+				kring = NMR(na, t)[i];
+				if (nm_kring_pending_on(kring)) {
+					kring->nr_mode = NKR_NETMAP_ON;
+				}
+			}
+		}
+		nm_set_native_flags(na);
+	} else {
+		ena_trace(ENA_NETMAP, "netmap off\n");
+		nm_clear_native_flags(na);
+		for_rx_tx(t) {
+			for (i = 0; i <= nma_get_nrings(na, t); i++) {
+				kring = NMR(na, t)[i];
+				if (nm_kring_pending_off(kring)) {
+					kring->nr_mode = NKR_NETMAP_OFF;
+				}
+			}
+		}
+	}
+
+	rc = ena_up(adapter);
+	if (rc != 0) {
+		ena_trace(ENA_WARNING, "ena_up failed with rc=%d\n", rc);
+		adapter->reset_reason = ENA_REGS_RESET_DRIVER_INVALID_STATE;
+		nm_clear_native_flags(na);
+		ena_destroy_device(adapter, false);
+		ENA_FLAG_SET_ATOMIC(ENA_FLAG_DEV_UP_BEFORE_RESET, adapter);
+		rc = ena_restore_device(adapter);
+	}
+	sx_unlock(&adapter->ioctl_sx);
+
+	return (rc);
+}
+
+static int
+ena_netmap_txsync(struct netmap_kring *kring, int flags)
+{
+	struct ena_netmap_ctx ctx;
+	int rc = 0;
+
+	ena_netmap_fill_ctx(kring, &ctx, ENA_IO_TXQ_IDX(kring->ring_id));
+	ctx.ring = &ctx.adapter->tx_ring[kring->ring_id];
+
+	ENA_RING_MTX_LOCK(ctx.ring);
+	if (unlikely(!ENA_FLAG_ISSET(ENA_FLAG_DEV_UP, ctx.adapter)))
+		goto txsync_end;
+
+	if (unlikely(!ENA_FLAG_ISSET(ENA_FLAG_LINK_UP, ctx.adapter)))
+		goto txsync_end;
+
+	rc = ena_netmap_tx_frames(&ctx);
+	ena_netmap_tx_cleanup(&ctx);
+
+txsync_end:
+	ENA_RING_MTX_UNLOCK(ctx.ring);
+	return (rc);
+}
+
+static int
+ena_netmap_tx_frames(struct ena_netmap_ctx *ctx)
+{
+	struct ena_ring *tx_ring = ctx->ring;
+	int rc = 0;
+
+	ctx->nm_i = ctx->kring->nr_hwcur;
+	ctx->nt = ctx->ring->next_to_use;
+
+	__builtin_prefetch(&ctx->slots[ctx->nm_i]);
+
+	while (ctx->nm_i != ctx->kring->rhead) {
+		if ((rc = ena_netmap_tx_frame(ctx)) != 0) {
+			/*
+			* When there is no empty space in Tx ring, error is
+			* still being returned. It should not be passed to the
+			* netmap, as application knows current ring state from
+			* netmap ring pointers. Returning error there could
+			* cause application to exit, but the Tx ring is commonly
+			* being full.
+			*/
+			if (rc == ENA_COM_NO_MEM)
+				rc = 0;
+			break;
+		}
+		tx_ring->acum_pkts++;
+	}
+
+	/* If any packet was sent... */
+	if (likely(ctx->nm_i != ctx->kring->nr_hwcur)) {
+		wmb();
+		/* ...send the doorbell to the device. */
+		ena_com_write_sq_doorbell(ctx->io_sq);
+		counter_u64_add(ctx->ring->tx_stats.doorbells, 1);
+		tx_ring->acum_pkts = 0;
+
+		ctx->ring->next_to_use = ctx->nt;
+		ctx->kring->nr_hwcur = ctx->nm_i;
+	}
+
+	return (rc);
+}
+
+static int
+ena_netmap_tx_frame(struct ena_netmap_ctx *ctx)
+{
+	struct ena_com_tx_ctx ena_tx_ctx;
+	struct ena_adapter *adapter;
+	struct ena_ring *tx_ring;
+	struct ena_tx_buffer *tx_info;
+	uint16_t req_id;
+	uint16_t header_len;
+	uint16_t packet_len;
+	int nb_hw_desc;
+	int rc;
+	void *push_hdr;
+
+	adapter = ctx->adapter;
+	if (ena_netmap_count_slots(ctx) > adapter->max_tx_sgl_size) {
+		ena_trace(ENA_WARNING, "Too many slots per packet\n");
+		return (EINVAL);
+	}
+
+	tx_ring = ctx->ring;
+
+	req_id = tx_ring->free_tx_ids[ctx->nt];
+	tx_info = &tx_ring->tx_buffer_info[req_id];
+	tx_info->num_of_bufs = 0;
+	tx_info->nm_info.sockets_used = 0;
+
+	rc = ena_netmap_tx_map_slots(ctx, tx_info, &push_hdr, &header_len,
+	    &packet_len);
+	if (unlikely(rc != 0)) {
+		device_printf(adapter->pdev, "Failed to map Tx slot\n");
+		return (rc);
+	}
+
+	bzero(&ena_tx_ctx, sizeof(struct ena_com_tx_ctx));
+	ena_tx_ctx.ena_bufs = tx_info->bufs;
+	ena_tx_ctx.push_header = push_hdr;
+	ena_tx_ctx.num_bufs = tx_info->num_of_bufs;
+	ena_tx_ctx.req_id = req_id;
+	ena_tx_ctx.header_len = header_len;
+
+	/* There are no any offloads, as the netmap doesn't support them */
+
+	if (tx_ring->acum_pkts == DB_THRESHOLD ||
+	    ena_com_is_doorbell_needed(ctx->io_sq, &ena_tx_ctx)) {
+		wmb();
+		ena_com_write_sq_doorbell(ctx->io_sq);
+		counter_u64_add(tx_ring->tx_stats.doorbells, 1);
+		tx_ring->acum_pkts = 0;
+	}
+
+	rc = ena_com_prepare_tx(ctx->io_sq, &ena_tx_ctx, &nb_hw_desc);
+	if (unlikely(rc != 0)) {
+		if (likely(rc == ENA_COM_NO_MEM)) {
+			ena_trace(ENA_NETMAP | ENA_DBG | ENA_TXPTH,
+			    "Tx ring[%d] is out of space\n", tx_ring->que->id);
+		} else {
+			device_printf(adapter->pdev,
+			    "Failed to prepare Tx bufs\n");
+		}
+		counter_u64_add(tx_ring->tx_stats.prepare_ctx_err, 1);
+
+		ena_netmap_unmap_last_socket_chain(ctx, tx_info);
+		return (rc);
+	}
+
+	counter_enter();
+	counter_u64_add_protected(tx_ring->tx_stats.cnt, 1);
+	counter_u64_add_protected(tx_ring->tx_stats.bytes, packet_len);
+	counter_u64_add_protected(adapter->hw_stats.tx_packets, 1);
+	counter_u64_add_protected(adapter->hw_stats.tx_bytes, packet_len);
+	counter_exit();
+
+	tx_info->tx_descs = nb_hw_desc;
+
+	ctx->nt = ENA_TX_RING_IDX_NEXT(ctx->nt, ctx->ring->ring_size);
+
+	for (unsigned int i = 0; i < tx_info->num_of_bufs; i++)
+		bus_dmamap_sync(adapter->tx_buf_tag,
+		   tx_info->nm_info.map_seg[i], BUS_DMASYNC_PREWRITE);
+
+	return (0);
+}
+
+static inline uint16_t
+ena_netmap_count_slots(struct ena_netmap_ctx *ctx)
+{
+	uint16_t slots = 1;
+	uint16_t nm = ctx->nm_i;
+
+	while ((ctx->slots[nm].flags & NS_MOREFRAG) != 0) {
+		slots++;
+		nm = nm_next(nm, ctx->lim);
+	}
+
+	return slots;
+}
+
+static inline uint16_t
+ena_netmap_packet_len(struct netmap_slot *slots, u_int slot_index,
+    uint16_t limit)
+{
+	struct netmap_slot *nm_slot;
+	uint16_t packet_size = 0;
+
+	do {
+		nm_slot = &slots[slot_index];
+		packet_size += nm_slot->len;
+		slot_index = nm_next(slot_index, limit);
+	} while ((nm_slot->flags & NS_MOREFRAG) != 0);
+
+	return packet_size;
+}
+
+static int
+ena_netmap_copy_data(struct netmap_adapter *na, struct netmap_slot *slots,
+    u_int slot_index, uint16_t limit, uint16_t bytes_to_copy, void *destination)
+{
+	struct netmap_slot *nm_slot;
+	void *slot_vaddr;
+	uint16_t packet_size;
+	uint16_t data_amount;
+
+	packet_size = 0;
+	do {
+		nm_slot = &slots[slot_index];
+		slot_vaddr = NMB(na, nm_slot);
+		if (unlikely(slot_vaddr == NULL))
+			return (EINVAL);
+
+		data_amount = min_t(uint16_t, bytes_to_copy, nm_slot->len);
+		memcpy(destination, slot_vaddr, data_amount);
+		bytes_to_copy -= data_amount;
+
+		slot_index = nm_next(slot_index, limit);
+	} while ((nm_slot->flags & NS_MOREFRAG) != 0 && bytes_to_copy > 0);
+
+	return (0);
+}
+
+static int
+ena_netmap_map_single_slot(struct netmap_adapter *na, struct netmap_slot *slot,
+    bus_dma_tag_t dmatag, bus_dmamap_t dmamap, void **vaddr, uint64_t *paddr)
+{
+	int rc;
+
+	*vaddr = PNMB(na, slot, paddr);
+	if (unlikely(vaddr == NULL)) {
+		ena_trace(ENA_ALERT, "Slot address is NULL\n");
+		return (EINVAL);
+	}
+
+	rc = netmap_load_map(na, dmatag, dmamap, *vaddr);
+	if (unlikely(rc != 0)) {
+		ena_trace(ENA_ALERT, "Failed to map slot %d for DMA\n",
+		    slot->buf_idx);
+		return (EINVAL);
+	}
+
+	return (0);
+}
+
+static int
+ena_netmap_tx_map_slots(struct ena_netmap_ctx *ctx,
+    struct ena_tx_buffer *tx_info, void **push_hdr, uint16_t *header_len,
+    uint16_t *packet_len)
+{
+	struct netmap_slot *slot;
+	struct ena_com_buf *ena_buf;
+	struct ena_adapter *adapter;
+	struct ena_ring *tx_ring;
+	struct ena_netmap_tx_info *nm_info;
+	bus_dmamap_t *nm_maps;
+	void *vaddr;
+	uint64_t paddr;
+	uint32_t *nm_buf_idx;
+	uint32_t slot_head_len;
+	uint32_t frag_len;
+	uint32_t remaining_len;
+	uint16_t push_len;
+	uint16_t delta;
+	int rc;
+
+	adapter = ctx->adapter;
+	tx_ring = ctx->ring;
+	ena_buf = tx_info->bufs;
+	nm_info = &tx_info->nm_info;
+	nm_maps = nm_info->map_seg;
+	nm_buf_idx = nm_info->socket_buf_idx;
+	slot = &ctx->slots[ctx->nm_i];
+
+	slot_head_len = slot->len;
+	*packet_len = ena_netmap_packet_len(ctx->slots, ctx->nm_i, ctx->lim);
+	remaining_len = *packet_len;
+	delta = 0;
+
+	__builtin_prefetch(&ctx->slots[ctx->nm_i + 1]);
+	if (tx_ring->tx_mem_queue_type == ENA_ADMIN_PLACEMENT_POLICY_DEV) {
+		/*
+		 * When the device is in LLQ mode, the driver will copy
+		 * the header into the device memory space.
+		 * The ena_com layer assumes that the header is in a linear
+		 * memory space.
+		 * This assumption might be wrong since part of the header
+		 * can be in the fragmented buffers.
+		 * First, check if header fits in the first slot. If not, copy
+		 * it to separate buffer that will be holding linearized data.
+		 */
+		push_len = min_t(uint32_t, *packet_len,
+		    tx_ring->tx_max_header_size);
+		*header_len = push_len;
+		/* If header is in linear space, just point to socket's data. */
+		if (likely(push_len <= slot_head_len)) {
+			*push_hdr = NMB(ctx->na, slot);
+			if (unlikely(push_hdr == NULL)) {
+				device_printf(adapter->pdev,
+				    "Slot vaddress is NULL\n");
+				return (EINVAL);
+			}
+		/*
+		 * Otherwise, copy whole portion of header from multiple slots
+		 * to intermediate buffer.
+		 */
+		} else {
+			rc = ena_netmap_copy_data(ctx->na,
+			    ctx->slots,
+			    ctx->nm_i,
+			    ctx->lim,
+			    push_len,
+			    tx_ring->push_buf_intermediate_buf);
+			if (unlikely(rc)) {
+				device_printf(adapter->pdev,
+				    "Failed to copy data from slots to push_buf\n");
+				return (EINVAL);
+			}
+
+			*push_hdr = tx_ring->push_buf_intermediate_buf;
+			counter_u64_add(tx_ring->tx_stats.llq_buffer_copy, 1);
+
+			delta = push_len - slot_head_len;
+		}
+
+		ena_trace(ENA_NETMAP | ENA_DBG | ENA_TXPTH,
+		    "slot: %d header_buf->vaddr: %p push_len: %d\n",
+		    slot->buf_idx, *push_hdr, push_len);
+
+		/*
+		* If header was in linear memory space, map for the dma rest of the data
+		* in the first mbuf of the mbuf chain.
+		*/
+		if (slot_head_len > push_len) {
+			rc = ena_netmap_map_single_slot(ctx->na,
+			    slot,
+			    adapter->tx_buf_tag,
+			    *nm_maps,
+			    &vaddr,
+			    &paddr);
+			if (unlikely(rc != 0)) {
+				device_printf(adapter->pdev,
+				    "DMA mapping error\n");
+				return (rc);
+			}
+			nm_maps++;
+
+			ena_buf->paddr = paddr + push_len;
+			ena_buf->len = slot->len - push_len;
+			ena_buf++;
+
+			tx_info->num_of_bufs++;
+		}
+
+		remaining_len -= slot->len;
+
+		/* Save buf idx before advancing */
+		*nm_buf_idx = slot->buf_idx;
+		nm_buf_idx++;
+		slot->buf_idx = 0;
+
+		/* Advance to the next socket */
+		ctx->nm_i = nm_next(ctx->nm_i, ctx->lim);
+		slot = &ctx->slots[ctx->nm_i];
+		nm_info->sockets_used++;
+
+		/*
+		 * If header is in non linear space (delta > 0), then skip mbufs
+		 * containing header and map the last one containing both header
+		 * and the packet data.
+		 * The first segment is already counted in.
+		 */
+		while (delta > 0) {
+			__builtin_prefetch(&ctx->slots[ctx->nm_i + 1]);
+			frag_len = slot->len;
+
+			/*
+			 * If whole segment contains header just move to the
+			 * next one and reduce delta.
+			 */
+			if (unlikely(delta >= frag_len)) {
+				delta -= frag_len;
+			} else {
+				/*
+				 * Map the data and then assign it with the
+				 * offsets
+				 */
+				rc = ena_netmap_map_single_slot(ctx->na,
+				    slot,
+				    adapter->tx_buf_tag,
+				    *nm_maps,
+				    &vaddr,
+				    &paddr);
+				if (unlikely(rc != 0)) {
+					device_printf(adapter->pdev,
+					    "DMA mapping error\n");
+					goto error_map;
+				}
+				nm_maps++;
+
+				ena_buf->paddr = paddr + delta;
+				ena_buf->len = slot->len - delta;
+				ena_buf++;
+
+				tx_info->num_of_bufs++;
+				delta = 0;
+			}
+
+			remaining_len -= slot->len;
+
+			/* Save buf idx before advancing */
+			*nm_buf_idx = slot->buf_idx;
+			nm_buf_idx++;
+			slot->buf_idx = 0;
+
+			/* Advance to the next socket */
+			ctx->nm_i = nm_next(ctx->nm_i, ctx->lim);
+			slot = &ctx->slots[ctx->nm_i];
+			nm_info->sockets_used++;
+		}
+	} else {
+		*push_hdr = NULL;
+		/*
+		* header_len is just a hint for the device. Because netmap is
+		* not giving us any information about packet header length and
+		* it is not guaranteed that all packet headers will be in the
+		* 1st slot, setting header_len to 0 is making the device ignore
+		* this value and resolve header on it's own.
+		*/
+		*header_len = 0;
+	}
+
+	/* Map all remaining data (regular routine for non-LLQ mode) */
+	while (remaining_len > 0) {
+		__builtin_prefetch(&ctx->slots[ctx->nm_i + 1]);
+
+		rc = ena_netmap_map_single_slot(ctx->na,
+			    slot,
+			    adapter->tx_buf_tag,
+			    *nm_maps,
+			    &vaddr,
+			    &paddr);
+		if (unlikely(rc != 0)) {
+			device_printf(adapter->pdev,
+			    "DMA mapping error\n");
+			goto error_map;
+		}
+		nm_maps++;
+
+		ena_buf->paddr = paddr;
+		ena_buf->len = slot->len;
+		ena_buf++;
+
+		tx_info->num_of_bufs++;
+
+		remaining_len -= slot->len;
+
+		/* Save buf idx before advancing */
+		*nm_buf_idx = slot->buf_idx;
+		nm_buf_idx++;
+		slot->buf_idx = 0;
+
+		/* Advance to the next socket */
+		ctx->nm_i = nm_next(ctx->nm_i, ctx->lim);
+		slot = &ctx->slots[ctx->nm_i];
+		nm_info->sockets_used++;
+	}
+
+	return (0);
+
+error_map:
+	ena_netmap_unmap_last_socket_chain(ctx, tx_info);
+
+	return (rc);
+}
+
+static void
+ena_netmap_unmap_last_socket_chain(struct ena_netmap_ctx *ctx,
+    struct ena_tx_buffer *tx_info)
+{
+	struct ena_netmap_tx_info *nm_info;
+	int n;
+
+	nm_info = &tx_info->nm_info;
+
+	/**
+	 * As the used sockets must not be equal to the buffers used in the LLQ
+	 * mode, they must be treated separately.
+	 * First, unmap the DMA maps.
+	 */
+	n = tx_info->num_of_bufs;
+	while (n--) {
+		netmap_unload_map(ctx->na, ctx->adapter->tx_buf_tag,
+		    nm_info->map_seg[n]);
+	}
+	tx_info->num_of_bufs = 0;
+
+	/* Next, retain the sockets back to the userspace */
+	n = nm_info->sockets_used;
+	while (n--) {
+		ctx->slots[ctx->nm_i].buf_idx = nm_info->socket_buf_idx[n];
+		ctx->slots[ctx->nm_i].flags = NS_BUF_CHANGED;
+		nm_info->socket_buf_idx[n] = 0;
+		ctx->nm_i = nm_prev(ctx->nm_i, ctx->lim);
+	}
+	nm_info->sockets_used = 0;
+}
+
+static void
+ena_netmap_tx_cleanup(struct ena_netmap_ctx *ctx)
+{
+	uint16_t req_id;
+	uint16_t total_tx_descs = 0;
+
+	ctx->nm_i = ctx->kring->nr_hwtail;
+	ctx->nt = ctx->ring->next_to_clean;
+
+	/* Reclaim buffers for completed transmissions */
+	while (ena_com_tx_comp_req_id_get(ctx->io_cq, &req_id) >= 0) {
+		if (validate_tx_req_id(ctx->ring, req_id) != 0)
+			break;
+		total_tx_descs += ena_netmap_tx_clean_one(ctx, req_id);
+	}
+
+	ctx->kring->nr_hwtail = ctx->nm_i;
+
+	if (total_tx_descs > 0) {
+		/* acknowledge completion of sent packets */
+		ctx->ring->next_to_clean = ctx->nt;
+		ena_com_comp_ack(ctx->ring->ena_com_io_sq, total_tx_descs);
+		ena_com_update_dev_comp_head(ctx->ring->ena_com_io_cq);
+	}
+}
+
+static uint16_t
+ena_netmap_tx_clean_one(struct ena_netmap_ctx *ctx, uint16_t req_id)
+{
+	struct ena_tx_buffer *tx_info;
+	struct ena_netmap_tx_info *nm_info;
+	int n;
+
+	tx_info = &ctx->ring->tx_buffer_info[req_id];
+	nm_info = &tx_info->nm_info;
+
+	/**
+	 * As the used sockets must not be equal to the buffers used in the LLQ
+	 * mode, they must be treated separately.
+	 * First, unmap the DMA maps.
+	 */
+	n = tx_info->num_of_bufs;
+	for (n = 0; n < tx_info->num_of_bufs; n++) {
+		netmap_unload_map(ctx->na, ctx->adapter->tx_buf_tag,
+		    nm_info->map_seg[n]);
+	}
+	tx_info->num_of_bufs = 0;
+
+	/* Next, retain the sockets back to the userspace */
+	for (n = 0; n < nm_info->sockets_used; n++) {
+		ctx->nm_i = nm_next(ctx->nm_i, ctx->lim);
+		ENA_ASSERT(ctx->slots[ctx->nm_i].buf_idx == 0,
+		    "Tx idx is not 0.\n");
+		ctx->slots[ctx->nm_i].buf_idx = nm_info->socket_buf_idx[n];
+		ctx->slots[ctx->nm_i].flags = NS_BUF_CHANGED;
+		nm_info->socket_buf_idx[n] = 0;
+	}
+	nm_info->sockets_used = 0;
+
+	ctx->ring->free_tx_ids[ctx->nt] = req_id;
+	ctx->nt = ENA_TX_RING_IDX_NEXT(ctx->nt, ctx->lim);
+
+	return tx_info->tx_descs;
+}
+
+static inline int
+validate_tx_req_id(struct ena_ring *tx_ring, uint16_t req_id)
+{
+	struct ena_adapter *adapter = tx_ring->adapter;
+
+	if (likely(req_id < tx_ring->ring_size))
+		return (0);
+
+	ena_trace(ENA_WARNING, "Invalid req_id: %hu\n", req_id);
+	counter_u64_add(tx_ring->tx_stats.bad_req_id, 1);
+
+	adapter->reset_reason = ENA_REGS_RESET_INV_TX_REQ_ID;
+	ENA_FLAG_SET_ATOMIC(ENA_FLAG_TRIGGER_RESET, adapter);
+
+	return (EFAULT);
+}
+
+static int
+ena_netmap_rxsync(struct netmap_kring *kring, int flags)
+{
+	struct ena_netmap_ctx ctx;
+	int rc;
+
+	ena_netmap_fill_ctx(kring, &ctx, ENA_IO_RXQ_IDX(kring->ring_id));
+	ctx.ring = &ctx.adapter->rx_ring[kring->ring_id];
+
+	if (ctx.kring->rhead > ctx.lim) {
+		/* Probably not needed to release slots from RX ring. */
+		return (netmap_ring_reinit(ctx.kring));
+	}
+
+	if (unlikely((if_getdrvflags(ctx.na->ifp) & IFF_DRV_RUNNING) == 0))
+		return (0);
+
+	if (unlikely(!ENA_FLAG_ISSET(ENA_FLAG_LINK_UP, ctx.adapter)))
+		return (0);
+
+	if ((rc = ena_netmap_rx_frames(&ctx)) != 0)
+		return (rc);
+
+	ena_netmap_rx_cleanup(&ctx);
+
+	return (0);
+}
+
+static inline int
+ena_netmap_rx_frames(struct ena_netmap_ctx *ctx)
+{
+	int rc = 0;
+	int frames_counter = 0;
+
+	ctx->nt = ctx->ring->next_to_clean;
+	ctx->nm_i = ctx->kring->nr_hwtail;
+
+	while((rc = ena_netmap_rx_frame(ctx)) == ENA_NETMAP_MORE_FRAMES) {
+		frames_counter++;
+		/* In case of multiple frames, it is not an error. */
+		rc = 0;
+		if (frames_counter > ENA_MAX_FRAMES) {
+			device_printf(ctx->adapter->pdev,
+				"Driver is stuck in the Rx loop\n");
+			break;
+		}
+	};
+
+	ctx->kring->nr_hwtail = ctx->nm_i;
+	ctx->kring->nr_kflags &= ~NKR_PENDINTR;
+	ctx->ring->next_to_clean = ctx->nt;
+
+	return (rc);
+}
+
+static inline int
+ena_netmap_rx_frame(struct ena_netmap_ctx *ctx)
+{
+	struct ena_com_rx_ctx ena_rx_ctx;
+	int rc, len = 0;
+	uint16_t buf, nm;
+
+	ena_rx_ctx.ena_bufs = ctx->ring->ena_bufs;
+	ena_rx_ctx.max_bufs = ctx->adapter->max_rx_sgl_size;
+	bus_dmamap_sync(ctx->io_cq->cdesc_addr.mem_handle.tag,
+	    ctx->io_cq->cdesc_addr.mem_handle.map, BUS_DMASYNC_POSTREAD);
+
+	rc = ena_com_rx_pkt(ctx->io_cq, ctx->io_sq, &ena_rx_ctx);
+	if (unlikely(rc != 0)) {
+		ena_trace(ENA_ALERT, "Too many desc from the device.\n");
+		counter_u64_add(ctx->ring->rx_stats.bad_desc_num, 1);
+		ctx->adapter->reset_reason = ENA_REGS_RESET_TOO_MANY_RX_DESCS;
+		ENA_FLAG_SET_ATOMIC(ENA_FLAG_TRIGGER_RESET, ctx->adapter);
+		return (rc);
+	}
+	if (unlikely(ena_rx_ctx.descs == 0))
+		return (ENA_NETMAP_NO_MORE_FRAMES);
+
+        ena_trace(ENA_NETMAP | ENA_DBG, "Rx: q %d got packet from ena. descs #:"
+	    " %d l3 proto %d l4 proto %d hash: %x\n", ctx->ring->qid,
+	    ena_rx_ctx.descs, ena_rx_ctx.l3_proto, ena_rx_ctx.l4_proto,
+	    ena_rx_ctx.hash);
+
+	for (buf = 0; buf < ena_rx_ctx.descs; buf++)
+		if ((rc = ena_netmap_rx_load_desc(ctx, buf, &len)) != 0)
+			break;
+	/*
+	 * ena_netmap_rx_load_desc doesn't know the number of descriptors.
+	 * It just set flag NS_MOREFRAG to all slots, then here flag of
+	 * last slot is cleared.
+	 */
+	ctx->slots[nm_prev(ctx->nm_i, ctx->lim)].flags = NS_BUF_CHANGED;
+
+	if (rc != 0) {
+		goto rx_clear_desc;
+	}
+
+	bus_dmamap_sync(ctx->io_cq->cdesc_addr.mem_handle.tag,
+            ctx->io_cq->cdesc_addr.mem_handle.map, BUS_DMASYNC_PREREAD);
+
+	counter_enter();
+	counter_u64_add_protected(ctx->ring->rx_stats.bytes, len);
+	counter_u64_add_protected(ctx->adapter->hw_stats.rx_bytes, len);
+	counter_u64_add_protected(ctx->ring->rx_stats.cnt, 1);
+	counter_u64_add_protected(ctx->adapter->hw_stats.rx_packets, 1);
+	counter_exit();
+
+	return (ENA_NETMAP_MORE_FRAMES);
+
+rx_clear_desc:
+	nm = ctx->nm_i;
+
+	/* Remove failed packet from ring */
+	while(buf--) {
+		ctx->slots[nm].flags = 0;
+		ctx->slots[nm].len = 0;
+		nm = nm_prev(nm, ctx->lim);
+	}
+
+	return (rc);
+}
+
+static inline int
+ena_netmap_rx_load_desc(struct ena_netmap_ctx *ctx, uint16_t buf, int *len)
+{
+	struct ena_rx_buffer *rx_info;
+	uint16_t req_id;
+	int rc;
+
+	req_id = ctx->ring->ena_bufs[buf].req_id;
+	rc = validate_rx_req_id(ctx->ring, req_id);
+	if (unlikely(rc != 0))
+		return (rc);
+
+	rx_info = &ctx->ring->rx_buffer_info[req_id];
+	bus_dmamap_sync(ctx->adapter->rx_buf_tag, rx_info->map,
+	    BUS_DMASYNC_POSTREAD);
+	netmap_unload_map(ctx->na, ctx->adapter->rx_buf_tag, rx_info->map);
+
+	ENA_ASSERT(ctx->slots[ctx->nm_i].buf_idx == 0, "Rx idx is not 0.\n");
+
+	ctx->slots[ctx->nm_i].buf_idx = rx_info->netmap_buf_idx;
+	rx_info->netmap_buf_idx = 0;
+	/*
+	 * Set NS_MOREFRAG to all slots.
+	 * Then ena_netmap_rx_frame clears it from last one.
+	 */
+	ctx->slots[ctx->nm_i].flags |= NS_MOREFRAG | NS_BUF_CHANGED;
+	ctx->slots[ctx->nm_i].len = ctx->ring->ena_bufs[buf].len;
+	*len += ctx->slots[ctx->nm_i].len;
+	ctx->ring->free_rx_ids[ctx->nt] = req_id;
+	ena_trace(ENA_DBG, "rx_info %p, buf_idx %d, paddr %jx, nm: %d\n",
+	    rx_info, ctx->slots[ctx->nm_i].buf_idx,
+	    (uintmax_t)rx_info->ena_buf.paddr, ctx->nm_i);
+
+	ctx->nm_i = nm_next(ctx->nm_i, ctx->lim);
+	ctx->nt = ENA_RX_RING_IDX_NEXT(ctx->nt, ctx->ring->ring_size);
+
+	return (0);
+}
+
+static inline void
+ena_netmap_rx_cleanup(struct ena_netmap_ctx *ctx)
+{
+	int refill_required;
+
+	refill_required = ctx->kring->rhead - ctx->kring->nr_hwcur;
+	if (ctx->kring->nr_hwcur != ctx->kring->nr_hwtail)
+		refill_required -= 1;
+
+	if (refill_required == 0)
+		return;
+	else if (refill_required < 0)
+		refill_required += ctx->kring->nkr_num_slots;
+
+	ena_refill_rx_bufs(ctx->ring, refill_required);
+}
+
+static inline void
+ena_netmap_fill_ctx(struct netmap_kring *kring, struct ena_netmap_ctx *ctx,
+    uint16_t ena_qid)
+{
+	ctx->kring = kring;
+	ctx->na = kring->na;
+	ctx->adapter = ctx->na->ifp->if_softc;
+	ctx->lim = kring->nkr_num_slots - 1;
+	ctx->io_cq = &ctx->adapter->ena_dev->io_cq_queues[ena_qid];
+	ctx->io_sq = &ctx->adapter->ena_dev->io_sq_queues[ena_qid];
+	ctx->slots = kring->ring->slot;
+}
+
+void
+ena_netmap_unload(struct ena_adapter *adapter, bus_dmamap_t map)
+{
+	struct netmap_adapter *na = NA(adapter->ifp);
+
+	netmap_unload_map(na, adapter->tx_buf_tag, map);
+}
+
+#endif /* DEV_NETMAP */

--- a/kernel/fbsd/ena/ena_netmap.h
+++ b/kernel/fbsd/ena/ena_netmap.h
@@ -1,0 +1,60 @@
+/*-
+ * BSD LICENSE
+ *
+ * Copyright (c) 2015-2019 Amazon.com, Inc. or its affiliates.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ * $FreeBSD$
+ *
+ */
+
+#ifndef _ENA_NETMAP_H_
+#define _ENA_NETMAP_H_
+
+/* Undef (un)likely as they are defined in netmap_kern.h */
+#ifdef likely
+#undef likely
+#endif /* likely */
+#ifdef unlikely
+#undef unlikely
+#endif /* unlikely */
+
+#include <net/netmap.h>
+#include <sys/selinfo.h>
+#include <dev/netmap/netmap_kern.h>
+
+int	ena_netmap_attach(struct ena_adapter *);
+int	ena_netmap_alloc_rx_slot(struct ena_adapter *, struct ena_ring *,
+    struct ena_rx_buffer *);
+void	ena_netmap_free_rx_slot(struct ena_adapter *, struct ena_ring *,
+    struct ena_rx_buffer *);
+bool	ena_rx_ring_in_netmap(struct ena_adapter *, int);
+bool	ena_tx_ring_in_netmap(struct ena_adapter *, int);
+void	ena_netmap_reset_rx_ring(struct ena_adapter *, int);
+void	ena_netmap_reset_tx_ring(struct ena_adapter *, int);
+void	ena_netmap_unload(struct ena_adapter *, bus_dmamap_t);
+
+#endif /* _ENA_NETMAP_H_ */


### PR DESCRIPTION
Changes since last release (v2.0.0)

**New Features**
* Add netmap support.
* Add LLQ support for the aarch64 by enabling WC.

**Bug Fixes**
* Fix infinite missing keep alive reset loop in case the reset routine
  takes too long because of the host being overloaded.

**Minor Changes**
* Split controller and datapath code into separate files.

Signed-off-by: Michal Krawczyk <mk@semihalf.com>