### PR TITLE
Backport of the ENA patches from 19.08 and 19.05

### DIFF
--- a/userspace/dpdk/16.04/0001-Backport-ENA-PMD-to-v16.04.patch
+++ b/userspace/dpdk/16.04/0001-Backport-ENA-PMD-to-v16.04.patch
@@ -1,7 +1,7 @@
 From 65a31061fe33969bfc2dc73862d5446f0327041c Mon Sep 17 00:00:00 2001
 From: Michal Krawczyk <mk@semihalf.com>
 Date: Mon, 4 Sep 2017 14:46:32 +0200
-Subject: [PATCH 01/10] Backport ENA PMD to v16.04
+Subject: [PATCH 01/14] Backport ENA PMD to v16.04
 
 The ENA PMD was backported from the commit:
 222555480a7f9979d10faa9bb8b9773b0e1aa058
@@ -13,17 +13,17 @@ net/ena: fix cleanup of the Tx bufs
 
 net/ena: add memory initialization for the allocation macros
 ---
- drivers/net/ena/Makefile                        |   5 -
- drivers/net/ena/base/ena_com.c                  | 276 ++++++++-------
- drivers/net/ena/base/ena_com.h                  |  82 +++--
- drivers/net/ena/base/ena_defs/ena_admin_defs.h  | 107 +-----
- drivers/net/ena/base/ena_defs/ena_eth_io_defs.h | 436 ++++++-----------------
- drivers/net/ena/base/ena_defs/ena_gen_info.h    |   4 +-
- drivers/net/ena/base/ena_eth_com.c              |  32 +-
- drivers/net/ena/base/ena_eth_com.h              |  14 +
- drivers/net/ena/base/ena_plat_dpdk.h            |  54 ++-
- drivers/net/ena/ena_ethdev.c                    | 448 +++++++++++++++++++-----
- drivers/net/ena/ena_ethdev.h                    |  63 ++--
+ drivers/net/ena/Makefile                      |   5 -
+ drivers/net/ena/base/ena_com.c                | 276 +++++------
+ drivers/net/ena/base/ena_com.h                |  82 ++--
+ .../net/ena/base/ena_defs/ena_admin_defs.h    | 107 +----
+ .../net/ena/base/ena_defs/ena_eth_io_defs.h   | 436 +++++------------
+ drivers/net/ena/base/ena_defs/ena_gen_info.h  |   4 +-
+ drivers/net/ena/base/ena_eth_com.c            |  32 +-
+ drivers/net/ena/base/ena_eth_com.h            |  14 +
+ drivers/net/ena/base/ena_plat_dpdk.h          |  54 ++-
+ drivers/net/ena/ena_ethdev.c                  | 448 ++++++++++++++----
+ drivers/net/ena/ena_ethdev.h                  |  63 ++-
  11 files changed, 793 insertions(+), 728 deletions(-)
 
 diff --git a/drivers/net/ena/Makefile b/drivers/net/ena/Makefile
@@ -3011,5 +3011,5 @@ index ba6f01e66..dc3080ffd 100644
  	int id_number;
  	char name[ENA_NAME_MAX_LEN];
 -- 
-2.14.1
+2.20.1
 

--- a/userspace/dpdk/16.04/0002-net-ena-do-not-set-Tx-L4-offloads-in-Rx-path.patch
+++ b/userspace/dpdk/16.04/0002-net-ena-do-not-set-Tx-L4-offloads-in-Rx-path.patch
@@ -1,7 +1,7 @@
 From 3941b2982c75bd966ab918e429f76acef8eb3a0e Mon Sep 17 00:00:00 2001
 From: Rafal Kozik <rk@semihalf.com>
 Date: Tue, 9 Jan 2018 16:19:08 +0100
-Subject: [PATCH 02/10] net/ena: do not set Tx L4 offloads in Rx path
+Subject: [PATCH 02/14] net/ena: do not set Tx L4 offloads in Rx path
 
 [ upstream commit fd617795679019c7aea5ab1e8c85db02cf53f169 ]
 
@@ -14,6 +14,7 @@ correct.
 Fixes: 1173fca25af9 ("ena: add polling-mode driver")
 Cc: stable@dpdk.org
 
+Change-Id: I6d643e4c87fa8788ff98d84c9c0931393c1abf12
 Reported-by: Matthew Smith <mgsmith@netgate.com>
 Signed-off-by: Rafal Kozik <rk@semihalf.com>
 Signed-off-by: Michal Krawczyk <mk@semihalf.com>
@@ -56,5 +57,5 @@ index 8823c51cf..9d677b8d7 100644
  
  static inline void ena_tx_mbuf_prepare(struct rte_mbuf *mbuf,
 -- 
-2.14.1
+2.20.1
 

--- a/userspace/dpdk/16.04/0003-net-ena-check-pointer-before-memset.patch
+++ b/userspace/dpdk/16.04/0003-net-ena-check-pointer-before-memset.patch
@@ -1,7 +1,7 @@
 From 262082943426689695cb5d4688abceef809f0dab Mon Sep 17 00:00:00 2001
 From: Rafal Kozik <rk@semihalf.com>
 Date: Thu, 7 Jun 2018 11:43:18 +0200
-Subject: [PATCH 03/10] net/ena: check pointer before memset
+Subject: [PATCH 03/14] net/ena: check pointer before memset
 
 [ upstream commit 46916aa17d4b2007df8c0454f99ba0ca8b8cb93b ]
 
@@ -11,6 +11,7 @@ Using memset on NULL pointer cause segfault.
 Fixes: 9ba7981ec992 ("ena: add communication layer for DPDK")
 Cc: stable@dpdk.org
 
+Change-Id: I7f7d1150234fd49312d9104d9603752ee4a3a0c8
 Signed-off-by: Rafal Kozik <rk@semihalf.com>
 Acked-by: Michal Krawczyk <mk@semihalf.com>
 ---
@@ -59,5 +60,5 @@ index a812d75e2..cc69b3372 100644
  
  #define ENA_MEM_ALLOC_NODE(dmadev, size, virt, node, dev_node) \
 -- 
-2.14.1
+2.20.1
 

--- a/userspace/dpdk/16.04/0004-net-ena-change-memory-type.patch
+++ b/userspace/dpdk/16.04/0004-net-ena-change-memory-type.patch
@@ -1,7 +1,7 @@
 From db52b57f5e85c103a254cf1f055dbd641a316881 Mon Sep 17 00:00:00 2001
 From: Rafal Kozik <rk@semihalf.com>
 Date: Thu, 7 Jun 2018 11:43:19 +0200
-Subject: [PATCH 04/10] net/ena: change memory type
+Subject: [PATCH 04/14] net/ena: change memory type
 
 [ upstream commit 9f32c7e7e6ce58ab772913f54f8328c1c0186a17 ]
 
@@ -14,6 +14,7 @@ To avoid both issue use rte_zmalloc_socket.
 Fixes: 3d3edc265fc8 ("net/ena: make coherent memory allocation NUMA-aware")
 Cc: stable@dpdk.org
 
+Change-Id: I09427bfc0d3b7f90771c5a7be16aef3b95bd9069
 Signed-off-by: Rafal Kozik <rk@semihalf.com>
 Acked-by: Michal Krawczyk <mk@semihalf.com>
 ---
@@ -41,5 +42,5 @@ index cc69b3372..ff873e807 100644
  
  #define ENA_MEM_ALLOC(dmadev, size) rte_zmalloc(NULL, size, 1)
 -- 
-2.14.1
+2.20.1
 

--- a/userspace/dpdk/16.04/0005-net-ena-fix-GENMASK_ULL-macro.patch
+++ b/userspace/dpdk/16.04/0005-net-ena-fix-GENMASK_ULL-macro.patch
@@ -1,7 +1,7 @@
 From 0bdbbc2dd91c97c89fa5ca57e37013a4f204693c Mon Sep 17 00:00:00 2001
 From: Rafal Kozik <rk@semihalf.com>
 Date: Thu, 7 Jun 2018 11:43:20 +0200
-Subject: [PATCH 05/10] net/ena: fix GENMASK_ULL macro
+Subject: [PATCH 05/14] net/ena: fix GENMASK_ULL macro
 
 [ upstream commit 7544aee8d0b4ae0262b1ba7e1539cf8171664df7 ]
 
@@ -12,6 +12,7 @@ is undefined operation and failed on some platforms.
 Fixes: 9ba7981ec992 ("ena: add communication layer for DPDK")
 Cc: stable@dpdk.org
 
+Change-Id: I2094d149a9ff038824ebdff734b2e47bcb0f003f
 Signed-off-by: Rafal Kozik <rk@semihalf.com>
 Acked-by: Michal Krawczyk <mk@semihalf.com>
 ---
@@ -38,5 +39,5 @@ index ff873e807..791b44ff7 100644
  #ifdef RTE_LIBRTE_ENA_COM_DEBUG
  #define ena_trc_dbg(format, arg...)					\
 -- 
-2.14.1
+2.20.1
 

--- a/userspace/dpdk/16.04/0006-net-ena-set-link-speed-as-none.patch
+++ b/userspace/dpdk/16.04/0006-net-ena-set-link-speed-as-none.patch
@@ -1,7 +1,7 @@
 From 36c229d1eeb16670c7b3cc219cbe7287554e7738 Mon Sep 17 00:00:00 2001
 From: Rafal Kozik <rk@semihalf.com>
 Date: Thu, 7 Jun 2018 11:43:22 +0200
-Subject: [PATCH 06/10] net/ena: set link speed as none
+Subject: [PATCH 06/14] net/ena: set link speed as none
 
 [ upstream commit 41e59028dd8ab2038a7655c6fc3098222661aa53 ]
 
@@ -13,6 +13,7 @@ rely on this value when using ENA PMD.
 Fixes: 1173fca25af9 ("ena: add polling-mode driver")
 Cc: stable@dpdk.org
 
+Change-Id: I046f53eb179ba5171c687038820045affee833f3
 Signed-off-by: Rafal Kozik <rk@semihalf.com>
 Acked-by: Michal Krawczyk <mk@semihalf.com>
 ---
@@ -33,5 +34,5 @@ index 9d677b8d7..98848e935 100644
  
  	return 0;
 -- 
-2.14.1
+2.20.1
 

--- a/userspace/dpdk/16.04/0007-net-ena-fix-SIGFPE-with-0-Rx-queue.patch
+++ b/userspace/dpdk/16.04/0007-net-ena-fix-SIGFPE-with-0-Rx-queue.patch
@@ -1,7 +1,7 @@
 From f85679db3886449cdc79d112fbfb8170b256cf8a Mon Sep 17 00:00:00 2001
 From: Daria Kolistratova <daria.kolistratova@intel.com>
 Date: Tue, 26 Jun 2018 18:38:56 +0100
-Subject: [PATCH 07/10] net/ena: fix SIGFPE with 0 Rx queue
+Subject: [PATCH 07/14] net/ena: fix SIGFPE with 0 Rx queue
 
 [ upstream commit 361913ad6f8c05fc541fe4bfdae3b0dc095ae3af ]
 
@@ -11,6 +11,7 @@ It happens when the application is also requesting ETH_MQ_RX_RSS_FLAG
 in the rte_dev->data->dev_conf.rxmode.mq_mode.
 Fixed adding zero rx queues check.
 
+Change-Id: I04fff738df0134172be5443cdc1af3a3b35a2c32
 Signed-off-by: Daria Kolistratova <daria.kolistratova@intel.com>
 Acked-by: Michal Krawczyk <mk@semihalf.com>
 ---
@@ -31,5 +32,5 @@ index 98848e935..3a257a9e5 100644
  		if (rc)
  			return rc;
 -- 
-2.14.1
+2.20.1
 

--- a/userspace/dpdk/16.04/0008-net-ena-fix-passing-RSS-hash-to-mbuf.patch
+++ b/userspace/dpdk/16.04/0008-net-ena-fix-passing-RSS-hash-to-mbuf.patch
@@ -1,7 +1,7 @@
 From f32b3ec7c7dec3683b1cf2cd2e8de038d2ef3585 Mon Sep 17 00:00:00 2001
 From: Stewart Allen <allenste@amazon.com>
 Date: Thu, 25 Oct 2018 19:59:22 +0200
-Subject: [PATCH 08/10] net/ena: fix passing RSS hash to mbuf
+Subject: [PATCH 08/14] net/ena: fix passing RSS hash to mbuf
 
 [ upstream commit e5df9f33db00eb9d322abaefff30da74fd0e625d ]
 
@@ -11,6 +11,7 @@ from the device. Now, the RSS hash from the Rx descriptor is being set.
 Fixes: 1173fca25af9 ("ena: add polling-mode driver")
 Cc: stable@dpdk.org
 
+Change-Id: Iea37e68a1d685800166fa3733f150ad79a2e0b25
 Signed-off-by: Stewart Allen <allenste@amazon.com>
 Acked-by: Michal Krawczyk <mk@semihalf.com>
 ---
@@ -31,5 +32,5 @@ index 3a257a9e5..24e319764 100644
  		/* pass to DPDK application head mbuf */
  		rx_pkts[recv_idx] = mbuf_head;
 -- 
-2.14.1
+2.20.1
 

--- a/userspace/dpdk/16.04/0009-net-ena-add-supported-RSS-offloads-types.patch
+++ b/userspace/dpdk/16.04/0009-net-ena-add-supported-RSS-offloads-types.patch
@@ -1,7 +1,7 @@
 From 94a6f13df8511a16ccc97b79e83e4bc719fdff44 Mon Sep 17 00:00:00 2001
 From: Rafal Kozik <rk@semihalf.com>
 Date: Fri, 14 Dec 2018 14:18:38 +0100
-Subject: [PATCH 09/10] net/ena: add supported RSS offloads types
+Subject: [PATCH 09/14] net/ena: add supported RSS offloads types
 
 [ upstream commit b01ead202beb45346d7daeb2f2b1a608006af644 ]
 
@@ -12,6 +12,7 @@ missing information was added.
 Fixes: 1173fca25af9 ("ena: add polling-mode driver")
 Cc: stable@dpdk.org
 
+Change-Id: I6326ed866bc47a5e6780669f446fc96fc3b0032f
 Signed-off-by: Rafal Kozik <rk@semihalf.com>
 Acked-by: Michal Krawczyk <mk@semihalf.com>
 ---
@@ -33,5 +34,5 @@ index 24e319764..e355c4c2f 100644
  	dev_info->max_rx_pktlen  = adapter->max_mtu;
  	dev_info->max_mac_addrs = 1;
 -- 
-2.14.1
+2.20.1
 

--- a/userspace/dpdk/16.04/0010-net-ena-fix-dev-init-with-multi-process.patch
+++ b/userspace/dpdk/16.04/0010-net-ena-fix-dev-init-with-multi-process.patch
@@ -1,7 +1,7 @@
 From 0904bb2a43de0893a768900a760170f3a15cb5ca Mon Sep 17 00:00:00 2001
 From: Michal Krawczyk <mk@semihalf.com>
 Date: Fri, 25 Jan 2019 09:10:25 +0100
-Subject: [PATCH 10/10] net/ena: fix dev init with multi-process
+Subject: [PATCH 10/14] net/ena: fix dev init with multi-process
 
 [ upstream commit fd9768905870856a2340266d25f8c0100dfccfff ]
 
@@ -15,6 +15,7 @@ main process.
 Fixes: 1173fca25af9 ("ena: add polling-mode driver")
 Cc: stable@dpdk.org
 
+Change-Id: Ifd276868de27e321d1ae7083ce746d24533d06b5
 Signed-off-by: Michal Krawczyk <mk@semihalf.com>
 ---
  drivers/net/ena/ena_ethdev.c | 10 +++++-----
@@ -49,5 +50,5 @@ index e355c4c2f..dd0a9a27b 100644
  	adapter->pdev = pci_dev;
  
 -- 
-2.14.1
+2.20.1
 

--- a/userspace/dpdk/16.04/0011-net-ena-get-device-info-statically.patch
+++ b/userspace/dpdk/16.04/0011-net-ena-get-device-info-statically.patch
@@ -1,0 +1,114 @@
+From 647a39dd8e973f48fec3e54e3c55bcffeadb5a31 Mon Sep 17 00:00:00 2001
+From: Michal Krawczyk <mk@semihalf.com>
+Date: Fri, 15 Feb 2019 09:36:39 +0100
+Subject: [PATCH 11/14] net/ena: get device info statically
+
+[ upstream commit 117ba4a60488a0f96a5737f38ddba6d0f9a728b6 ]
+
+Whenever the app is calling rte_eth_dev_info_get(), it shouldn't use the
+admin command. It was causing problems, if it was called from the
+secondary process - the main process was crashing, and the secondary app
+wasn't getting any result, as the admin request couldn't be processed by
+the process which was requesting the data.
+
+To fix that, the data is being written to the adapter structure during
+device initialization routine.
+
+Change-Id: I94f61f51223725602f70ac9795acf02b7b014984
+Signed-off-by: Michal Krawczyk <mk@semihalf.com>
+---
+ drivers/net/ena/ena_ethdev.c | 29 +++++++++++------------------
+ drivers/net/ena/ena_ethdev.h |  8 +++++++-
+ 2 files changed, 18 insertions(+), 19 deletions(-)
+
+diff --git a/drivers/net/ena/ena_ethdev.c b/drivers/net/ena/ena_ethdev.c
+index dd0a9a27b..6c986cfc0 100644
+--- a/drivers/net/ena/ena_ethdev.c
++++ b/drivers/net/ena/ena_ethdev.c
+@@ -1348,9 +1348,14 @@ static int eth_ena_dev_init(struct rte_eth_dev *eth_dev)
+ 	/* Set max MTU for this device */
+ 	adapter->max_mtu = get_feat_ctx.dev_attr.max_mtu;
+ 
+-	/* set device support for TSO */
+-	adapter->tso4_supported = get_feat_ctx.offload.tx &
+-				  ENA_ADMIN_FEATURE_OFFLOAD_DESC_TSO_IPV4_MASK;
++	/* set device support for offloads */
++	adapter->offloads.tso4_supported = (get_feat_ctx.offload.tx &
++		ENA_ADMIN_FEATURE_OFFLOAD_DESC_TSO_IPV4_MASK) != 0;
++	adapter->offloads.tx_csum_supported = (get_feat_ctx.offload.tx &
++		ENA_ADMIN_FEATURE_OFFLOAD_DESC_TX_L4_IPV4_CSUM_PART_MASK) != 0;
++	adapter->offloads.tx_csum_supported =
++		(get_feat_ctx.offload.rx_supported &
++		ENA_ADMIN_FEATURE_OFFLOAD_DESC_RX_L4_IPV4_CSUM_MASK) != 0;
+ 
+ 	/* Copy MAC address and point DPDK to it */
+ 	eth_dev->data->mac_addrs = (struct ether_addr *)adapter->mac_addr;
+@@ -1429,9 +1434,7 @@ static void ena_infos_get(struct rte_eth_dev *dev,
+ {
+ 	struct ena_adapter *adapter;
+ 	struct ena_com_dev *ena_dev;
+-	struct ena_com_dev_get_features_ctx feat;
+ 	uint32_t rx_feat = 0, tx_feat = 0;
+-	int rc = 0;
+ 
+ 	ena_assert_msg(dev->data != NULL, "Uninitialized device");
+ 	ena_assert_msg(dev->data->dev_private != NULL, "Uninitialized device");
+@@ -1451,26 +1454,16 @@ static void ena_infos_get(struct rte_eth_dev *dev,
+ 			ETH_LINK_SPEED_50G  |
+ 			ETH_LINK_SPEED_100G;
+ 
+-	/* Get supported features from HW */
+-	rc = ena_com_get_dev_attr_feat(ena_dev, &feat);
+-	if (unlikely(rc)) {
+-		RTE_LOG(ERR, PMD,
+-			"Cannot get attribute for ena device rc= %d\n", rc);
+-		return;
+-	}
+-
+ 	/* Set Tx & Rx features available for device */
+-	if (feat.offload.tx & ENA_ADMIN_FEATURE_OFFLOAD_DESC_TSO_IPV4_MASK)
++	if (adapter->offloads.tso4_supported)
+ 		tx_feat	|= DEV_TX_OFFLOAD_TCP_TSO;
+ 
+-	if (feat.offload.tx &
+-	    ENA_ADMIN_FEATURE_OFFLOAD_DESC_TX_L4_IPV4_CSUM_PART_MASK)
++	if (adapter->offloads.tx_csum_supported)
+ 		tx_feat |= DEV_TX_OFFLOAD_IPV4_CKSUM |
+ 			DEV_TX_OFFLOAD_UDP_CKSUM |
+ 			DEV_TX_OFFLOAD_TCP_CKSUM;
+ 
+-	if (feat.offload.rx_supported &
+-	    ENA_ADMIN_FEATURE_OFFLOAD_DESC_RX_L4_IPV4_CSUM_MASK)
++	if (adapter->offloads.rx_csum_supported)
+ 		rx_feat |= DEV_RX_OFFLOAD_IPV4_CKSUM |
+ 			DEV_RX_OFFLOAD_UDP_CKSUM  |
+ 			DEV_RX_OFFLOAD_TCP_CKSUM;
+diff --git a/drivers/net/ena/ena_ethdev.h b/drivers/net/ena/ena_ethdev.h
+index dc3080ffd..4791c53b5 100644
+--- a/drivers/net/ena/ena_ethdev.h
++++ b/drivers/net/ena/ena_ethdev.h
+@@ -143,6 +143,12 @@ struct ena_stats_rx {
+ 	u64 small_copy_len_pkt;
+ };
+ 
++struct ena_offloads {
++	bool tso4_supported;
++	bool tx_csum_supported;
++	bool rx_csum_supported;
++};
++
+ /* board specific private data structure */
+ struct ena_adapter {
+ 	/* OS defined structs */
+@@ -162,7 +168,7 @@ struct ena_adapter {
+ 
+ 	u16 num_queues;
+ 	u16 max_mtu;
+-	u8 tso4_supported;
++	struct ena_offloads offloads;
+ 
+ 	int id_number;
+ 	char name[ENA_NAME_MAX_LEN];
+-- 
+2.20.1
+

--- a/userspace/dpdk/16.04/0012-net-ena-fix-checksum-feature-flag.patch
+++ b/userspace/dpdk/16.04/0012-net-ena-fix-checksum-feature-flag.patch
@@ -1,0 +1,35 @@
+From ec0b65c55948813480d15c77633177a48af20731 Mon Sep 17 00:00:00 2001
+From: Michal Krawczyk <mk@semihalf.com>
+Date: Mon, 8 Apr 2019 12:27:44 +0200
+Subject: [PATCH 12/14] net/ena: fix checksum feature flag
+
+[ upstream commit ef538c1a7f565c9b58518375a500aa864445fd11 ]
+
+The boolean value was assigned to Tx flag twice, so it could cause bug
+whenever Rx checksum will not be supported and Tx will be.
+
+Coverity issue: 336831
+Fixes: 117ba4a60488 ("net/ena: get device info statically")
+
+Change-Id: Id1ca7bb11b566c35ab7c9691593dcab40263c0f7
+Signed-off-by: Michal Krawczyk <mk@semihalf.com>
+---
+ drivers/net/ena/ena_ethdev.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/drivers/net/ena/ena_ethdev.c b/drivers/net/ena/ena_ethdev.c
+index 6c986cfc0..068641ee5 100644
+--- a/drivers/net/ena/ena_ethdev.c
++++ b/drivers/net/ena/ena_ethdev.c
+@@ -1353,7 +1353,7 @@ static int eth_ena_dev_init(struct rte_eth_dev *eth_dev)
+ 		ENA_ADMIN_FEATURE_OFFLOAD_DESC_TSO_IPV4_MASK) != 0;
+ 	adapter->offloads.tx_csum_supported = (get_feat_ctx.offload.tx &
+ 		ENA_ADMIN_FEATURE_OFFLOAD_DESC_TX_L4_IPV4_CSUM_PART_MASK) != 0;
+-	adapter->offloads.tx_csum_supported =
++	adapter->offloads.rx_csum_supported =
+ 		(get_feat_ctx.offload.rx_supported &
+ 		ENA_ADMIN_FEATURE_OFFLOAD_DESC_RX_L4_IPV4_CSUM_MASK) != 0;
+ 
+-- 
+2.20.1
+

--- a/userspace/dpdk/16.04/0013-net-ena-fix-Rx-checksum-errors-statistics.patch
+++ b/userspace/dpdk/16.04/0013-net-ena-fix-Rx-checksum-errors-statistics.patch
@@ -1,0 +1,52 @@
+From fc3dbe3a20809ea0457d4a117313d13b1fe8358e Mon Sep 17 00:00:00 2001
+From: Michal Krawczyk <mk@semihalf.com>
+Date: Tue, 28 May 2019 10:28:34 +0200
+Subject: [PATCH 13/14] net/ena: fix Rx checksum errors statistics
+
+[ upstream commit ef74b5f7b69b9502ddab81121611243efcfe1dde ]
+
+Rx checksum flags and input errors shouldn't be updated on Tx, as it
+would work only for packets forwarding.
+
+The ierrors statistic should be updated on Rx, right after checking
+Rx checksum flags if the Rx checksum offload is enabled.
+
+Fixes: 1173fca25af9 ("ena: add polling-mode driver")
+Cc: stable@dpdk.org
+
+Change-Id: I4ccf68bcb1ef6b50d01c811fc7f050a3d7ec9966
+Signed-off-by: Michal Krawczyk <mk@semihalf.com>
+---
+ drivers/net/ena/ena_ethdev.c | 9 +++++----
+ 1 file changed, 5 insertions(+), 4 deletions(-)
+
+diff --git a/drivers/net/ena/ena_ethdev.c b/drivers/net/ena/ena_ethdev.c
+index 068641ee5..2863ecbc9 100644
+--- a/drivers/net/ena/ena_ethdev.c
++++ b/drivers/net/ena/ena_ethdev.c
+@@ -1555,6 +1555,11 @@ static uint16_t eth_ena_recv_pkts(void *rx_queue, struct rte_mbuf **rx_pkts,
+ 
+ 		/* fill mbuf attributes if any */
+ 		ena_rx_mbuf_prepare(mbuf_head, &ena_rx_ctx);
++
++		if (unlikely(mbuf_head->ol_flags &
++				(PKT_RX_IP_CKSUM_BAD | PKT_RX_L4_CKSUM_BAD)))
++			rte_atomic64_inc(&rx_ring->adapter->drv_stats->ierrors);
++
+ 		mbuf_head->hash.rss = ena_rx_ctx.hash;
+ 
+ 		/* pass to DPDK application head mbuf */
+@@ -1630,10 +1635,6 @@ static uint16_t eth_ena_xmit_pkts(void *tx_queue, struct rte_mbuf **tx_pkts,
+ 		/* Set TX offloads flags, if applicable */
+ 		ena_tx_mbuf_prepare(mbuf, &ena_tx_ctx);
+ 
+-		if (unlikely(mbuf->ol_flags &
+-			     (PKT_RX_L4_CKSUM_BAD | PKT_RX_IP_CKSUM_BAD)))
+-			rte_atomic64_inc(&tx_ring->adapter->drv_stats->ierrors);
+-
+ 		rte_prefetch0(tx_pkts[(sent_idx + 4) & ring_mask]);
+ 
+ 		/* Process first segment taking into
+-- 
+2.20.1
+

--- a/userspace/dpdk/16.04/0014-net-ena-fix-assigning-NUMA-node-to-IO-queue.patch
+++ b/userspace/dpdk/16.04/0014-net-ena-fix-assigning-NUMA-node-to-IO-queue.patch
@@ -1,0 +1,123 @@
+From 964ad4e89de9d039667e12547a545c42926d8031 Mon Sep 17 00:00:00 2001
+From: Michal Krawczyk <mk@semihalf.com>
+Date: Tue, 4 Jun 2019 12:59:36 +0200
+Subject: [PATCH 14/14] net/ena: fix assigning NUMA node to IO queue
+
+[ upstream commit 4217cb0b7d2c5385f06f531af7f14b860927aba7 ]
+
+Previous solution was using memzones in invalid way in hope to assign
+IO queue to the appropriate NUMA zone.
+
+The right way is to use socket_id from the rx/tx queue setup function
+and then pass it to the IO queue.
+
+Fixes: 3d3edc265fc8 ("net/ena: make coherent memory allocation NUMA-aware")
+Cc: stable@dpdk.org
+
+Change-Id: I252df018ca6aae9d566618b6967bec0c5b3d939a
+Signed-off-by: Michal Krawczyk <mk@semihalf.com>
+Reviewed-by: David Marchand <david.marchand@redhat.com>
+---
+ drivers/net/ena/ena_ethdev.c | 23 ++++++-----------------
+ drivers/net/ena/ena_ethdev.h |  2 ++
+ 2 files changed, 8 insertions(+), 17 deletions(-)
+
+diff --git a/drivers/net/ena/ena_ethdev.c b/drivers/net/ena/ena_ethdev.c
+index 2863ecbc9..ac21f0628 100644
+--- a/drivers/net/ena/ena_ethdev.c
++++ b/drivers/net/ena/ena_ethdev.c
+@@ -38,7 +38,6 @@
+ #include <rte_dev.h>
+ #include <rte_errno.h>
+ #include <rte_version.h>
+-#include <rte_eal_memconfig.h>
+ 
+ #include "ena_ethdev.h"
+ #include "ena_logs.h"
+@@ -242,18 +241,6 @@ static const struct eth_dev_ops ena_dev_ops = {
+ 	.reta_query           = ena_rss_reta_query,
+ };
+ 
+-#define NUMA_NO_NODE	SOCKET_ID_ANY
+-
+-static inline int ena_cpu_to_node(int cpu)
+-{
+-	struct rte_config *config = rte_eal_get_configuration();
+-
+-	if (likely(cpu < RTE_MAX_MEMZONE))
+-		return config->mem_config->memzone[cpu].socket_id;
+-
+-	return NUMA_NO_NODE;
+-}
+-
+ static inline void ena_rx_mbuf_prepare(struct rte_mbuf *mbuf,
+ 				       struct ena_com_rx_ctx *ena_rx_ctx)
+ {
+@@ -943,7 +930,7 @@ static int ena_queue_restart(struct ena_ring *ring)
+ static int ena_tx_queue_setup(struct rte_eth_dev *dev,
+ 			      uint16_t queue_idx,
+ 			      uint16_t nb_desc,
+-			      __rte_unused unsigned int socket_id,
++			      unsigned int socket_id,
+ 			      __rte_unused const struct rte_eth_txconf *tx_conf)
+ {
+ 	struct ena_com_create_io_ctx ctx =
+@@ -988,7 +975,7 @@ static int ena_tx_queue_setup(struct rte_eth_dev *dev,
+ 	ctx.msix_vector = -1; /* admin interrupts not used */
+ 	ctx.mem_queue_type = ena_dev->tx_mem_queue_type;
+ 	ctx.queue_size = adapter->tx_ring_size;
+-	ctx.numa_node = ena_cpu_to_node(queue_idx);
++	ctx.numa_node = socket_id;
+ 
+ 	rc = ena_com_create_io_queue(ena_dev, &ctx);
+ 	if (rc) {
+@@ -1014,6 +1001,7 @@ static int ena_tx_queue_setup(struct rte_eth_dev *dev,
+ 	txq->next_to_clean = 0;
+ 	txq->next_to_use = 0;
+ 	txq->ring_size = nb_desc;
++	txq->numa_socket_id = socket_id;
+ 
+ 	txq->tx_buffer_info = rte_zmalloc("txq->tx_buffer_info",
+ 					  sizeof(struct ena_tx_buffer) *
+@@ -1045,7 +1033,7 @@ err:
+ static int ena_rx_queue_setup(struct rte_eth_dev *dev,
+ 			      uint16_t queue_idx,
+ 			      uint16_t nb_desc,
+-			      __rte_unused unsigned int socket_id,
++			      unsigned int socket_id,
+ 			      __rte_unused const struct rte_eth_rxconf *rx_conf,
+ 			      struct rte_mempool *mp)
+ {
+@@ -1089,7 +1077,7 @@ static int ena_rx_queue_setup(struct rte_eth_dev *dev,
+ 	ctx.mem_queue_type = ENA_ADMIN_PLACEMENT_POLICY_HOST;
+ 	ctx.msix_vector = -1; /* admin interrupts not used */
+ 	ctx.queue_size = adapter->rx_ring_size;
+-	ctx.numa_node = ena_cpu_to_node(queue_idx);
++	ctx.numa_node = socket_id;
+ 
+ 	rc = ena_com_create_io_queue(ena_dev, &ctx);
+ 	if (rc)
+@@ -1113,6 +1101,7 @@ static int ena_rx_queue_setup(struct rte_eth_dev *dev,
+ 	rxq->next_to_clean = 0;
+ 	rxq->next_to_use = 0;
+ 	rxq->ring_size = nb_desc;
++	rxq->numa_socket_id = socket_id;
+ 	rxq->mb_pool = mp;
+ 
+ 	rxq->rx_buffer_info = rte_zmalloc("rxq->buffer_info",
+diff --git a/drivers/net/ena/ena_ethdev.h b/drivers/net/ena/ena_ethdev.h
+index 4791c53b5..8d5eb5a7c 100644
+--- a/drivers/net/ena/ena_ethdev.h
++++ b/drivers/net/ena/ena_ethdev.h
+@@ -90,6 +90,8 @@ struct ena_ring {
+ 	uint8_t tx_max_header_size;
+ 	int configured;
+ 	struct ena_adapter *adapter;
++
++	unsigned int numa_socket_id;
+ } __rte_cache_aligned;
+ 
+ enum ena_adapter_state {
+-- 
+2.20.1
+

--- a/userspace/dpdk/16.11/0001-net-ena-cleanup-if-refilling-of-Rx-descriptors-fails.patch
+++ b/userspace/dpdk/16.11/0001-net-ena-cleanup-if-refilling-of-Rx-descriptors-fails.patch
@@ -1,7 +1,7 @@
 From 395ef06d77c3d2d7d1eb9400a3988ec8857fd5d7 Mon Sep 17 00:00:00 2001
 From: Michal Krawczyk <mk@semihalf.com>
 Date: Mon, 10 Apr 2017 16:28:10 +0200
-Subject: [PATCH 01/15] net/ena: cleanup if refilling of Rx descriptors fails
+Subject: [PATCH 01/19] net/ena: cleanup if refilling of Rx descriptors fails
 
 [ upstream commit 2732e07ad1e54c648c8ca5bc6965af5bf607ba10 ]
 
@@ -35,5 +35,5 @@ index ab9a178f7..dd53c32d9 100644
  			break;
  		}
 -- 
-2.14.1
+2.20.1
 

--- a/userspace/dpdk/16.11/0002-net-ena-fix-Rx-descriptors-allocation.patch
+++ b/userspace/dpdk/16.11/0002-net-ena-fix-Rx-descriptors-allocation.patch
@@ -1,7 +1,7 @@
 From a8c9bdcc04fddbd930f1856ce7f56dc7b20e4d0b Mon Sep 17 00:00:00 2001
 From: Michal Krawczyk <mk@semihalf.com>
 Date: Thu, 18 May 2017 17:41:50 +0200
-Subject: [PATCH 02/15] net/ena: fix Rx descriptors allocation
+Subject: [PATCH 02/19] net/ena: fix Rx descriptors allocation
 
 [ backported from upstream commit a467e8f37a3eec98210c0c3ec04bf6e9506ddd81 ]
 
@@ -66,5 +66,5 @@ index dd53c32d9..2318cf35d 100644
  	if (ring_size - desc_in_use > ENA_RING_DESCS_RATIO(ring_size))
  		ena_populate_rx_queue(rx_ring, ring_size - desc_in_use);
 -- 
-2.14.1
+2.20.1
 

--- a/userspace/dpdk/16.11/0003-net-ena-fix-delayed-cleanup-of-Rx-descriptors.patch
+++ b/userspace/dpdk/16.11/0003-net-ena-fix-delayed-cleanup-of-Rx-descriptors.patch
@@ -1,7 +1,7 @@
 From 9566e5c1adc033c0a43601def1132a4775522cb0 Mon Sep 17 00:00:00 2001
 From: Michal Krawczyk <mk@semihalf.com>
 Date: Thu, 18 May 2017 17:41:51 +0200
-Subject: [PATCH 03/15] net/ena: fix delayed cleanup of Rx descriptors
+Subject: [PATCH 03/19] net/ena: fix delayed cleanup of Rx descriptors
 
 [ backported from upstream commit ec78af6bc0556cf2a1133185ca33fb835b38afe0 ]
 
@@ -18,6 +18,7 @@ ring state.
 
 Fixes: 1daff5260ff8 ("net/ena: use unmasked head and tail")
 
+Change-Id: Ie36046371daa8d3002608d30a064ee4499931e1f
 Signed-off-by: Michal Krawczyk <mk@semihalf.com>
 Reviewed-by: Jakub Palider <jpalider@gmail.com>
 Acked-by: Jan Medala <jan.medala@outlook.com>
@@ -47,5 +48,5 @@ index 2318cf35d..8d4898d67 100644
  }
  
 -- 
-2.14.1
+2.20.1
 

--- a/userspace/dpdk/16.11/0004-net-ena-fix-cleanup-of-the-Tx-bufs.patch
+++ b/userspace/dpdk/16.11/0004-net-ena-fix-cleanup-of-the-Tx-bufs.patch
@@ -1,7 +1,7 @@
 From 9457d1b00377ffe171d674a96f8dbe36edc16252 Mon Sep 17 00:00:00 2001
 From: Michal Krawczyk <mk@semihalf.com>
 Date: Fri, 16 Jun 2017 08:19:16 +0000
-Subject: [PATCH 04/15] net/ena: fix cleanup of the Tx bufs
+Subject: [PATCH 04/19] net/ena: fix cleanup of the Tx bufs
 
 [ upstream commit 207a514ce516f8ab3c1ad2b0f930f045b90b773c ]
 
@@ -15,6 +15,7 @@ range between head and tail was being cleaned up.
 Fixes: 1173fca25af9 ("ena: add polling-mode driver")
 Cc: stable@dpdk.org
 
+Change-Id: If577110bdc3f423365eabf8270e3dd5a87d373f4
 Signed-off-by: Michal Krawczyk <mk@semihalf.com>
 ---
  drivers/net/ena/ena_ethdev.c | 8 ++++----
@@ -48,5 +49,5 @@ index 8d4898d67..c832d241f 100644
  		/* Put back descriptor to the ring for reuse */
  		tx_ring->empty_tx_reqs[next_to_clean & ring_mask] = req_id;
 -- 
-2.14.1
+2.20.1
 

--- a/userspace/dpdk/16.11/0005-net-ena-base-initialize-memory-in-the-allocation-mac.patch
+++ b/userspace/dpdk/16.11/0005-net-ena-base-initialize-memory-in-the-allocation-mac.patch
@@ -1,7 +1,7 @@
 From 752d24a3c56d0c7bffcba40249912b8fe112af4b Mon Sep 17 00:00:00 2001
 From: Michal Krawczyk <mk@semihalf.com>
 Date: Fri, 16 Jun 2017 09:10:48 +0000
-Subject: [PATCH 05/15] net/ena/base: initialize memory in the allocation
+Subject: [PATCH 05/19] net/ena/base: initialize memory in the allocation
  macros
 
 [ upstream commit 2861ea8df0173f047efe2636ef3b9643d4d989bc ]
@@ -12,6 +12,7 @@ completion of the invalid mbuf.
 Fixes: 3d3edc265fc8 ("net/ena: make coherent memory allocation NUMA-aware")
 Cc: stable@dpdk.org
 
+Change-Id: I4d9f76d67302d42faa8c8abdd16963692e8c98d2
 Signed-off-by: Alexander Matushevsky <matua@amazon.com>
 Signed-off-by: Michal Krawczyk <mk@semihalf.com>
 ---
@@ -39,5 +40,5 @@ index 87c3bf13b..a812d75e2 100644
  	} while (0)
  
 -- 
-2.14.1
+2.20.1
 

--- a/userspace/dpdk/16.11/0006-net-ena-do-not-set-Tx-L4-offloads-in-Rx-path.patch
+++ b/userspace/dpdk/16.11/0006-net-ena-do-not-set-Tx-L4-offloads-in-Rx-path.patch
@@ -1,7 +1,7 @@
 From 97f897630d47295ac8b8c3b25724b9beeee8b0b2 Mon Sep 17 00:00:00 2001
 From: Rafal Kozik <rk@semihalf.com>
 Date: Tue, 9 Jan 2018 16:19:08 +0100
-Subject: [PATCH 06/15] net/ena: do not set Tx L4 offloads in Rx path
+Subject: [PATCH 06/19] net/ena: do not set Tx L4 offloads in Rx path
 
 [ upstream commit fd617795679019c7aea5ab1e8c85db02cf53f169 ]
 
@@ -14,6 +14,7 @@ correct.
 Fixes: 1173fca25af9 ("ena: add polling-mode driver")
 Cc: stable@dpdk.org
 
+Change-Id: I83051a29df473557948e8ca7e6141d61fd886108
 Reported-by: Matthew Smith <mgsmith@netgate.com>
 Signed-off-by: Rafal Kozik <rk@semihalf.com>
 Signed-off-by: Michal Krawczyk <mk@semihalf.com>
@@ -56,5 +57,5 @@ index c832d241f..3e73fe1fb 100644
  
  static inline void ena_tx_mbuf_prepare(struct rte_mbuf *mbuf,
 -- 
-2.14.1
+2.20.1
 

--- a/userspace/dpdk/16.11/0007-net-ena-check-pointer-before-memset.patch
+++ b/userspace/dpdk/16.11/0007-net-ena-check-pointer-before-memset.patch
@@ -1,7 +1,7 @@
 From 38a75ccdb2ea650ac7e98b2c3948616cd6fab432 Mon Sep 17 00:00:00 2001
 From: Rafal Kozik <rk@semihalf.com>
 Date: Thu, 7 Jun 2018 11:43:18 +0200
-Subject: [PATCH 07/15] net/ena: check pointer before memset
+Subject: [PATCH 07/19] net/ena: check pointer before memset
 
 [ upstream commit 46916aa17d4b2007df8c0454f99ba0ca8b8cb93b ]
 
@@ -11,6 +11,7 @@ Using memset on NULL pointer cause segfault.
 Fixes: 9ba7981ec992 ("ena: add communication layer for DPDK")
 Cc: stable@dpdk.org
 
+Change-Id: I7f7d1150234fd49312d9104d9603752ee4a3a0c8
 Signed-off-by: Rafal Kozik <rk@semihalf.com>
 Acked-by: Michal Krawczyk <mk@semihalf.com>
 ---
@@ -59,5 +60,5 @@ index a812d75e2..cc69b3372 100644
  
  #define ENA_MEM_ALLOC_NODE(dmadev, size, virt, node, dev_node) \
 -- 
-2.14.1
+2.20.1
 

--- a/userspace/dpdk/16.11/0008-net-ena-change-memory-type.patch
+++ b/userspace/dpdk/16.11/0008-net-ena-change-memory-type.patch
@@ -1,7 +1,7 @@
 From 85c0b74c24ab44e78cfdece88993be142fb2ccba Mon Sep 17 00:00:00 2001
 From: Rafal Kozik <rk@semihalf.com>
 Date: Thu, 7 Jun 2018 11:43:19 +0200
-Subject: [PATCH 08/15] net/ena: change memory type
+Subject: [PATCH 08/19] net/ena: change memory type
 
 [ upstream commit 9f32c7e7e6ce58ab772913f54f8328c1c0186a17 ]
 
@@ -14,6 +14,7 @@ To avoid both issue use rte_zmalloc_socket.
 Fixes: 3d3edc265fc8 ("net/ena: make coherent memory allocation NUMA-aware")
 Cc: stable@dpdk.org
 
+Change-Id: I09427bfc0d3b7f90771c5a7be16aef3b95bd9069
 Signed-off-by: Rafal Kozik <rk@semihalf.com>
 Acked-by: Michal Krawczyk <mk@semihalf.com>
 ---
@@ -41,5 +42,5 @@ index cc69b3372..ff873e807 100644
  
  #define ENA_MEM_ALLOC(dmadev, size) rte_zmalloc(NULL, size, 1)
 -- 
-2.14.1
+2.20.1
 

--- a/userspace/dpdk/16.11/0009-net-ena-fix-GENMASK_ULL-macro.patch
+++ b/userspace/dpdk/16.11/0009-net-ena-fix-GENMASK_ULL-macro.patch
@@ -1,7 +1,7 @@
 From 51758b4a25224f10a434c97bd5c46299ea35923f Mon Sep 17 00:00:00 2001
 From: Rafal Kozik <rk@semihalf.com>
 Date: Thu, 7 Jun 2018 11:43:20 +0200
-Subject: [PATCH 09/15] net/ena: fix GENMASK_ULL macro
+Subject: [PATCH 09/19] net/ena: fix GENMASK_ULL macro
 
 [ upstream commit 7544aee8d0b4ae0262b1ba7e1539cf8171664df7 ]
 
@@ -12,6 +12,7 @@ is undefined operation and failed on some platforms.
 Fixes: 9ba7981ec992 ("ena: add communication layer for DPDK")
 Cc: stable@dpdk.org
 
+Change-Id: I2094d149a9ff038824ebdff734b2e47bcb0f003f
 Signed-off-by: Rafal Kozik <rk@semihalf.com>
 Acked-by: Michal Krawczyk <mk@semihalf.com>
 ---
@@ -38,5 +39,5 @@ index ff873e807..791b44ff7 100644
  #ifdef RTE_LIBRTE_ENA_COM_DEBUG
  #define ena_trc_dbg(format, arg...)					\
 -- 
-2.14.1
+2.20.1
 

--- a/userspace/dpdk/16.11/0010-net-ena-set-link-speed-as-none.patch
+++ b/userspace/dpdk/16.11/0010-net-ena-set-link-speed-as-none.patch
@@ -1,7 +1,7 @@
 From c59dd287eb5cf304d48a865b2eea3e014acb7c55 Mon Sep 17 00:00:00 2001
 From: Rafal Kozik <rk@semihalf.com>
 Date: Thu, 7 Jun 2018 11:43:22 +0200
-Subject: [PATCH 10/15] net/ena: set link speed as none
+Subject: [PATCH 10/19] net/ena: set link speed as none
 
 [ upstream commit 41e59028dd8ab2038a7655c6fc3098222661aa53 ]
 
@@ -13,6 +13,7 @@ rely on this value when using ENA PMD.
 Fixes: 1173fca25af9 ("ena: add polling-mode driver")
 Cc: stable@dpdk.org
 
+Change-Id: I046f53eb179ba5171c687038820045affee833f3
 Signed-off-by: Rafal Kozik <rk@semihalf.com>
 Acked-by: Michal Krawczyk <mk@semihalf.com>
 ---
@@ -33,5 +34,5 @@ index 3e73fe1fb..713f5323e 100644
  
  	return 0;
 -- 
-2.14.1
+2.20.1
 

--- a/userspace/dpdk/16.11/0011-net-ena-fix-SIGFPE-with-0-Rx-queue.patch
+++ b/userspace/dpdk/16.11/0011-net-ena-fix-SIGFPE-with-0-Rx-queue.patch
@@ -1,7 +1,7 @@
 From 65757a0c198c2d99e43b528024b065cfb02b1341 Mon Sep 17 00:00:00 2001
 From: Daria Kolistratova <daria.kolistratova@intel.com>
 Date: Tue, 26 Jun 2018 18:38:56 +0100
-Subject: [PATCH 11/15] net/ena: fix SIGFPE with 0 Rx queue
+Subject: [PATCH 11/19] net/ena: fix SIGFPE with 0 Rx queue
 
 [ upstream commit 361913ad6f8c05fc541fe4bfdae3b0dc095ae3af ]
 
@@ -11,6 +11,7 @@ It happens when the application is also requesting ETH_MQ_RX_RSS_FLAG
 in the rte_dev->data->dev_conf.rxmode.mq_mode.
 Fixed adding zero rx queues check.
 
+Change-Id: I04fff738df0134172be5443cdc1af3a3b35a2c32
 Signed-off-by: Daria Kolistratova <daria.kolistratova@intel.com>
 Acked-by: Michal Krawczyk <mk@semihalf.com>
 ---
@@ -31,5 +32,5 @@ index 713f5323e..a67065398 100644
  		if (rc)
  			return rc;
 -- 
-2.14.1
+2.20.1
 

--- a/userspace/dpdk/16.11/0012-net-ena-fix-passing-RSS-hash-to-mbuf.patch
+++ b/userspace/dpdk/16.11/0012-net-ena-fix-passing-RSS-hash-to-mbuf.patch
@@ -1,7 +1,7 @@
 From a8100fd4d73c8abc979e681a8efe16d7628cd558 Mon Sep 17 00:00:00 2001
 From: Stewart Allen <allenste@amazon.com>
 Date: Thu, 25 Oct 2018 19:59:22 +0200
-Subject: [PATCH 12/15] net/ena: fix passing RSS hash to mbuf
+Subject: [PATCH 12/19] net/ena: fix passing RSS hash to mbuf
 
 [ upstream commit e5df9f33db00eb9d322abaefff30da74fd0e625d ]
 
@@ -11,6 +11,7 @@ from the device. Now, the RSS hash from the Rx descriptor is being set.
 Fixes: 1173fca25af9 ("ena: add polling-mode driver")
 Cc: stable@dpdk.org
 
+Change-Id: Iea37e68a1d685800166fa3733f150ad79a2e0b25
 Signed-off-by: Stewart Allen <allenste@amazon.com>
 Acked-by: Michal Krawczyk <mk@semihalf.com>
 ---
@@ -31,5 +32,5 @@ index a67065398..e38407287 100644
  		/* pass to DPDK application head mbuf */
  		rx_pkts[recv_idx] = mbuf_head;
 -- 
-2.14.1
+2.20.1
 

--- a/userspace/dpdk/16.11/0013-net-ena-add-supported-RSS-offloads-types.patch
+++ b/userspace/dpdk/16.11/0013-net-ena-add-supported-RSS-offloads-types.patch
@@ -1,7 +1,7 @@
 From c9469181aa7ff3411f1e090e07f7abc67b62ffe4 Mon Sep 17 00:00:00 2001
 From: Rafal Kozik <rk@semihalf.com>
 Date: Fri, 14 Dec 2018 14:18:38 +0100
-Subject: [PATCH 13/15] net/ena: add supported RSS offloads types
+Subject: [PATCH 13/19] net/ena: add supported RSS offloads types
 
 [ upstream commit b01ead202beb45346d7daeb2f2b1a608006af644 ]
 
@@ -12,6 +12,7 @@ missing information was added.
 Fixes: 1173fca25af9 ("ena: add polling-mode driver")
 Cc: stable@dpdk.org
 
+Change-Id: I91396b6a6f3941553a599bd66a224e1ea1ffd2a7
 Signed-off-by: Rafal Kozik <rk@semihalf.com>
 Acked-by: Michal Krawczyk <mk@semihalf.com>
 ---
@@ -33,5 +34,5 @@ index e38407287..088893230 100644
  	dev_info->max_rx_pktlen  = adapter->max_mtu;
  	dev_info->max_mac_addrs = 1;
 -- 
-2.14.1
+2.20.1
 

--- a/userspace/dpdk/16.11/0014-net-ena-update-completion-queue-after-cleanup.patch
+++ b/userspace/dpdk/16.11/0014-net-ena-update-completion-queue-after-cleanup.patch
@@ -1,7 +1,7 @@
 From f8f96ba4b28049cf514ba8c5ba0324e25c063f2b Mon Sep 17 00:00:00 2001
 From: Rafal Kozik <rk@semihalf.com>
 Date: Fri, 14 Dec 2018 14:18:44 +0100
-Subject: [PATCH 14/15] net/ena: update completion queue after cleanup
+Subject: [PATCH 14/19] net/ena: update completion queue after cleanup
 
 [ upstream commit a45462c507e98b49cb5c2302e0be3c72d2e20a1a ]
 
@@ -11,6 +11,7 @@ ena_com_update_dev_comp_head().
 Fixes: 1daff5260ff8 ("net/ena: use unmasked head and tail")
 Cc: stable@dpdk.org
 
+Change-Id: Ic57a9ad208badc587423844f3afec3005c4c5f0a
 Signed-off-by: Rafal Kozik <rk@semihalf.com>
 Acked-by: Michal Krawczyk <mk@semihalf.com>
 ---
@@ -45,5 +46,5 @@ index 088893230..9642bdb18 100644
  
  	return sent_idx;
 -- 
-2.14.1
+2.20.1
 

--- a/userspace/dpdk/16.11/0015-net-ena-fix-dev-init-with-multi-process.patch
+++ b/userspace/dpdk/16.11/0015-net-ena-fix-dev-init-with-multi-process.patch
@@ -1,7 +1,7 @@
 From 5a56e222261788b4ff1f0a778bad136a8017494c Mon Sep 17 00:00:00 2001
 From: Michal Krawczyk <mk@semihalf.com>
 Date: Fri, 25 Jan 2019 09:10:25 +0100
-Subject: [PATCH 15/15] net/ena: fix dev init with multi-process
+Subject: [PATCH 15/19] net/ena: fix dev init with multi-process
 
 [ upstream commit fd9768905870856a2340266d25f8c0100dfccfff ]
 
@@ -15,6 +15,7 @@ main process.
 Fixes: 1173fca25af9 ("ena: add polling-mode driver")
 Cc: stable@dpdk.org
 
+Change-Id: I7350adee016294df2e9e9c93fa81a7a8503cf8f2
 Signed-off-by: Michal Krawczyk <mk@semihalf.com>
 ---
  drivers/net/ena/ena_ethdev.c | 10 +++++-----
@@ -49,5 +50,5 @@ index 9642bdb18..5a0d39cb2 100644
  	adapter->pdev = pci_dev;
  
 -- 
-2.14.1
+2.20.1
 

--- a/userspace/dpdk/16.11/0016-net-ena-get-device-info-statically.patch
+++ b/userspace/dpdk/16.11/0016-net-ena-get-device-info-statically.patch
@@ -1,0 +1,111 @@
+From dcbca00d0c5ed9e68112c3abd4c59dd8a8253214 Mon Sep 17 00:00:00 2001
+From: Michal Krawczyk <mk@semihalf.com>
+Date: Fri, 15 Feb 2019 09:36:39 +0100
+Subject: [PATCH 16/19] net/ena: get device info statically
+
+[ upstream commit 117ba4a60488a0f96a5737f38ddba6d0f9a728b6 ]
+
+Whenever the app is calling rte_eth_dev_info_get(), it shouldn't use the
+admin command. It was causing problems, if it was called from the
+secondary process - the main process was crashing, and the secondary app
+wasn't getting any result, as the admin request couldn't be processed by
+the process which was requesting the data.
+
+To fix that, the data is being written to the adapter structure during
+device initialization routine.
+
+Change-Id: I94f61f51223725602f70ac9795acf02b7b014984
+Signed-off-by: Michal Krawczyk <mk@semihalf.com>
+---
+ drivers/net/ena/ena_ethdev.c | 27 ++++++++++++---------------
+ drivers/net/ena/ena_ethdev.h |  7 +++++++
+ 2 files changed, 19 insertions(+), 15 deletions(-)
+
+diff --git a/drivers/net/ena/ena_ethdev.c b/drivers/net/ena/ena_ethdev.c
+index 5a0d39cb2..4ba2162a7 100644
+--- a/drivers/net/ena/ena_ethdev.c
++++ b/drivers/net/ena/ena_ethdev.c
+@@ -1352,6 +1352,15 @@ static int eth_ena_dev_init(struct rte_eth_dev *eth_dev)
+ 	/* Set max MTU for this device */
+ 	adapter->max_mtu = get_feat_ctx.dev_attr.max_mtu;
+ 
++	/* set device support for offloads */
++	adapter->offloads.tso4_supported = (get_feat_ctx.offload.tx &
++		ENA_ADMIN_FEATURE_OFFLOAD_DESC_TSO_IPV4_MASK) != 0;
++	adapter->offloads.tx_csum_supported = (get_feat_ctx.offload.tx &
++		ENA_ADMIN_FEATURE_OFFLOAD_DESC_TX_L4_IPV4_CSUM_PART_MASK) != 0;
++	adapter->offloads.tx_csum_supported =
++		(get_feat_ctx.offload.rx_supported &
++		ENA_ADMIN_FEATURE_OFFLOAD_DESC_RX_L4_IPV4_CSUM_MASK) != 0;
++
+ 	/* Copy MAC address and point DPDK to it */
+ 	eth_dev->data->mac_addrs = (struct ether_addr *)adapter->mac_addr;
+ 	ether_addr_copy((struct ether_addr *)get_feat_ctx.dev_attr.mac_addr,
+@@ -1429,9 +1438,7 @@ static void ena_infos_get(struct rte_eth_dev *dev,
+ {
+ 	struct ena_adapter *adapter;
+ 	struct ena_com_dev *ena_dev;
+-	struct ena_com_dev_get_features_ctx feat;
+ 	uint32_t rx_feat = 0, tx_feat = 0;
+-	int rc = 0;
+ 
+ 	ena_assert_msg(dev->data != NULL, "Uninitialized device");
+ 	ena_assert_msg(dev->data->dev_private != NULL, "Uninitialized device");
+@@ -1450,26 +1457,16 @@ static void ena_infos_get(struct rte_eth_dev *dev,
+ 			ETH_LINK_SPEED_50G  |
+ 			ETH_LINK_SPEED_100G;
+ 
+-	/* Get supported features from HW */
+-	rc = ena_com_get_dev_attr_feat(ena_dev, &feat);
+-	if (unlikely(rc)) {
+-		RTE_LOG(ERR, PMD,
+-			"Cannot get attribute for ena device rc= %d\n", rc);
+-		return;
+-	}
+-
+ 	/* Set Tx & Rx features available for device */
+-	if (feat.offload.tx & ENA_ADMIN_FEATURE_OFFLOAD_DESC_TSO_IPV4_MASK)
++	if (adapter->offloads.tso4_supported)
+ 		tx_feat	|= DEV_TX_OFFLOAD_TCP_TSO;
+ 
+-	if (feat.offload.tx &
+-	    ENA_ADMIN_FEATURE_OFFLOAD_DESC_TX_L4_IPV4_CSUM_PART_MASK)
++	if (adapter->offloads.tx_csum_supported)
+ 		tx_feat |= DEV_TX_OFFLOAD_IPV4_CKSUM |
+ 			DEV_TX_OFFLOAD_UDP_CKSUM |
+ 			DEV_TX_OFFLOAD_TCP_CKSUM;
+ 
+-	if (feat.offload.tx &
+-	    ENA_ADMIN_FEATURE_OFFLOAD_DESC_RX_L4_IPV4_CSUM_MASK)
++	if (adapter->offloads.rx_csum_supported)
+ 		rx_feat |= DEV_RX_OFFLOAD_IPV4_CKSUM |
+ 			DEV_RX_OFFLOAD_UDP_CKSUM  |
+ 			DEV_RX_OFFLOAD_TCP_CKSUM;
+diff --git a/drivers/net/ena/ena_ethdev.h b/drivers/net/ena/ena_ethdev.h
+index 4c7edbb9e..4791c53b5 100644
+--- a/drivers/net/ena/ena_ethdev.h
++++ b/drivers/net/ena/ena_ethdev.h
+@@ -143,6 +143,12 @@ struct ena_stats_rx {
+ 	u64 small_copy_len_pkt;
+ };
+ 
++struct ena_offloads {
++	bool tso4_supported;
++	bool tx_csum_supported;
++	bool rx_csum_supported;
++};
++
+ /* board specific private data structure */
+ struct ena_adapter {
+ 	/* OS defined structs */
+@@ -162,6 +168,7 @@ struct ena_adapter {
+ 
+ 	u16 num_queues;
+ 	u16 max_mtu;
++	struct ena_offloads offloads;
+ 
+ 	int id_number;
+ 	char name[ENA_NAME_MAX_LEN];
+-- 
+2.20.1
+

--- a/userspace/dpdk/16.11/0017-net-ena-fix-checksum-feature-flag.patch
+++ b/userspace/dpdk/16.11/0017-net-ena-fix-checksum-feature-flag.patch
@@ -1,0 +1,35 @@
+From bcbb265edef2a42fb5af62d2788eb46c30445674 Mon Sep 17 00:00:00 2001
+From: Michal Krawczyk <mk@semihalf.com>
+Date: Mon, 8 Apr 2019 12:27:44 +0200
+Subject: [PATCH 17/19] net/ena: fix checksum feature flag
+
+[ upstream commit ef538c1a7f565c9b58518375a500aa864445fd11 ]
+
+The boolean value was assigned to Tx flag twice, so it could cause bug
+whenever Rx checksum will not be supported and Tx will be.
+
+Coverity issue: 336831
+Fixes: 117ba4a60488 ("net/ena: get device info statically")
+
+Change-Id: Id1ca7bb11b566c35ab7c9691593dcab40263c0f7
+Signed-off-by: Michal Krawczyk <mk@semihalf.com>
+---
+ drivers/net/ena/ena_ethdev.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/drivers/net/ena/ena_ethdev.c b/drivers/net/ena/ena_ethdev.c
+index 4ba2162a7..4adeb9728 100644
+--- a/drivers/net/ena/ena_ethdev.c
++++ b/drivers/net/ena/ena_ethdev.c
+@@ -1357,7 +1357,7 @@ static int eth_ena_dev_init(struct rte_eth_dev *eth_dev)
+ 		ENA_ADMIN_FEATURE_OFFLOAD_DESC_TSO_IPV4_MASK) != 0;
+ 	adapter->offloads.tx_csum_supported = (get_feat_ctx.offload.tx &
+ 		ENA_ADMIN_FEATURE_OFFLOAD_DESC_TX_L4_IPV4_CSUM_PART_MASK) != 0;
+-	adapter->offloads.tx_csum_supported =
++	adapter->offloads.rx_csum_supported =
+ 		(get_feat_ctx.offload.rx_supported &
+ 		ENA_ADMIN_FEATURE_OFFLOAD_DESC_RX_L4_IPV4_CSUM_MASK) != 0;
+ 
+-- 
+2.20.1
+

--- a/userspace/dpdk/16.11/0018-net-ena-fix-Rx-checksum-errors-statistics.patch
+++ b/userspace/dpdk/16.11/0018-net-ena-fix-Rx-checksum-errors-statistics.patch
@@ -1,0 +1,52 @@
+From 8c2d266436055d21dd239890e7422d97079f2084 Mon Sep 17 00:00:00 2001
+From: Michal Krawczyk <mk@semihalf.com>
+Date: Tue, 28 May 2019 10:28:34 +0200
+Subject: [PATCH 18/19] net/ena: fix Rx checksum errors statistics
+
+[ upstream commit ef74b5f7b69b9502ddab81121611243efcfe1dde ]
+
+Rx checksum flags and input errors shouldn't be updated on Tx, as it
+would work only for packets forwarding.
+
+The ierrors statistic should be updated on Rx, right after checking
+Rx checksum flags if the Rx checksum offload is enabled.
+
+Fixes: 1173fca25af9 ("ena: add polling-mode driver")
+Cc: stable@dpdk.org
+
+Change-Id: I4ccf68bcb1ef6b50d01c811fc7f050a3d7ec9966
+Signed-off-by: Michal Krawczyk <mk@semihalf.com>
+---
+ drivers/net/ena/ena_ethdev.c | 9 +++++----
+ 1 file changed, 5 insertions(+), 4 deletions(-)
+
+diff --git a/drivers/net/ena/ena_ethdev.c b/drivers/net/ena/ena_ethdev.c
+index 4adeb9728..7998f4e6a 100644
+--- a/drivers/net/ena/ena_ethdev.c
++++ b/drivers/net/ena/ena_ethdev.c
+@@ -1558,6 +1558,11 @@ static uint16_t eth_ena_recv_pkts(void *rx_queue, struct rte_mbuf **rx_pkts,
+ 
+ 		/* fill mbuf attributes if any */
+ 		ena_rx_mbuf_prepare(mbuf_head, &ena_rx_ctx);
++
++		if (unlikely(mbuf_head->ol_flags &
++				(PKT_RX_IP_CKSUM_BAD | PKT_RX_L4_CKSUM_BAD)))
++			rte_atomic64_inc(&rx_ring->adapter->drv_stats->ierrors);
++
+ 		mbuf_head->hash.rss = ena_rx_ctx.hash;
+ 
+ 		/* pass to DPDK application head mbuf */
+@@ -1635,10 +1640,6 @@ static uint16_t eth_ena_xmit_pkts(void *tx_queue, struct rte_mbuf **tx_pkts,
+ 		/* Set TX offloads flags, if applicable */
+ 		ena_tx_mbuf_prepare(mbuf, &ena_tx_ctx);
+ 
+-		if (unlikely(mbuf->ol_flags &
+-			     (PKT_RX_L4_CKSUM_BAD | PKT_RX_IP_CKSUM_BAD)))
+-			rte_atomic64_inc(&tx_ring->adapter->drv_stats->ierrors);
+-
+ 		rte_prefetch0(tx_pkts[(sent_idx + 4) & ring_mask]);
+ 
+ 		/* Process first segment taking into
+-- 
+2.20.1
+

--- a/userspace/dpdk/16.11/0019-net-ena-fix-assigning-NUMA-node-to-IO-queue.patch
+++ b/userspace/dpdk/16.11/0019-net-ena-fix-assigning-NUMA-node-to-IO-queue.patch
@@ -1,0 +1,123 @@
+From da602284b0284e7bf3986557aea26a69257d8c32 Mon Sep 17 00:00:00 2001
+From: Michal Krawczyk <mk@semihalf.com>
+Date: Tue, 4 Jun 2019 12:59:36 +0200
+Subject: [PATCH 19/19] net/ena: fix assigning NUMA node to IO queue
+
+[ upstream commit 4217cb0b7d2c5385f06f531af7f14b860927aba7 ]
+
+Previous solution was using memzones in invalid way in hope to assign
+IO queue to the appropriate NUMA zone.
+
+The right way is to use socket_id from the rx/tx queue setup function
+and then pass it to the IO queue.
+
+Fixes: 3d3edc265fc8 ("net/ena: make coherent memory allocation NUMA-aware")
+Cc: stable@dpdk.org
+
+Change-Id: I252df018ca6aae9d566618b6967bec0c5b3d939a
+Signed-off-by: Michal Krawczyk <mk@semihalf.com>
+Reviewed-by: David Marchand <david.marchand@redhat.com>
+---
+ drivers/net/ena/ena_ethdev.c | 23 ++++++-----------------
+ drivers/net/ena/ena_ethdev.h |  2 ++
+ 2 files changed, 8 insertions(+), 17 deletions(-)
+
+diff --git a/drivers/net/ena/ena_ethdev.c b/drivers/net/ena/ena_ethdev.c
+index 7998f4e6a..97c8046ed 100644
+--- a/drivers/net/ena/ena_ethdev.c
++++ b/drivers/net/ena/ena_ethdev.c
+@@ -38,7 +38,6 @@
+ #include <rte_dev.h>
+ #include <rte_errno.h>
+ #include <rte_version.h>
+-#include <rte_eal_memconfig.h>
+ 
+ #include "ena_ethdev.h"
+ #include "ena_logs.h"
+@@ -232,18 +231,6 @@ static struct eth_dev_ops ena_dev_ops = {
+ 	.reta_query           = ena_rss_reta_query,
+ };
+ 
+-#define NUMA_NO_NODE	SOCKET_ID_ANY
+-
+-static inline int ena_cpu_to_node(int cpu)
+-{
+-	struct rte_config *config = rte_eal_get_configuration();
+-
+-	if (likely(cpu < RTE_MAX_MEMZONE))
+-		return config->mem_config->memzone[cpu].socket_id;
+-
+-	return NUMA_NO_NODE;
+-}
+-
+ static inline void ena_rx_mbuf_prepare(struct rte_mbuf *mbuf,
+ 				       struct ena_com_rx_ctx *ena_rx_ctx)
+ {
+@@ -938,7 +925,7 @@ static int ena_queue_restart(struct ena_ring *ring)
+ static int ena_tx_queue_setup(struct rte_eth_dev *dev,
+ 			      uint16_t queue_idx,
+ 			      uint16_t nb_desc,
+-			      __rte_unused unsigned int socket_id,
++			      unsigned int socket_id,
+ 			      __rte_unused const struct rte_eth_txconf *tx_conf)
+ {
+ 	struct ena_com_create_io_ctx ctx =
+@@ -983,7 +970,7 @@ static int ena_tx_queue_setup(struct rte_eth_dev *dev,
+ 	ctx.msix_vector = -1; /* admin interrupts not used */
+ 	ctx.mem_queue_type = ena_dev->tx_mem_queue_type;
+ 	ctx.queue_size = adapter->tx_ring_size;
+-	ctx.numa_node = ena_cpu_to_node(queue_idx);
++	ctx.numa_node = socket_id;
+ 
+ 	rc = ena_com_create_io_queue(ena_dev, &ctx);
+ 	if (rc) {
+@@ -1009,6 +996,7 @@ static int ena_tx_queue_setup(struct rte_eth_dev *dev,
+ 	txq->next_to_clean = 0;
+ 	txq->next_to_use = 0;
+ 	txq->ring_size = nb_desc;
++	txq->numa_socket_id = socket_id;
+ 
+ 	txq->tx_buffer_info = rte_zmalloc("txq->tx_buffer_info",
+ 					  sizeof(struct ena_tx_buffer) *
+@@ -1040,7 +1028,7 @@ static int ena_tx_queue_setup(struct rte_eth_dev *dev,
+ static int ena_rx_queue_setup(struct rte_eth_dev *dev,
+ 			      uint16_t queue_idx,
+ 			      uint16_t nb_desc,
+-			      __rte_unused unsigned int socket_id,
++			      unsigned int socket_id,
+ 			      __rte_unused const struct rte_eth_rxconf *rx_conf,
+ 			      struct rte_mempool *mp)
+ {
+@@ -1084,7 +1072,7 @@ static int ena_rx_queue_setup(struct rte_eth_dev *dev,
+ 	ctx.mem_queue_type = ENA_ADMIN_PLACEMENT_POLICY_HOST;
+ 	ctx.msix_vector = -1; /* admin interrupts not used */
+ 	ctx.queue_size = adapter->rx_ring_size;
+-	ctx.numa_node = ena_cpu_to_node(queue_idx);
++	ctx.numa_node = socket_id;
+ 
+ 	rc = ena_com_create_io_queue(ena_dev, &ctx);
+ 	if (rc)
+@@ -1108,6 +1096,7 @@ static int ena_rx_queue_setup(struct rte_eth_dev *dev,
+ 	rxq->next_to_clean = 0;
+ 	rxq->next_to_use = 0;
+ 	rxq->ring_size = nb_desc;
++	rxq->numa_socket_id = socket_id;
+ 	rxq->mb_pool = mp;
+ 
+ 	rxq->rx_buffer_info = rte_zmalloc("rxq->buffer_info",
+diff --git a/drivers/net/ena/ena_ethdev.h b/drivers/net/ena/ena_ethdev.h
+index 4791c53b5..8d5eb5a7c 100644
+--- a/drivers/net/ena/ena_ethdev.h
++++ b/drivers/net/ena/ena_ethdev.h
+@@ -90,6 +90,8 @@ struct ena_ring {
+ 	uint8_t tx_max_header_size;
+ 	int configured;
+ 	struct ena_adapter *adapter;
++
++	unsigned int numa_socket_id;
+ } __rte_cache_aligned;
+ 
+ enum ena_adapter_state {
+-- 
+2.20.1
+

--- a/userspace/dpdk/17.02/0001-net-ena-fix-Rx-descriptors-allocation.patch
+++ b/userspace/dpdk/17.02/0001-net-ena-fix-Rx-descriptors-allocation.patch
@@ -1,7 +1,7 @@
 From ad5f91443d2f6596268e7a0619c9509e00ba3b12 Mon Sep 17 00:00:00 2001
 From: Michal Krawczyk <mk@semihalf.com>
 Date: Mon, 10 Apr 2017 16:28:08 +0200
-Subject: [PATCH 01/17] net/ena: fix Rx descriptors allocation
+Subject: [PATCH 01/21] net/ena: fix Rx descriptors allocation
 
 [ upstream commit a467e8f37a3eec98210c0c3ec04bf6e9506ddd81 ]
 
@@ -64,5 +64,5 @@ index b5e6db624..90cf2ad3c 100644
  	if (ring_size - desc_in_use > ENA_RING_DESCS_RATIO(ring_size))
  		ena_populate_rx_queue(rx_ring, ring_size - desc_in_use);
 -- 
-2.14.1
+2.20.1
 

--- a/userspace/dpdk/17.02/0002-net-ena-fix-delayed-cleanup-of-Rx-descriptors.patch
+++ b/userspace/dpdk/17.02/0002-net-ena-fix-delayed-cleanup-of-Rx-descriptors.patch
@@ -1,7 +1,7 @@
 From 1e449ffd3b2d11d7d296222fce58de4a12b769c6 Mon Sep 17 00:00:00 2001
 From: Michal Krawczyk <mk@semihalf.com>
 Date: Mon, 10 Apr 2017 16:28:09 +0200
-Subject: [PATCH 02/17] net/ena: fix delayed cleanup of Rx descriptors
+Subject: [PATCH 02/21] net/ena: fix delayed cleanup of Rx descriptors
 
 [ upstream commit ec78af6bc0556cf2a1133185ca33fb835b38afe0 ]
 
@@ -47,5 +47,5 @@ index 90cf2ad3c..b4c713f94 100644
  }
  
 -- 
-2.14.1
+2.20.1
 

--- a/userspace/dpdk/17.02/0003-net-ena-cleanup-if-refilling-of-Rx-descriptors-fails.patch
+++ b/userspace/dpdk/17.02/0003-net-ena-cleanup-if-refilling-of-Rx-descriptors-fails.patch
@@ -1,7 +1,7 @@
 From 1b794e3d217507604a567ba692121ccfff415dd7 Mon Sep 17 00:00:00 2001
 From: Michal Krawczyk <mk@semihalf.com>
 Date: Mon, 10 Apr 2017 16:28:10 +0200
-Subject: [PATCH 03/17] net/ena: cleanup if refilling of Rx descriptors fails
+Subject: [PATCH 03/21] net/ena: cleanup if refilling of Rx descriptors fails
 
 [ upstream commit 2732e07ad1e54c648c8ca5bc6965af5bf607ba10 ]
 
@@ -35,5 +35,5 @@ index b4c713f94..e6e889bdd 100644
  			break;
  		}
 -- 
-2.14.1
+2.20.1
 

--- a/userspace/dpdk/17.02/0004-net-ena-calculate-partial-checksum-if-DF-bit-is-disa.patch
+++ b/userspace/dpdk/17.02/0004-net-ena-calculate-partial-checksum-if-DF-bit-is-disa.patch
@@ -1,7 +1,7 @@
 From 931953ad093d51d077a787d5901a33863f33e040 Mon Sep 17 00:00:00 2001
 From: Michal Krawczyk <mk@semihalf.com>
 Date: Mon, 10 Apr 2017 16:28:11 +0200
-Subject: [PATCH 04/17] net/ena: calculate partial checksum if DF bit is
+Subject: [PATCH 04/21] net/ena: calculate partial checksum if DF bit is
  disabled
 
 [ upstream commit bc5ef57d43c5f4ea423734b2aeae070ae19dd91f ]
@@ -18,6 +18,7 @@ frame because we have to look inside the packet to check for the DF flag.
 To make it work properly, PMD is assuming that before sending
 packet application called function rte_eth_tx_prepare().
 
+Change-Id: I0e62aa883e1579ba6288c8ed1dddf1386a72dd6e
 Signed-off-by: Michal Krawczyk <mk@semihalf.com>
 Reviewed-by: Jakub Palider <jpalider@gmail.com>
 Acked-by: Jan Medala <jan.medala@outlook.com>
@@ -84,5 +85,5 @@ index e6e889bdd..3ba990142 100644
  		 * hardware must be provided with partial checksum, otherwise
  		 * it will take care of necessary calculations.
 -- 
-2.14.1
+2.20.1
 

--- a/userspace/dpdk/17.02/0005-net-ena-fix-cleanup-of-the-Tx-bufs.patch
+++ b/userspace/dpdk/17.02/0005-net-ena-fix-cleanup-of-the-Tx-bufs.patch
@@ -1,7 +1,7 @@
 From c5b08a137d41947130192010b99829b84cfdf43c Mon Sep 17 00:00:00 2001
 From: Michal Krawczyk <mk@semihalf.com>
 Date: Fri, 16 Jun 2017 08:19:16 +0000
-Subject: [PATCH 05/17] net/ena: fix cleanup of the Tx bufs
+Subject: [PATCH 05/21] net/ena: fix cleanup of the Tx bufs
 
 [ upstream commit 207a514ce516f8ab3c1ad2b0f930f045b90b773c ]
 
@@ -15,6 +15,7 @@ range between head and tail was being cleaned up.
 Fixes: 1173fca25af9 ("ena: add polling-mode driver")
 Cc: stable@dpdk.org
 
+Change-Id: I17d4e85371b6f6fd44a9d8cea20576ead68303df
 Signed-off-by: Michal Krawczyk <mk@semihalf.com>
 ---
  drivers/net/ena/ena_ethdev.c | 8 ++++----
@@ -48,5 +49,5 @@ index 3ba990142..7fca0278d 100644
  		/* Put back descriptor to the ring for reuse */
  		tx_ring->empty_tx_reqs[next_to_clean & ring_mask] = req_id;
 -- 
-2.14.1
+2.20.1
 

--- a/userspace/dpdk/17.02/0006-net-ena-add-memory-initialization-for-the-allocation.patch
+++ b/userspace/dpdk/17.02/0006-net-ena-add-memory-initialization-for-the-allocation.patch
@@ -1,7 +1,7 @@
 From 3384e8610b2227a436057d385fce01660b9f9afc Mon Sep 17 00:00:00 2001
 From: Michal Krawczyk <mk@semihalf.com>
 Date: Fri, 16 Jun 2017 09:10:48 +0000
-Subject: [PATCH 06/17] net/ena: add memory initialization for the allocation
+Subject: [PATCH 06/21] net/ena: add memory initialization for the allocation
  macros
 
 [ upstream commit 2861ea8df0173f047efe2636ef3b9643d4d989bc ]
@@ -12,6 +12,7 @@ completion of the invalid mbuf.
 Fixes: 3d3edc265fc8 ("net/ena: make coherent memory allocation NUMA-aware")
 Cc: stable@dpdk.org
 
+Change-Id: I54cdf95930b39bcfd26c9ce55853f0b3ddbc5deb
 Signed-off-by: Alexander Matushevsky <matua@amazon.com>
 Signed-off-by: Michal Krawczyk <mk@semihalf.com>
 ---
@@ -39,5 +40,5 @@ index 7eaebf40f..71a8c1e22 100644
  	} while (0)
  
 -- 
-2.14.1
+2.20.1
 

--- a/userspace/dpdk/17.02/0007-net-ena-do-not-set-Tx-L4-offloads-in-Rx-path.patch
+++ b/userspace/dpdk/17.02/0007-net-ena-do-not-set-Tx-L4-offloads-in-Rx-path.patch
@@ -1,7 +1,7 @@
 From e25e5ab7245cd9893f1ede458c35d59685533324 Mon Sep 17 00:00:00 2001
 From: Rafal Kozik <rk@semihalf.com>
 Date: Tue, 9 Jan 2018 16:19:08 +0100
-Subject: [PATCH 07/17] net/ena: do not set Tx L4 offloads in Rx path
+Subject: [PATCH 07/21] net/ena: do not set Tx L4 offloads in Rx path
 
 [ upstream commit fd617795679019c7aea5ab1e8c85db02cf53f169 ]
 
@@ -14,6 +14,7 @@ correct.
 Fixes: 1173fca25af9 ("ena: add polling-mode driver")
 Cc: stable@dpdk.org
 
+Change-Id: Icd33c149403377cacf5663b21029cbdc30ccb125
 Reported-by: Matthew Smith <mgsmith@netgate.com>
 Signed-off-by: Rafal Kozik <rk@semihalf.com>
 Signed-off-by: Michal Krawczyk <mk@semihalf.com>
@@ -56,5 +57,5 @@ index 7fca0278d..b7812c62b 100644
  
  static inline void ena_tx_mbuf_prepare(struct rte_mbuf *mbuf,
 -- 
-2.14.1
+2.20.1
 

--- a/userspace/dpdk/17.02/0008-net-ena-check-pointer-before-memset.patch
+++ b/userspace/dpdk/17.02/0008-net-ena-check-pointer-before-memset.patch
@@ -1,7 +1,7 @@
 From 268c0b4c464a91261fdd006d2865e514bf0471b3 Mon Sep 17 00:00:00 2001
 From: Rafal Kozik <rk@semihalf.com>
 Date: Thu, 7 Jun 2018 11:43:18 +0200
-Subject: [PATCH 08/17] net/ena: check pointer before memset
+Subject: [PATCH 08/21] net/ena: check pointer before memset
 
 [ upstream commit 46916aa17d4b2007df8c0454f99ba0ca8b8cb93b ]
 
@@ -11,6 +11,7 @@ Using memset on NULL pointer cause segfault.
 Fixes: 9ba7981ec992 ("ena: add communication layer for DPDK")
 Cc: stable@dpdk.org
 
+Change-Id: I7f7d1150234fd49312d9104d9603752ee4a3a0c8
 Signed-off-by: Rafal Kozik <rk@semihalf.com>
 Acked-by: Michal Krawczyk <mk@semihalf.com>
 ---
@@ -59,5 +60,5 @@ index 71a8c1e22..955d6302d 100644
  
  #define ENA_MEM_ALLOC_NODE(dmadev, size, virt, node, dev_node) \
 -- 
-2.14.1
+2.20.1
 

--- a/userspace/dpdk/17.02/0009-net-ena-change-memory-type.patch
+++ b/userspace/dpdk/17.02/0009-net-ena-change-memory-type.patch
@@ -1,7 +1,7 @@
 From 4e5f623eff43540c140ae98df593163a6b516d23 Mon Sep 17 00:00:00 2001
 From: Rafal Kozik <rk@semihalf.com>
 Date: Thu, 7 Jun 2018 11:43:19 +0200
-Subject: [PATCH 09/17] net/ena: change memory type
+Subject: [PATCH 09/21] net/ena: change memory type
 
 [ upstream commit 9f32c7e7e6ce58ab772913f54f8328c1c0186a17 ]
 
@@ -14,6 +14,7 @@ To avoid both issue use rte_zmalloc_socket.
 Fixes: 3d3edc265fc8 ("net/ena: make coherent memory allocation NUMA-aware")
 Cc: stable@dpdk.org
 
+Change-Id: I09427bfc0d3b7f90771c5a7be16aef3b95bd9069
 Signed-off-by: Rafal Kozik <rk@semihalf.com>
 Acked-by: Michal Krawczyk <mk@semihalf.com>
 ---
@@ -41,5 +42,5 @@ index 955d6302d..977bee49f 100644
  
  #define ENA_MEM_ALLOC(dmadev, size) rte_zmalloc(NULL, size, 1)
 -- 
-2.14.1
+2.20.1
 

--- a/userspace/dpdk/17.02/0010-net-ena-fix-GENMASK_ULL-macro.patch
+++ b/userspace/dpdk/17.02/0010-net-ena-fix-GENMASK_ULL-macro.patch
@@ -1,7 +1,7 @@
 From aad5c2696533c1d07b2eaba8fec10f45fa5caf6d Mon Sep 17 00:00:00 2001
 From: Rafal Kozik <rk@semihalf.com>
 Date: Thu, 7 Jun 2018 11:43:20 +0200
-Subject: [PATCH 10/17] net/ena: fix GENMASK_ULL macro
+Subject: [PATCH 10/21] net/ena: fix GENMASK_ULL macro
 
 [ upstream commit 7544aee8d0b4ae0262b1ba7e1539cf8171664df7 ]
 
@@ -12,6 +12,7 @@ is undefined operation and failed on some platforms.
 Fixes: 9ba7981ec992 ("ena: add communication layer for DPDK")
 Cc: stable@dpdk.org
 
+Change-Id: I2094d149a9ff038824ebdff734b2e47bcb0f003f
 Signed-off-by: Rafal Kozik <rk@semihalf.com>
 Acked-by: Michal Krawczyk <mk@semihalf.com>
 ---
@@ -38,5 +39,5 @@ index 977bee49f..06b637870 100644
  #ifdef RTE_LIBRTE_ENA_COM_DEBUG
  #define ena_trc_dbg(format, arg...)					\
 -- 
-2.14.1
+2.20.1
 

--- a/userspace/dpdk/17.02/0011-net-ena-set-link-speed-as-none.patch
+++ b/userspace/dpdk/17.02/0011-net-ena-set-link-speed-as-none.patch
@@ -1,7 +1,7 @@
 From 80d00b05a0978bc71fb656ae421e7e5443310e2e Mon Sep 17 00:00:00 2001
 From: Rafal Kozik <rk@semihalf.com>
 Date: Thu, 7 Jun 2018 11:43:22 +0200
-Subject: [PATCH 11/17] net/ena: set link speed as none
+Subject: [PATCH 11/21] net/ena: set link speed as none
 
 [ upstream commit 41e59028dd8ab2038a7655c6fc3098222661aa53 ]
 
@@ -13,6 +13,7 @@ rely on this value when using ENA PMD.
 Fixes: 1173fca25af9 ("ena: add polling-mode driver")
 Cc: stable@dpdk.org
 
+Change-Id: I046f53eb179ba5171c687038820045affee833f3
 Signed-off-by: Rafal Kozik <rk@semihalf.com>
 Acked-by: Michal Krawczyk <mk@semihalf.com>
 ---
@@ -33,5 +34,5 @@ index b7812c62b..13eeb6b7b 100644
  
  	return 0;
 -- 
-2.14.1
+2.20.1
 

--- a/userspace/dpdk/17.02/0012-net-ena-fix-SIGFPE-with-0-Rx-queue.patch
+++ b/userspace/dpdk/17.02/0012-net-ena-fix-SIGFPE-with-0-Rx-queue.patch
@@ -1,7 +1,7 @@
 From 3288b6f499b06608b5b506a0e67536a1cf5376be Mon Sep 17 00:00:00 2001
 From: Daria Kolistratova <daria.kolistratova@intel.com>
 Date: Tue, 26 Jun 2018 18:38:56 +0100
-Subject: [PATCH 12/17] net/ena: fix SIGFPE with 0 Rx queue
+Subject: [PATCH 12/21] net/ena: fix SIGFPE with 0 Rx queue
 
 [ upstream commit 361913ad6f8c05fc541fe4bfdae3b0dc095ae3af ]
 
@@ -11,6 +11,7 @@ It happens when the application is also requesting ETH_MQ_RX_RSS_FLAG
 in the rte_dev->data->dev_conf.rxmode.mq_mode.
 Fixed adding zero rx queues check.
 
+Change-Id: I04fff738df0134172be5443cdc1af3a3b35a2c32
 Signed-off-by: Daria Kolistratova <daria.kolistratova@intel.com>
 Acked-by: Michal Krawczyk <mk@semihalf.com>
 ---
@@ -31,5 +32,5 @@ index 13eeb6b7b..72473e06a 100644
  		if (rc)
  			return rc;
 -- 
-2.14.1
+2.20.1
 

--- a/userspace/dpdk/17.02/0013-net-ena-fix-passing-RSS-hash-to-mbuf.patch
+++ b/userspace/dpdk/17.02/0013-net-ena-fix-passing-RSS-hash-to-mbuf.patch
@@ -1,7 +1,7 @@
 From bbff4cdbd2b5a9e2d32843e9314252a25bebd70e Mon Sep 17 00:00:00 2001
 From: Stewart Allen <allenste@amazon.com>
 Date: Thu, 25 Oct 2018 19:59:22 +0200
-Subject: [PATCH 13/17] net/ena: fix passing RSS hash to mbuf
+Subject: [PATCH 13/21] net/ena: fix passing RSS hash to mbuf
 
 [ upstream commit e5df9f33db00eb9d322abaefff30da74fd0e625d ]
 
@@ -11,6 +11,7 @@ from the device. Now, the RSS hash from the Rx descriptor is being set.
 Fixes: 1173fca25af9 ("ena: add polling-mode driver")
 Cc: stable@dpdk.org
 
+Change-Id: Iea37e68a1d685800166fa3733f150ad79a2e0b25
 Signed-off-by: Stewart Allen <allenste@amazon.com>
 Acked-by: Michal Krawczyk <mk@semihalf.com>
 ---
@@ -31,5 +32,5 @@ index 72473e06a..837ab468c 100644
  		/* pass to DPDK application head mbuf */
  		rx_pkts[recv_idx] = mbuf_head;
 -- 
-2.14.1
+2.20.1
 

--- a/userspace/dpdk/17.02/0014-net-ena-add-supported-RSS-offloads-types.patch
+++ b/userspace/dpdk/17.02/0014-net-ena-add-supported-RSS-offloads-types.patch
@@ -1,7 +1,7 @@
 From 69a5de44b392f04c27822cc5086bb89926eae1bf Mon Sep 17 00:00:00 2001
 From: Rafal Kozik <rk@semihalf.com>
 Date: Fri, 14 Dec 2018 14:18:38 +0100
-Subject: [PATCH 14/17] net/ena: add supported RSS offloads types
+Subject: [PATCH 14/21] net/ena: add supported RSS offloads types
 
 [ upstream commit b01ead202beb45346d7daeb2f2b1a608006af644 ]
 
@@ -12,6 +12,7 @@ missing information was added.
 Fixes: 1173fca25af9 ("ena: add polling-mode driver")
 Cc: stable@dpdk.org
 
+Change-Id: I1bd653526a00906db0d07673de73948ab8e67fec
 Signed-off-by: Rafal Kozik <rk@semihalf.com>
 Acked-by: Michal Krawczyk <mk@semihalf.com>
 ---
@@ -33,5 +34,5 @@ index 837ab468c..7c9ec59f8 100644
  	dev_info->max_rx_pktlen  = adapter->max_mtu;
  	dev_info->max_mac_addrs = 1;
 -- 
-2.14.1
+2.20.1
 

--- a/userspace/dpdk/17.02/0015-net-ena-update-completion-queue-after-cleanup.patch
+++ b/userspace/dpdk/17.02/0015-net-ena-update-completion-queue-after-cleanup.patch
@@ -1,7 +1,7 @@
 From 70b364b1f505d3328719e72db955569b39c5049b Mon Sep 17 00:00:00 2001
 From: Rafal Kozik <rk@semihalf.com>
 Date: Fri, 14 Dec 2018 14:18:44 +0100
-Subject: [PATCH 15/17] net/ena: update completion queue after cleanup
+Subject: [PATCH 15/21] net/ena: update completion queue after cleanup
 
 [ upstream commit a45462c507e98b49cb5c2302e0be3c72d2e20a1a ]
 
@@ -11,6 +11,7 @@ ena_com_update_dev_comp_head().
 Fixes: 1daff5260ff8 ("net/ena: use unmasked head and tail")
 Cc: stable@dpdk.org
 
+Change-Id: I6c540b6b20205571d8759a7ef4c5835a6c8466cf
 Signed-off-by: Rafal Kozik <rk@semihalf.com>
 Acked-by: Michal Krawczyk <mk@semihalf.com>
 ---
@@ -45,5 +46,5 @@ index 7c9ec59f8..932f711c2 100644
  
  	return sent_idx;
 -- 
-2.14.1
+2.20.1
 

--- a/userspace/dpdk/17.02/0016-net-ena-fix-dev-init-with-multi-process.patch
+++ b/userspace/dpdk/17.02/0016-net-ena-fix-dev-init-with-multi-process.patch
@@ -1,7 +1,7 @@
 From 47327061cdf32a07923a985a9142bd3a079ec890 Mon Sep 17 00:00:00 2001
 From: Michal Krawczyk <mk@semihalf.com>
 Date: Fri, 25 Jan 2019 09:10:25 +0100
-Subject: [PATCH 16/17] net/ena: fix dev init with multi-process
+Subject: [PATCH 16/21] net/ena: fix dev init with multi-process
 
 [ upstream commit fd9768905870856a2340266d25f8c0100dfccfff ]
 
@@ -15,6 +15,7 @@ main process.
 Fixes: 1173fca25af9 ("ena: add polling-mode driver")
 Cc: stable@dpdk.org
 
+Change-Id: Icd37ab0bfc5324a7fbec4248e9e028f54e2026a2
 Signed-off-by: Michal Krawczyk <mk@semihalf.com>
 ---
  drivers/net/ena/ena_ethdev.c | 11 ++++++-----
@@ -51,5 +52,5 @@ index 932f711c2..aad3ab458 100644
  	adapter->pdev = pci_dev;
  
 -- 
-2.14.1
+2.20.1
 

--- a/userspace/dpdk/17.02/0017-net-ena-fix-errno-to-positive-value.patch
+++ b/userspace/dpdk/17.02/0017-net-ena-fix-errno-to-positive-value.patch
@@ -1,7 +1,7 @@
 From 0040e38ff046ca7029dbd53705224dcb745c6d19 Mon Sep 17 00:00:00 2001
 From: Michal Krawczyk <mk@semihalf.com>
 Date: Fri, 25 Jan 2019 09:10:26 +0100
-Subject: [PATCH 17/17] net/ena: fix errno to positive value
+Subject: [PATCH 17/21] net/ena: fix errno to positive value
 
 [ upstream commit baeed5f404dd1b049118cfec26a2fd3203671572 ]
 
@@ -11,6 +11,7 @@ to be fixed.
 Fixes: b3fc5a1ae10d ("net/ena: add Tx preparation")
 Cc: stable@dpdk.org
 
+Change-Id: If87b7246991ba450182fb48724b3a46977810602
 Signed-off-by: Michal Krawczyk <mk@semihalf.com>
 ---
  drivers/net/ena/ena_ethdev.c | 6 +++---
@@ -47,5 +48,5 @@ index aad3ab458..6c791f2a9 100644
  		}
  	}
 -- 
-2.14.1
+2.20.1
 

--- a/userspace/dpdk/17.02/0018-net-ena-get-device-info-statically.patch
+++ b/userspace/dpdk/17.02/0018-net-ena-get-device-info-statically.patch
@@ -1,0 +1,123 @@
+From 61a20a71541a8e3a20f74a02296fd8d26a71cc6b Mon Sep 17 00:00:00 2001
+From: Michal Krawczyk <mk@semihalf.com>
+Date: Fri, 15 Feb 2019 09:36:39 +0100
+Subject: [PATCH 18/21] net/ena: get device info statically
+
+[ upstream commit 117ba4a60488a0f96a5737f38ddba6d0f9a728b6 ]
+
+Whenever the app is calling rte_eth_dev_info_get(), it shouldn't use the
+admin command. It was causing problems, if it was called from the
+secondary process - the main process was crashing, and the secondary app
+wasn't getting any result, as the admin request couldn't be processed by
+the process which was requesting the data.
+
+To fix that, the data is being written to the adapter structure during
+device initialization routine.
+
+Change-Id: I94f61f51223725602f70ac9795acf02b7b014984
+Signed-off-by: Michal Krawczyk <mk@semihalf.com>
+---
+ drivers/net/ena/ena_ethdev.c | 31 ++++++++++++-------------------
+ drivers/net/ena/ena_ethdev.h |  8 +++++++-
+ 2 files changed, 19 insertions(+), 20 deletions(-)
+
+diff --git a/drivers/net/ena/ena_ethdev.c b/drivers/net/ena/ena_ethdev.c
+index 6c791f2a9..c3c655dd8 100644
+--- a/drivers/net/ena/ena_ethdev.c
++++ b/drivers/net/ena/ena_ethdev.c
+@@ -1360,9 +1360,14 @@ static int eth_ena_dev_init(struct rte_eth_dev *eth_dev)
+ 	/* Set max MTU for this device */
+ 	adapter->max_mtu = get_feat_ctx.dev_attr.max_mtu;
+ 
+-	/* set device support for TSO */
+-	adapter->tso4_supported = get_feat_ctx.offload.tx &
+-				  ENA_ADMIN_FEATURE_OFFLOAD_DESC_TSO_IPV4_MASK;
++	/* set device support for offloads */
++	adapter->offloads.tso4_supported = (get_feat_ctx.offload.tx &
++		ENA_ADMIN_FEATURE_OFFLOAD_DESC_TSO_IPV4_MASK) != 0;
++	adapter->offloads.tx_csum_supported = (get_feat_ctx.offload.tx &
++		ENA_ADMIN_FEATURE_OFFLOAD_DESC_TX_L4_IPV4_CSUM_PART_MASK) != 0;
++	adapter->offloads.tx_csum_supported =
++		(get_feat_ctx.offload.rx_supported &
++		ENA_ADMIN_FEATURE_OFFLOAD_DESC_RX_L4_IPV4_CSUM_MASK) != 0;
+ 
+ 	/* Copy MAC address and point DPDK to it */
+ 	eth_dev->data->mac_addrs = (struct ether_addr *)adapter->mac_addr;
+@@ -1441,9 +1446,7 @@ static void ena_infos_get(struct rte_eth_dev *dev,
+ {
+ 	struct ena_adapter *adapter;
+ 	struct ena_com_dev *ena_dev;
+-	struct ena_com_dev_get_features_ctx feat;
+ 	uint32_t rx_feat = 0, tx_feat = 0;
+-	int rc = 0;
+ 
+ 	ena_assert_msg(dev->data != NULL, "Uninitialized device");
+ 	ena_assert_msg(dev->data->dev_private != NULL, "Uninitialized device");
+@@ -1464,26 +1467,16 @@ static void ena_infos_get(struct rte_eth_dev *dev,
+ 			ETH_LINK_SPEED_50G  |
+ 			ETH_LINK_SPEED_100G;
+ 
+-	/* Get supported features from HW */
+-	rc = ena_com_get_dev_attr_feat(ena_dev, &feat);
+-	if (unlikely(rc)) {
+-		RTE_LOG(ERR, PMD,
+-			"Cannot get attribute for ena device rc= %d\n", rc);
+-		return;
+-	}
+-
+ 	/* Set Tx & Rx features available for device */
+-	if (feat.offload.tx & ENA_ADMIN_FEATURE_OFFLOAD_DESC_TSO_IPV4_MASK)
++	if (adapter->offloads.tso4_supported)
+ 		tx_feat	|= DEV_TX_OFFLOAD_TCP_TSO;
+ 
+-	if (feat.offload.tx &
+-	    ENA_ADMIN_FEATURE_OFFLOAD_DESC_TX_L4_IPV4_CSUM_PART_MASK)
++	if (adapter->offloads.tx_csum_supported)
+ 		tx_feat |= DEV_TX_OFFLOAD_IPV4_CKSUM |
+ 			DEV_TX_OFFLOAD_UDP_CKSUM |
+ 			DEV_TX_OFFLOAD_TCP_CKSUM;
+ 
+-	if (feat.offload.rx_supported &
+-	    ENA_ADMIN_FEATURE_OFFLOAD_DESC_RX_L4_IPV4_CSUM_MASK)
++	if (adapter->offloads.rx_csum_supported)
+ 		rx_feat |= DEV_RX_OFFLOAD_IPV4_CKSUM |
+ 			DEV_RX_OFFLOAD_UDP_CKSUM  |
+ 			DEV_RX_OFFLOAD_TCP_CKSUM;
+@@ -1629,7 +1622,7 @@ eth_ena_prep_pkts(void *tx_queue, struct rte_mbuf **tx_pkts,
+ 			/* If IPv4 header has DF flag enabled and TSO support is
+ 			 * disabled, partial chcecksum should not be calculated.
+ 			 */
+-			if (!tx_ring->adapter->tso4_supported)
++			if (!tx_ring->adapter->offloads.tso4_supported)
+ 				continue;
+ 		}
+ 
+diff --git a/drivers/net/ena/ena_ethdev.h b/drivers/net/ena/ena_ethdev.h
+index dc3080ffd..4791c53b5 100644
+--- a/drivers/net/ena/ena_ethdev.h
++++ b/drivers/net/ena/ena_ethdev.h
+@@ -143,6 +143,12 @@ struct ena_stats_rx {
+ 	u64 small_copy_len_pkt;
+ };
+ 
++struct ena_offloads {
++	bool tso4_supported;
++	bool tx_csum_supported;
++	bool rx_csum_supported;
++};
++
+ /* board specific private data structure */
+ struct ena_adapter {
+ 	/* OS defined structs */
+@@ -162,7 +168,7 @@ struct ena_adapter {
+ 
+ 	u16 num_queues;
+ 	u16 max_mtu;
+-	u8 tso4_supported;
++	struct ena_offloads offloads;
+ 
+ 	int id_number;
+ 	char name[ENA_NAME_MAX_LEN];
+-- 
+2.20.1
+

--- a/userspace/dpdk/17.02/0019-net-ena-fix-checksum-feature-flag.patch
+++ b/userspace/dpdk/17.02/0019-net-ena-fix-checksum-feature-flag.patch
@@ -1,0 +1,35 @@
+From 92e3acef5333b7b45928bd79f7fa137939b5c612 Mon Sep 17 00:00:00 2001
+From: Michal Krawczyk <mk@semihalf.com>
+Date: Mon, 8 Apr 2019 12:27:44 +0200
+Subject: [PATCH 19/21] net/ena: fix checksum feature flag
+
+[ upstream commit ef538c1a7f565c9b58518375a500aa864445fd11 ]
+
+The boolean value was assigned to Tx flag twice, so it could cause bug
+whenever Rx checksum will not be supported and Tx will be.
+
+Coverity issue: 336831
+Fixes: 117ba4a60488 ("net/ena: get device info statically")
+
+Change-Id: Id1ca7bb11b566c35ab7c9691593dcab40263c0f7
+Signed-off-by: Michal Krawczyk <mk@semihalf.com>
+---
+ drivers/net/ena/ena_ethdev.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/drivers/net/ena/ena_ethdev.c b/drivers/net/ena/ena_ethdev.c
+index c3c655dd8..c011e9382 100644
+--- a/drivers/net/ena/ena_ethdev.c
++++ b/drivers/net/ena/ena_ethdev.c
+@@ -1365,7 +1365,7 @@ static int eth_ena_dev_init(struct rte_eth_dev *eth_dev)
+ 		ENA_ADMIN_FEATURE_OFFLOAD_DESC_TSO_IPV4_MASK) != 0;
+ 	adapter->offloads.tx_csum_supported = (get_feat_ctx.offload.tx &
+ 		ENA_ADMIN_FEATURE_OFFLOAD_DESC_TX_L4_IPV4_CSUM_PART_MASK) != 0;
+-	adapter->offloads.tx_csum_supported =
++	adapter->offloads.rx_csum_supported =
+ 		(get_feat_ctx.offload.rx_supported &
+ 		ENA_ADMIN_FEATURE_OFFLOAD_DESC_RX_L4_IPV4_CSUM_MASK) != 0;
+ 
+-- 
+2.20.1
+

--- a/userspace/dpdk/17.02/0020-net-ena-fix-Rx-checksum-errors-statistics.patch
+++ b/userspace/dpdk/17.02/0020-net-ena-fix-Rx-checksum-errors-statistics.patch
@@ -1,0 +1,52 @@
+From 75fb64525968b152921a89eee76ae51884e13831 Mon Sep 17 00:00:00 2001
+From: Michal Krawczyk <mk@semihalf.com>
+Date: Tue, 28 May 2019 10:28:34 +0200
+Subject: [PATCH 20/21] net/ena: fix Rx checksum errors statistics
+
+[ upstream commit ef74b5f7b69b9502ddab81121611243efcfe1dde ]
+
+Rx checksum flags and input errors shouldn't be updated on Tx, as it
+would work only for packets forwarding.
+
+The ierrors statistic should be updated on Rx, right after checking
+Rx checksum flags if the Rx checksum offload is enabled.
+
+Fixes: 1173fca25af9 ("ena: add polling-mode driver")
+Cc: stable@dpdk.org
+
+Change-Id: I4ccf68bcb1ef6b50d01c811fc7f050a3d7ec9966
+Signed-off-by: Michal Krawczyk <mk@semihalf.com>
+---
+ drivers/net/ena/ena_ethdev.c | 9 +++++----
+ 1 file changed, 5 insertions(+), 4 deletions(-)
+
+diff --git a/drivers/net/ena/ena_ethdev.c b/drivers/net/ena/ena_ethdev.c
+index c011e9382..eeb85cbe4 100644
+--- a/drivers/net/ena/ena_ethdev.c
++++ b/drivers/net/ena/ena_ethdev.c
+@@ -1568,6 +1568,11 @@ static uint16_t eth_ena_recv_pkts(void *rx_queue, struct rte_mbuf **rx_pkts,
+ 
+ 		/* fill mbuf attributes if any */
+ 		ena_rx_mbuf_prepare(mbuf_head, &ena_rx_ctx);
++
++		if (unlikely(mbuf_head->ol_flags &
++				(PKT_RX_IP_CKSUM_BAD | PKT_RX_L4_CKSUM_BAD)))
++			rte_atomic64_inc(&rx_ring->adapter->drv_stats->ierrors);
++
+ 		mbuf_head->hash.rss = ena_rx_ctx.hash;
+ 
+ 		/* pass to DPDK application head mbuf */
+@@ -1715,10 +1720,6 @@ static uint16_t eth_ena_xmit_pkts(void *tx_queue, struct rte_mbuf **tx_pkts,
+ 		/* Set TX offloads flags, if applicable */
+ 		ena_tx_mbuf_prepare(mbuf, &ena_tx_ctx);
+ 
+-		if (unlikely(mbuf->ol_flags &
+-			     (PKT_RX_L4_CKSUM_BAD | PKT_RX_IP_CKSUM_BAD)))
+-			rte_atomic64_inc(&tx_ring->adapter->drv_stats->ierrors);
+-
+ 		rte_prefetch0(tx_pkts[(sent_idx + 4) & ring_mask]);
+ 
+ 		/* Process first segment taking into
+-- 
+2.20.1
+

--- a/userspace/dpdk/17.02/0021-net-ena-fix-assigning-NUMA-node-to-IO-queue.patch
+++ b/userspace/dpdk/17.02/0021-net-ena-fix-assigning-NUMA-node-to-IO-queue.patch
@@ -1,0 +1,123 @@
+From de5f761f4c19ea0b848c82119497f5d903ce8fb0 Mon Sep 17 00:00:00 2001
+From: Michal Krawczyk <mk@semihalf.com>
+Date: Tue, 4 Jun 2019 12:59:36 +0200
+Subject: [PATCH 21/21] net/ena: fix assigning NUMA node to IO queue
+
+[ upstream commit 4217cb0b7d2c5385f06f531af7f14b860927aba7 ]
+
+Previous solution was using memzones in invalid way in hope to assign
+IO queue to the appropriate NUMA zone.
+
+The right way is to use socket_id from the rx/tx queue setup function
+and then pass it to the IO queue.
+
+Fixes: 3d3edc265fc8 ("net/ena: make coherent memory allocation NUMA-aware")
+Cc: stable@dpdk.org
+
+Change-Id: I252df018ca6aae9d566618b6967bec0c5b3d939a
+Signed-off-by: Michal Krawczyk <mk@semihalf.com>
+Reviewed-by: David Marchand <david.marchand@redhat.com>
+---
+ drivers/net/ena/ena_ethdev.c | 23 ++++++-----------------
+ drivers/net/ena/ena_ethdev.h |  2 ++
+ 2 files changed, 8 insertions(+), 17 deletions(-)
+
+diff --git a/drivers/net/ena/ena_ethdev.c b/drivers/net/ena/ena_ethdev.c
+index eeb85cbe4..cc0e50e93 100644
+--- a/drivers/net/ena/ena_ethdev.c
++++ b/drivers/net/ena/ena_ethdev.c
+@@ -38,7 +38,6 @@
+ #include <rte_dev.h>
+ #include <rte_errno.h>
+ #include <rte_version.h>
+-#include <rte_eal_memconfig.h>
+ #include <rte_net.h>
+ 
+ #include "ena_ethdev.h"
+@@ -243,18 +242,6 @@ static const struct eth_dev_ops ena_dev_ops = {
+ 	.reta_query           = ena_rss_reta_query,
+ };
+ 
+-#define NUMA_NO_NODE	SOCKET_ID_ANY
+-
+-static inline int ena_cpu_to_node(int cpu)
+-{
+-	struct rte_config *config = rte_eal_get_configuration();
+-
+-	if (likely(cpu < RTE_MAX_MEMZONE))
+-		return config->mem_config->memzone[cpu].socket_id;
+-
+-	return NUMA_NO_NODE;
+-}
+-
+ static inline void ena_rx_mbuf_prepare(struct rte_mbuf *mbuf,
+ 				       struct ena_com_rx_ctx *ena_rx_ctx)
+ {
+@@ -944,7 +931,7 @@ static int ena_queue_restart(struct ena_ring *ring)
+ static int ena_tx_queue_setup(struct rte_eth_dev *dev,
+ 			      uint16_t queue_idx,
+ 			      uint16_t nb_desc,
+-			      __rte_unused unsigned int socket_id,
++			      unsigned int socket_id,
+ 			      __rte_unused const struct rte_eth_txconf *tx_conf)
+ {
+ 	struct ena_com_create_io_ctx ctx =
+@@ -989,7 +976,7 @@ static int ena_tx_queue_setup(struct rte_eth_dev *dev,
+ 	ctx.msix_vector = -1; /* admin interrupts not used */
+ 	ctx.mem_queue_type = ena_dev->tx_mem_queue_type;
+ 	ctx.queue_size = adapter->tx_ring_size;
+-	ctx.numa_node = ena_cpu_to_node(queue_idx);
++	ctx.numa_node = socket_id;
+ 
+ 	rc = ena_com_create_io_queue(ena_dev, &ctx);
+ 	if (rc) {
+@@ -1015,6 +1002,7 @@ static int ena_tx_queue_setup(struct rte_eth_dev *dev,
+ 	txq->next_to_clean = 0;
+ 	txq->next_to_use = 0;
+ 	txq->ring_size = nb_desc;
++	txq->numa_socket_id = socket_id;
+ 
+ 	txq->tx_buffer_info = rte_zmalloc("txq->tx_buffer_info",
+ 					  sizeof(struct ena_tx_buffer) *
+@@ -1046,7 +1034,7 @@ static int ena_tx_queue_setup(struct rte_eth_dev *dev,
+ static int ena_rx_queue_setup(struct rte_eth_dev *dev,
+ 			      uint16_t queue_idx,
+ 			      uint16_t nb_desc,
+-			      __rte_unused unsigned int socket_id,
++			      unsigned int socket_id,
+ 			      __rte_unused const struct rte_eth_rxconf *rx_conf,
+ 			      struct rte_mempool *mp)
+ {
+@@ -1090,7 +1078,7 @@ static int ena_rx_queue_setup(struct rte_eth_dev *dev,
+ 	ctx.mem_queue_type = ENA_ADMIN_PLACEMENT_POLICY_HOST;
+ 	ctx.msix_vector = -1; /* admin interrupts not used */
+ 	ctx.queue_size = adapter->rx_ring_size;
+-	ctx.numa_node = ena_cpu_to_node(queue_idx);
++	ctx.numa_node = socket_id;
+ 
+ 	rc = ena_com_create_io_queue(ena_dev, &ctx);
+ 	if (rc)
+@@ -1114,6 +1102,7 @@ static int ena_rx_queue_setup(struct rte_eth_dev *dev,
+ 	rxq->next_to_clean = 0;
+ 	rxq->next_to_use = 0;
+ 	rxq->ring_size = nb_desc;
++	rxq->numa_socket_id = socket_id;
+ 	rxq->mb_pool = mp;
+ 
+ 	rxq->rx_buffer_info = rte_zmalloc("rxq->buffer_info",
+diff --git a/drivers/net/ena/ena_ethdev.h b/drivers/net/ena/ena_ethdev.h
+index 4791c53b5..8d5eb5a7c 100644
+--- a/drivers/net/ena/ena_ethdev.h
++++ b/drivers/net/ena/ena_ethdev.h
+@@ -90,6 +90,8 @@ struct ena_ring {
+ 	uint8_t tx_max_header_size;
+ 	int configured;
+ 	struct ena_adapter *adapter;
++
++	unsigned int numa_socket_id;
+ } __rte_cache_aligned;
+ 
+ enum ena_adapter_state {
+-- 
+2.20.1
+

--- a/userspace/dpdk/17.05/0001-net-ena-fix-cleanup-of-the-Tx-bufs.patch
+++ b/userspace/dpdk/17.05/0001-net-ena-fix-cleanup-of-the-Tx-bufs.patch
@@ -1,7 +1,7 @@
 From c9a25c151987fb41fe6cd2dd036caef5fbf275c5 Mon Sep 17 00:00:00 2001
 From: Michal Krawczyk <mk@semihalf.com>
 Date: Fri, 16 Jun 2017 08:19:16 +0000
-Subject: [PATCH 01/13] net/ena: fix cleanup of the Tx bufs
+Subject: [PATCH 01/17] net/ena: fix cleanup of the Tx bufs
 
 [ upstream commit 207a514ce516f8ab3c1ad2b0f930f045b90b773c ]
 
@@ -15,6 +15,7 @@ range between head and tail was being cleaned up.
 Fixes: 1173fca25af9 ("ena: add polling-mode driver")
 Cc: stable@dpdk.org
 
+Change-Id: I17d4e85371b6f6fd44a9d8cea20576ead68303df
 Signed-off-by: Michal Krawczyk <mk@semihalf.com>
 ---
  drivers/net/ena/ena_ethdev.c | 8 ++++----
@@ -48,5 +49,5 @@ index 64fee05d3..ce07a26d0 100644
  		/* Put back descriptor to the ring for reuse */
  		tx_ring->empty_tx_reqs[next_to_clean & ring_mask] = req_id;
 -- 
-2.14.1
+2.20.1
 

--- a/userspace/dpdk/17.05/0002-net-ena-add-memory-initialization-for-the-allocation.patch
+++ b/userspace/dpdk/17.05/0002-net-ena-add-memory-initialization-for-the-allocation.patch
@@ -1,7 +1,7 @@
 From ed58565307ee85a621183c98c95fd69099a9017c Mon Sep 17 00:00:00 2001
 From: Michal Krawczyk <mk@semihalf.com>
 Date: Fri, 16 Jun 2017 09:10:48 +0000
-Subject: [PATCH 02/13] net/ena: add memory initialization for the allocation
+Subject: [PATCH 02/17] net/ena: add memory initialization for the allocation
  macros
 
 [ upstream commit 2861ea8df0173f047efe2636ef3b9643d4d989bc ]
@@ -12,6 +12,7 @@ completion of the invalid mbuf.
 Fixes: 3d3edc265fc8 ("net/ena: make coherent memory allocation NUMA-aware")
 Cc: stable@dpdk.org
 
+Change-Id: I54cdf95930b39bcfd26c9ce55853f0b3ddbc5deb
 Signed-off-by: Alexander Matushevsky <matua@amazon.com>
 Signed-off-by: Michal Krawczyk <mk@semihalf.com>
 ---
@@ -39,5 +40,5 @@ index 7eaebf40f..71a8c1e22 100644
  	} while (0)
  
 -- 
-2.14.1
+2.20.1
 

--- a/userspace/dpdk/17.05/0003-net-ena-do-not-set-Tx-L4-offloads-in-Rx-path.patch
+++ b/userspace/dpdk/17.05/0003-net-ena-do-not-set-Tx-L4-offloads-in-Rx-path.patch
@@ -1,7 +1,7 @@
 From cb942c4ed75cafaae651588248cda7ec94afd99c Mon Sep 17 00:00:00 2001
 From: Rafal Kozik <rk@semihalf.com>
 Date: Tue, 9 Jan 2018 16:19:08 +0100
-Subject: [PATCH 03/13] net/ena: do not set Tx L4 offloads in Rx path
+Subject: [PATCH 03/17] net/ena: do not set Tx L4 offloads in Rx path
 
 [ upstream commit fd617795679019c7aea5ab1e8c85db02cf53f169 ]
 
@@ -14,6 +14,7 @@ correct.
 Fixes: 1173fca25af9 ("ena: add polling-mode driver")
 Cc: stable@dpdk.org
 
+Change-Id: Icd33c149403377cacf5663b21029cbdc30ccb125
 Reported-by: Matthew Smith <mgsmith@netgate.com>
 Signed-off-by: Rafal Kozik <rk@semihalf.com>
 Signed-off-by: Michal Krawczyk <mk@semihalf.com>
@@ -56,5 +57,5 @@ index ce07a26d0..58b0b6355 100644
  
  static inline void ena_tx_mbuf_prepare(struct rte_mbuf *mbuf,
 -- 
-2.14.1
+2.20.1
 

--- a/userspace/dpdk/17.05/0004-net-ena-check-pointer-before-memset.patch
+++ b/userspace/dpdk/17.05/0004-net-ena-check-pointer-before-memset.patch
@@ -1,7 +1,7 @@
 From d69ed2f5bb0a6fd916cfa13ea866ff3ad50ea567 Mon Sep 17 00:00:00 2001
 From: Rafal Kozik <rk@semihalf.com>
 Date: Thu, 7 Jun 2018 11:43:18 +0200
-Subject: [PATCH 04/13] net/ena: check pointer before memset
+Subject: [PATCH 04/17] net/ena: check pointer before memset
 
 [ upstream commit 46916aa17d4b2007df8c0454f99ba0ca8b8cb93b ]
 
@@ -11,6 +11,7 @@ Using memset on NULL pointer cause segfault.
 Fixes: 9ba7981ec992 ("ena: add communication layer for DPDK")
 Cc: stable@dpdk.org
 
+Change-Id: I7f7d1150234fd49312d9104d9603752ee4a3a0c8
 Signed-off-by: Rafal Kozik <rk@semihalf.com>
 Acked-by: Michal Krawczyk <mk@semihalf.com>
 ---
@@ -59,5 +60,5 @@ index 71a8c1e22..955d6302d 100644
  
  #define ENA_MEM_ALLOC_NODE(dmadev, size, virt, node, dev_node) \
 -- 
-2.14.1
+2.20.1
 

--- a/userspace/dpdk/17.05/0005-net-ena-change-memory-type.patch
+++ b/userspace/dpdk/17.05/0005-net-ena-change-memory-type.patch
@@ -1,7 +1,7 @@
 From 6d7dde897ae61bd65ee1aa834af478a51d30ac39 Mon Sep 17 00:00:00 2001
 From: Rafal Kozik <rk@semihalf.com>
 Date: Thu, 7 Jun 2018 11:43:19 +0200
-Subject: [PATCH 05/13] net/ena: change memory type
+Subject: [PATCH 05/17] net/ena: change memory type
 
 [ upstream commit 9f32c7e7e6ce58ab772913f54f8328c1c0186a17 ]
 
@@ -14,6 +14,7 @@ To avoid both issue use rte_zmalloc_socket.
 Fixes: 3d3edc265fc8 ("net/ena: make coherent memory allocation NUMA-aware")
 Cc: stable@dpdk.org
 
+Change-Id: I09427bfc0d3b7f90771c5a7be16aef3b95bd9069
 Signed-off-by: Rafal Kozik <rk@semihalf.com>
 Acked-by: Michal Krawczyk <mk@semihalf.com>
 ---
@@ -41,5 +42,5 @@ index 955d6302d..977bee49f 100644
  
  #define ENA_MEM_ALLOC(dmadev, size) rte_zmalloc(NULL, size, 1)
 -- 
-2.14.1
+2.20.1
 

--- a/userspace/dpdk/17.05/0006-net-ena-fix-GENMASK_ULL-macro.patch
+++ b/userspace/dpdk/17.05/0006-net-ena-fix-GENMASK_ULL-macro.patch
@@ -1,7 +1,7 @@
 From a1f3aa39b175e931705981c4dc608b7b7c7f8fc8 Mon Sep 17 00:00:00 2001
 From: Rafal Kozik <rk@semihalf.com>
 Date: Thu, 7 Jun 2018 11:43:20 +0200
-Subject: [PATCH 06/13] net/ena: fix GENMASK_ULL macro
+Subject: [PATCH 06/17] net/ena: fix GENMASK_ULL macro
 
 [ upstream commit 7544aee8d0b4ae0262b1ba7e1539cf8171664df7 ]
 
@@ -12,6 +12,7 @@ is undefined operation and failed on some platforms.
 Fixes: 9ba7981ec992 ("ena: add communication layer for DPDK")
 Cc: stable@dpdk.org
 
+Change-Id: I2094d149a9ff038824ebdff734b2e47bcb0f003f
 Signed-off-by: Rafal Kozik <rk@semihalf.com>
 Acked-by: Michal Krawczyk <mk@semihalf.com>
 ---
@@ -38,5 +39,5 @@ index 977bee49f..06b637870 100644
  #ifdef RTE_LIBRTE_ENA_COM_DEBUG
  #define ena_trc_dbg(format, arg...)					\
 -- 
-2.14.1
+2.20.1
 

--- a/userspace/dpdk/17.05/0007-net-ena-set-link-speed-as-none.patch
+++ b/userspace/dpdk/17.05/0007-net-ena-set-link-speed-as-none.patch
@@ -1,7 +1,7 @@
 From 5f2238d1a6c1986f0b301c9b77232ca6cef0ef70 Mon Sep 17 00:00:00 2001
 From: Rafal Kozik <rk@semihalf.com>
 Date: Thu, 7 Jun 2018 11:43:22 +0200
-Subject: [PATCH 07/13] net/ena: set link speed as none
+Subject: [PATCH 07/17] net/ena: set link speed as none
 
 [ upstream commit 41e59028dd8ab2038a7655c6fc3098222661aa53 ]
 
@@ -13,6 +13,7 @@ rely on this value when using ENA PMD.
 Fixes: 1173fca25af9 ("ena: add polling-mode driver")
 Cc: stable@dpdk.org
 
+Change-Id: I046f53eb179ba5171c687038820045affee833f3
 Signed-off-by: Rafal Kozik <rk@semihalf.com>
 Acked-by: Michal Krawczyk <mk@semihalf.com>
 ---
@@ -33,5 +34,5 @@ index 58b0b6355..185fc6fca 100644
  
  	return 0;
 -- 
-2.14.1
+2.20.1
 

--- a/userspace/dpdk/17.05/0008-net-ena-fix-SIGFPE-with-0-Rx-queue.patch
+++ b/userspace/dpdk/17.05/0008-net-ena-fix-SIGFPE-with-0-Rx-queue.patch
@@ -1,7 +1,7 @@
 From 57d442274cdb3150da5449c92a1100a29a8ffdec Mon Sep 17 00:00:00 2001
 From: Daria Kolistratova <daria.kolistratova@intel.com>
 Date: Tue, 26 Jun 2018 18:38:56 +0100
-Subject: [PATCH 08/13] net/ena: fix SIGFPE with 0 Rx queue
+Subject: [PATCH 08/17] net/ena: fix SIGFPE with 0 Rx queue
 
 [ upstream commit 361913ad6f8c05fc541fe4bfdae3b0dc095ae3af ]
 
@@ -11,6 +11,7 @@ It happens when the application is also requesting ETH_MQ_RX_RSS_FLAG
 in the rte_dev->data->dev_conf.rxmode.mq_mode.
 Fixed adding zero rx queues check.
 
+Change-Id: I04fff738df0134172be5443cdc1af3a3b35a2c32
 Signed-off-by: Daria Kolistratova <daria.kolistratova@intel.com>
 Acked-by: Michal Krawczyk <mk@semihalf.com>
 ---
@@ -31,5 +32,5 @@ index 185fc6fca..52e353c2d 100644
  		if (rc)
  			return rc;
 -- 
-2.14.1
+2.20.1
 

--- a/userspace/dpdk/17.05/0009-net-ena-fix-passing-RSS-hash-to-mbuf.patch
+++ b/userspace/dpdk/17.05/0009-net-ena-fix-passing-RSS-hash-to-mbuf.patch
@@ -1,7 +1,7 @@
 From 0cb97dd4d90c398607395939f3a0e3d4fdedfa35 Mon Sep 17 00:00:00 2001
 From: Stewart Allen <allenste@amazon.com>
 Date: Thu, 25 Oct 2018 19:59:22 +0200
-Subject: [PATCH 09/13] net/ena: fix passing RSS hash to mbuf
+Subject: [PATCH 09/17] net/ena: fix passing RSS hash to mbuf
 
 [ upstream commit e5df9f33db00eb9d322abaefff30da74fd0e625d ]
 
@@ -11,6 +11,7 @@ from the device. Now, the RSS hash from the Rx descriptor is being set.
 Fixes: 1173fca25af9 ("ena: add polling-mode driver")
 Cc: stable@dpdk.org
 
+Change-Id: Iea37e68a1d685800166fa3733f150ad79a2e0b25
 Signed-off-by: Stewart Allen <allenste@amazon.com>
 Acked-by: Michal Krawczyk <mk@semihalf.com>
 ---
@@ -31,5 +32,5 @@ index 52e353c2d..aa88309f2 100644
  		/* pass to DPDK application head mbuf */
  		rx_pkts[recv_idx] = mbuf_head;
 -- 
-2.14.1
+2.20.1
 

--- a/userspace/dpdk/17.05/0010-net-ena-add-supported-RSS-offloads-types.patch
+++ b/userspace/dpdk/17.05/0010-net-ena-add-supported-RSS-offloads-types.patch
@@ -1,7 +1,7 @@
 From 5962c19d83add68482fa1735a3d2d51ab2174a5d Mon Sep 17 00:00:00 2001
 From: Rafal Kozik <rk@semihalf.com>
 Date: Fri, 14 Dec 2018 14:18:38 +0100
-Subject: [PATCH 10/13] net/ena: add supported RSS offloads types
+Subject: [PATCH 10/17] net/ena: add supported RSS offloads types
 
 [ upstream commit b01ead202beb45346d7daeb2f2b1a608006af644 ]
 
@@ -12,6 +12,7 @@ missing information was added.
 Fixes: 1173fca25af9 ("ena: add polling-mode driver")
 Cc: stable@dpdk.org
 
+Change-Id: I1bd653526a00906db0d07673de73948ab8e67fec
 Signed-off-by: Rafal Kozik <rk@semihalf.com>
 Acked-by: Michal Krawczyk <mk@semihalf.com>
 ---
@@ -33,5 +34,5 @@ index aa88309f2..fdc0e525e 100644
  	dev_info->max_rx_pktlen  = adapter->max_mtu;
  	dev_info->max_mac_addrs = 1;
 -- 
-2.14.1
+2.20.1
 

--- a/userspace/dpdk/17.05/0011-net-ena-update-completion-queue-after-cleanup.patch
+++ b/userspace/dpdk/17.05/0011-net-ena-update-completion-queue-after-cleanup.patch
@@ -1,7 +1,7 @@
 From 2b29031c93eadc01443c37e4fb83c1397804a36e Mon Sep 17 00:00:00 2001
 From: Rafal Kozik <rk@semihalf.com>
 Date: Fri, 14 Dec 2018 14:18:44 +0100
-Subject: [PATCH 11/13] net/ena: update completion queue after cleanup
+Subject: [PATCH 11/17] net/ena: update completion queue after cleanup
 
 [ upstream commit a45462c507e98b49cb5c2302e0be3c72d2e20a1a ]
 
@@ -11,6 +11,7 @@ ena_com_update_dev_comp_head().
 Fixes: 1daff5260ff8 ("net/ena: use unmasked head and tail")
 Cc: stable@dpdk.org
 
+Change-Id: I6c540b6b20205571d8759a7ef4c5835a6c8466cf
 Signed-off-by: Rafal Kozik <rk@semihalf.com>
 Acked-by: Michal Krawczyk <mk@semihalf.com>
 ---
@@ -45,5 +46,5 @@ index fdc0e525e..80b54bc94 100644
  
  	return sent_idx;
 -- 
-2.14.1
+2.20.1
 

--- a/userspace/dpdk/17.05/0012-net-ena-fix-dev-init-with-multi-process.patch
+++ b/userspace/dpdk/17.05/0012-net-ena-fix-dev-init-with-multi-process.patch
@@ -1,7 +1,7 @@
 From 6a16460d6e2f5dba53f21638ea0363f2c7a1d1ff Mon Sep 17 00:00:00 2001
 From: Michal Krawczyk <mk@semihalf.com>
 Date: Fri, 25 Jan 2019 09:10:25 +0100
-Subject: [PATCH 12/13] net/ena: fix dev init with multi-process
+Subject: [PATCH 12/17] net/ena: fix dev init with multi-process
 
 [ upstream commit fd9768905870856a2340266d25f8c0100dfccfff ]
 
@@ -15,6 +15,7 @@ main process.
 Fixes: 1173fca25af9 ("ena: add polling-mode driver")
 Cc: stable@dpdk.org
 
+Change-Id: Icd37ab0bfc5324a7fbec4248e9e028f54e2026a2
 Signed-off-by: Michal Krawczyk <mk@semihalf.com>
 ---
  drivers/net/ena/ena_ethdev.c | 11 ++++++-----
@@ -51,5 +52,5 @@ index 80b54bc94..35e293486 100644
  	adapter->pdev = pci_dev;
  
 -- 
-2.14.1
+2.20.1
 

--- a/userspace/dpdk/17.05/0013-net-ena-fix-errno-to-positive-value.patch
+++ b/userspace/dpdk/17.05/0013-net-ena-fix-errno-to-positive-value.patch
@@ -1,7 +1,7 @@
 From 1259ac4f7ddb3f3c439800a77610e49bb35cb3a0 Mon Sep 17 00:00:00 2001
 From: Michal Krawczyk <mk@semihalf.com>
 Date: Fri, 25 Jan 2019 09:10:26 +0100
-Subject: [PATCH 13/13] net/ena: fix errno to positive value
+Subject: [PATCH 13/17] net/ena: fix errno to positive value
 
 [ upstream commit baeed5f404dd1b049118cfec26a2fd3203671572 ]
 
@@ -11,6 +11,7 @@ to be fixed.
 Fixes: b3fc5a1ae10d ("net/ena: add Tx preparation")
 Cc: stable@dpdk.org
 
+Change-Id: If87b7246991ba450182fb48724b3a46977810602
 Signed-off-by: Michal Krawczyk <mk@semihalf.com>
 ---
  drivers/net/ena/ena_ethdev.c | 6 +++---
@@ -47,5 +48,5 @@ index 35e293486..652156930 100644
  		}
  	}
 -- 
-2.14.1
+2.20.1
 

--- a/userspace/dpdk/17.05/0014-net-ena-get-device-info-statically.patch
+++ b/userspace/dpdk/17.05/0014-net-ena-get-device-info-statically.patch
@@ -1,0 +1,123 @@
+From 5dda01af7a1f89d33a71b96ecc5c06fbc6b211e4 Mon Sep 17 00:00:00 2001
+From: Michal Krawczyk <mk@semihalf.com>
+Date: Fri, 15 Feb 2019 09:36:39 +0100
+Subject: [PATCH 14/17] net/ena: get device info statically
+
+[ upstream commit 117ba4a60488a0f96a5737f38ddba6d0f9a728b6 ]
+
+Whenever the app is calling rte_eth_dev_info_get(), it shouldn't use the
+admin command. It was causing problems, if it was called from the
+secondary process - the main process was crashing, and the secondary app
+wasn't getting any result, as the admin request couldn't be processed by
+the process which was requesting the data.
+
+To fix that, the data is being written to the adapter structure during
+device initialization routine.
+
+Change-Id: I94f61f51223725602f70ac9795acf02b7b014984
+Signed-off-by: Michal Krawczyk <mk@semihalf.com>
+---
+ drivers/net/ena/ena_ethdev.c | 31 ++++++++++++-------------------
+ drivers/net/ena/ena_ethdev.h |  8 +++++++-
+ 2 files changed, 19 insertions(+), 20 deletions(-)
+
+diff --git a/drivers/net/ena/ena_ethdev.c b/drivers/net/ena/ena_ethdev.c
+index 652156930..9dd57c906 100644
+--- a/drivers/net/ena/ena_ethdev.c
++++ b/drivers/net/ena/ena_ethdev.c
+@@ -1361,9 +1361,14 @@ static int eth_ena_dev_init(struct rte_eth_dev *eth_dev)
+ 	/* Set max MTU for this device */
+ 	adapter->max_mtu = get_feat_ctx.dev_attr.max_mtu;
+ 
+-	/* set device support for TSO */
+-	adapter->tso4_supported = get_feat_ctx.offload.tx &
+-				  ENA_ADMIN_FEATURE_OFFLOAD_DESC_TSO_IPV4_MASK;
++	/* set device support for offloads */
++	adapter->offloads.tso4_supported = (get_feat_ctx.offload.tx &
++		ENA_ADMIN_FEATURE_OFFLOAD_DESC_TSO_IPV4_MASK) != 0;
++	adapter->offloads.tx_csum_supported = (get_feat_ctx.offload.tx &
++		ENA_ADMIN_FEATURE_OFFLOAD_DESC_TX_L4_IPV4_CSUM_PART_MASK) != 0;
++	adapter->offloads.tx_csum_supported =
++		(get_feat_ctx.offload.rx_supported &
++		ENA_ADMIN_FEATURE_OFFLOAD_DESC_RX_L4_IPV4_CSUM_MASK) != 0;
+ 
+ 	/* Copy MAC address and point DPDK to it */
+ 	eth_dev->data->mac_addrs = (struct ether_addr *)adapter->mac_addr;
+@@ -1442,9 +1447,7 @@ static void ena_infos_get(struct rte_eth_dev *dev,
+ {
+ 	struct ena_adapter *adapter;
+ 	struct ena_com_dev *ena_dev;
+-	struct ena_com_dev_get_features_ctx feat;
+ 	uint32_t rx_feat = 0, tx_feat = 0;
+-	int rc = 0;
+ 
+ 	ena_assert_msg(dev->data != NULL, "Uninitialized device");
+ 	ena_assert_msg(dev->data->dev_private != NULL, "Uninitialized device");
+@@ -1465,26 +1468,16 @@ static void ena_infos_get(struct rte_eth_dev *dev,
+ 			ETH_LINK_SPEED_50G  |
+ 			ETH_LINK_SPEED_100G;
+ 
+-	/* Get supported features from HW */
+-	rc = ena_com_get_dev_attr_feat(ena_dev, &feat);
+-	if (unlikely(rc)) {
+-		RTE_LOG(ERR, PMD,
+-			"Cannot get attribute for ena device rc= %d\n", rc);
+-		return;
+-	}
+-
+ 	/* Set Tx & Rx features available for device */
+-	if (feat.offload.tx & ENA_ADMIN_FEATURE_OFFLOAD_DESC_TSO_IPV4_MASK)
++	if (adapter->offloads.tso4_supported)
+ 		tx_feat	|= DEV_TX_OFFLOAD_TCP_TSO;
+ 
+-	if (feat.offload.tx &
+-	    ENA_ADMIN_FEATURE_OFFLOAD_DESC_TX_L4_IPV4_CSUM_PART_MASK)
++	if (adapter->offloads.tx_csum_supported)
+ 		tx_feat |= DEV_TX_OFFLOAD_IPV4_CKSUM |
+ 			DEV_TX_OFFLOAD_UDP_CKSUM |
+ 			DEV_TX_OFFLOAD_TCP_CKSUM;
+ 
+-	if (feat.offload.rx_supported &
+-	    ENA_ADMIN_FEATURE_OFFLOAD_DESC_RX_L4_IPV4_CSUM_MASK)
++	if (adapter->offloads.rx_csum_supported)
+ 		rx_feat |= DEV_RX_OFFLOAD_IPV4_CKSUM |
+ 			DEV_RX_OFFLOAD_UDP_CKSUM  |
+ 			DEV_RX_OFFLOAD_TCP_CKSUM;
+@@ -1630,7 +1623,7 @@ eth_ena_prep_pkts(void *tx_queue, struct rte_mbuf **tx_pkts,
+ 			/* If IPv4 header has DF flag enabled and TSO support is
+ 			 * disabled, partial chcecksum should not be calculated.
+ 			 */
+-			if (!tx_ring->adapter->tso4_supported)
++			if (!tx_ring->adapter->offloads.tso4_supported)
+ 				continue;
+ 		}
+ 
+diff --git a/drivers/net/ena/ena_ethdev.h b/drivers/net/ena/ena_ethdev.h
+index dc3080ffd..4791c53b5 100644
+--- a/drivers/net/ena/ena_ethdev.h
++++ b/drivers/net/ena/ena_ethdev.h
+@@ -143,6 +143,12 @@ struct ena_stats_rx {
+ 	u64 small_copy_len_pkt;
+ };
+ 
++struct ena_offloads {
++	bool tso4_supported;
++	bool tx_csum_supported;
++	bool rx_csum_supported;
++};
++
+ /* board specific private data structure */
+ struct ena_adapter {
+ 	/* OS defined structs */
+@@ -162,7 +168,7 @@ struct ena_adapter {
+ 
+ 	u16 num_queues;
+ 	u16 max_mtu;
+-	u8 tso4_supported;
++	struct ena_offloads offloads;
+ 
+ 	int id_number;
+ 	char name[ENA_NAME_MAX_LEN];
+-- 
+2.20.1
+

--- a/userspace/dpdk/17.05/0015-net-ena-fix-checksum-feature-flag.patch
+++ b/userspace/dpdk/17.05/0015-net-ena-fix-checksum-feature-flag.patch
@@ -1,0 +1,35 @@
+From c9582d1ba1ba3b63b5700dd6d9a1a30c4b707d0c Mon Sep 17 00:00:00 2001
+From: Michal Krawczyk <mk@semihalf.com>
+Date: Mon, 8 Apr 2019 12:27:44 +0200
+Subject: [PATCH 15/17] net/ena: fix checksum feature flag
+
+[ upstream commit ef538c1a7f565c9b58518375a500aa864445fd11 ]
+
+The boolean value was assigned to Tx flag twice, so it could cause bug
+whenever Rx checksum will not be supported and Tx will be.
+
+Coverity issue: 336831
+Fixes: 117ba4a60488 ("net/ena: get device info statically")
+
+Change-Id: Id1ca7bb11b566c35ab7c9691593dcab40263c0f7
+Signed-off-by: Michal Krawczyk <mk@semihalf.com>
+---
+ drivers/net/ena/ena_ethdev.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/drivers/net/ena/ena_ethdev.c b/drivers/net/ena/ena_ethdev.c
+index 9dd57c906..d8406d6ff 100644
+--- a/drivers/net/ena/ena_ethdev.c
++++ b/drivers/net/ena/ena_ethdev.c
+@@ -1366,7 +1366,7 @@ static int eth_ena_dev_init(struct rte_eth_dev *eth_dev)
+ 		ENA_ADMIN_FEATURE_OFFLOAD_DESC_TSO_IPV4_MASK) != 0;
+ 	adapter->offloads.tx_csum_supported = (get_feat_ctx.offload.tx &
+ 		ENA_ADMIN_FEATURE_OFFLOAD_DESC_TX_L4_IPV4_CSUM_PART_MASK) != 0;
+-	adapter->offloads.tx_csum_supported =
++	adapter->offloads.rx_csum_supported =
+ 		(get_feat_ctx.offload.rx_supported &
+ 		ENA_ADMIN_FEATURE_OFFLOAD_DESC_RX_L4_IPV4_CSUM_MASK) != 0;
+ 
+-- 
+2.20.1
+

--- a/userspace/dpdk/17.05/0016-net-ena-fix-Rx-checksum-errors-statistics.patch
+++ b/userspace/dpdk/17.05/0016-net-ena-fix-Rx-checksum-errors-statistics.patch
@@ -1,0 +1,52 @@
+From 88dce76726ea60a3df37b7858308322d8e7c18af Mon Sep 17 00:00:00 2001
+From: Michal Krawczyk <mk@semihalf.com>
+Date: Tue, 28 May 2019 10:28:34 +0200
+Subject: [PATCH 16/17] net/ena: fix Rx checksum errors statistics
+
+[ upstream commit ef74b5f7b69b9502ddab81121611243efcfe1dde ]
+
+Rx checksum flags and input errors shouldn't be updated on Tx, as it
+would work only for packets forwarding.
+
+The ierrors statistic should be updated on Rx, right after checking
+Rx checksum flags if the Rx checksum offload is enabled.
+
+Fixes: 1173fca25af9 ("ena: add polling-mode driver")
+Cc: stable@dpdk.org
+
+Change-Id: I4ccf68bcb1ef6b50d01c811fc7f050a3d7ec9966
+Signed-off-by: Michal Krawczyk <mk@semihalf.com>
+---
+ drivers/net/ena/ena_ethdev.c | 9 +++++----
+ 1 file changed, 5 insertions(+), 4 deletions(-)
+
+diff --git a/drivers/net/ena/ena_ethdev.c b/drivers/net/ena/ena_ethdev.c
+index d8406d6ff..c5b2ed730 100644
+--- a/drivers/net/ena/ena_ethdev.c
++++ b/drivers/net/ena/ena_ethdev.c
+@@ -1569,6 +1569,11 @@ static uint16_t eth_ena_recv_pkts(void *rx_queue, struct rte_mbuf **rx_pkts,
+ 
+ 		/* fill mbuf attributes if any */
+ 		ena_rx_mbuf_prepare(mbuf_head, &ena_rx_ctx);
++
++		if (unlikely(mbuf_head->ol_flags &
++				(PKT_RX_IP_CKSUM_BAD | PKT_RX_L4_CKSUM_BAD)))
++			rte_atomic64_inc(&rx_ring->adapter->drv_stats->ierrors);
++
+ 		mbuf_head->hash.rss = ena_rx_ctx.hash;
+ 
+ 		/* pass to DPDK application head mbuf */
+@@ -1716,10 +1721,6 @@ static uint16_t eth_ena_xmit_pkts(void *tx_queue, struct rte_mbuf **tx_pkts,
+ 		/* Set TX offloads flags, if applicable */
+ 		ena_tx_mbuf_prepare(mbuf, &ena_tx_ctx);
+ 
+-		if (unlikely(mbuf->ol_flags &
+-			     (PKT_RX_L4_CKSUM_BAD | PKT_RX_IP_CKSUM_BAD)))
+-			rte_atomic64_inc(&tx_ring->adapter->drv_stats->ierrors);
+-
+ 		rte_prefetch0(tx_pkts[(sent_idx + 4) & ring_mask]);
+ 
+ 		/* Process first segment taking into
+-- 
+2.20.1
+

--- a/userspace/dpdk/17.05/0017-net-ena-fix-assigning-NUMA-node-to-IO-queue.patch
+++ b/userspace/dpdk/17.05/0017-net-ena-fix-assigning-NUMA-node-to-IO-queue.patch
@@ -1,0 +1,123 @@
+From 357a5c1638730c4f897f29db81726d0e7e4f54ea Mon Sep 17 00:00:00 2001
+From: Michal Krawczyk <mk@semihalf.com>
+Date: Tue, 4 Jun 2019 12:59:36 +0200
+Subject: [PATCH 17/17] net/ena: fix assigning NUMA node to IO queue
+
+[ upstream commit 4217cb0b7d2c5385f06f531af7f14b860927aba7 ]
+
+Previous solution was using memzones in invalid way in hope to assign
+IO queue to the appropriate NUMA zone.
+
+The right way is to use socket_id from the rx/tx queue setup function
+and then pass it to the IO queue.
+
+Fixes: 3d3edc265fc8 ("net/ena: make coherent memory allocation NUMA-aware")
+Cc: stable@dpdk.org
+
+Change-Id: I252df018ca6aae9d566618b6967bec0c5b3d939a
+Signed-off-by: Michal Krawczyk <mk@semihalf.com>
+Reviewed-by: David Marchand <david.marchand@redhat.com>
+---
+ drivers/net/ena/ena_ethdev.c | 23 ++++++-----------------
+ drivers/net/ena/ena_ethdev.h |  2 ++
+ 2 files changed, 8 insertions(+), 17 deletions(-)
+
+diff --git a/drivers/net/ena/ena_ethdev.c b/drivers/net/ena/ena_ethdev.c
+index c5b2ed730..24fc032e1 100644
+--- a/drivers/net/ena/ena_ethdev.c
++++ b/drivers/net/ena/ena_ethdev.c
+@@ -39,7 +39,6 @@
+ #include <rte_dev.h>
+ #include <rte_errno.h>
+ #include <rte_version.h>
+-#include <rte_eal_memconfig.h>
+ #include <rte_net.h>
+ 
+ #include "ena_ethdev.h"
+@@ -244,18 +243,6 @@ static const struct eth_dev_ops ena_dev_ops = {
+ 	.reta_query           = ena_rss_reta_query,
+ };
+ 
+-#define NUMA_NO_NODE	SOCKET_ID_ANY
+-
+-static inline int ena_cpu_to_node(int cpu)
+-{
+-	struct rte_config *config = rte_eal_get_configuration();
+-
+-	if (likely(cpu < RTE_MAX_MEMZONE))
+-		return config->mem_config->memzone[cpu].socket_id;
+-
+-	return NUMA_NO_NODE;
+-}
+-
+ static inline void ena_rx_mbuf_prepare(struct rte_mbuf *mbuf,
+ 				       struct ena_com_rx_ctx *ena_rx_ctx)
+ {
+@@ -945,7 +932,7 @@ static int ena_queue_restart(struct ena_ring *ring)
+ static int ena_tx_queue_setup(struct rte_eth_dev *dev,
+ 			      uint16_t queue_idx,
+ 			      uint16_t nb_desc,
+-			      __rte_unused unsigned int socket_id,
++			      unsigned int socket_id,
+ 			      __rte_unused const struct rte_eth_txconf *tx_conf)
+ {
+ 	struct ena_com_create_io_ctx ctx =
+@@ -990,7 +977,7 @@ static int ena_tx_queue_setup(struct rte_eth_dev *dev,
+ 	ctx.msix_vector = -1; /* admin interrupts not used */
+ 	ctx.mem_queue_type = ena_dev->tx_mem_queue_type;
+ 	ctx.queue_size = adapter->tx_ring_size;
+-	ctx.numa_node = ena_cpu_to_node(queue_idx);
++	ctx.numa_node = socket_id;
+ 
+ 	rc = ena_com_create_io_queue(ena_dev, &ctx);
+ 	if (rc) {
+@@ -1016,6 +1003,7 @@ static int ena_tx_queue_setup(struct rte_eth_dev *dev,
+ 	txq->next_to_clean = 0;
+ 	txq->next_to_use = 0;
+ 	txq->ring_size = nb_desc;
++	txq->numa_socket_id = socket_id;
+ 
+ 	txq->tx_buffer_info = rte_zmalloc("txq->tx_buffer_info",
+ 					  sizeof(struct ena_tx_buffer) *
+@@ -1047,7 +1035,7 @@ static int ena_tx_queue_setup(struct rte_eth_dev *dev,
+ static int ena_rx_queue_setup(struct rte_eth_dev *dev,
+ 			      uint16_t queue_idx,
+ 			      uint16_t nb_desc,
+-			      __rte_unused unsigned int socket_id,
++			      unsigned int socket_id,
+ 			      __rte_unused const struct rte_eth_rxconf *rx_conf,
+ 			      struct rte_mempool *mp)
+ {
+@@ -1091,7 +1079,7 @@ static int ena_rx_queue_setup(struct rte_eth_dev *dev,
+ 	ctx.mem_queue_type = ENA_ADMIN_PLACEMENT_POLICY_HOST;
+ 	ctx.msix_vector = -1; /* admin interrupts not used */
+ 	ctx.queue_size = adapter->rx_ring_size;
+-	ctx.numa_node = ena_cpu_to_node(queue_idx);
++	ctx.numa_node = socket_id;
+ 
+ 	rc = ena_com_create_io_queue(ena_dev, &ctx);
+ 	if (rc)
+@@ -1115,6 +1103,7 @@ static int ena_rx_queue_setup(struct rte_eth_dev *dev,
+ 	rxq->next_to_clean = 0;
+ 	rxq->next_to_use = 0;
+ 	rxq->ring_size = nb_desc;
++	rxq->numa_socket_id = socket_id;
+ 	rxq->mb_pool = mp;
+ 
+ 	rxq->rx_buffer_info = rte_zmalloc("rxq->buffer_info",
+diff --git a/drivers/net/ena/ena_ethdev.h b/drivers/net/ena/ena_ethdev.h
+index 4791c53b5..8d5eb5a7c 100644
+--- a/drivers/net/ena/ena_ethdev.h
++++ b/drivers/net/ena/ena_ethdev.h
+@@ -90,6 +90,8 @@ struct ena_ring {
+ 	uint8_t tx_max_header_size;
+ 	int configured;
+ 	struct ena_adapter *adapter;
++
++	unsigned int numa_socket_id;
+ } __rte_cache_aligned;
+ 
+ enum ena_adapter_state {
+-- 
+2.20.1
+

--- a/userspace/dpdk/17.08/0001-net-ena-do-not-set-Tx-L4-offloads-in-Rx-path.patch
+++ b/userspace/dpdk/17.08/0001-net-ena-do-not-set-Tx-L4-offloads-in-Rx-path.patch
@@ -1,7 +1,7 @@
 From 530e6d44c051f63b96100079d1a6f5af2d75c325 Mon Sep 17 00:00:00 2001
 From: Rafal Kozik <rk@semihalf.com>
 Date: Tue, 9 Jan 2018 16:19:08 +0100
-Subject: [PATCH 01/11] net/ena: do not set Tx L4 offloads in Rx path
+Subject: [PATCH 01/15] net/ena: do not set Tx L4 offloads in Rx path
 
 [ upstream commit fd617795679019c7aea5ab1e8c85db02cf53f169 ]
 
@@ -14,6 +14,7 @@ correct.
 Fixes: 1173fca25af9 ("ena: add polling-mode driver")
 Cc: stable@dpdk.org
 
+Change-Id: Icd33c149403377cacf5663b21029cbdc30ccb125
 Reported-by: Matthew Smith <mgsmith@netgate.com>
 Signed-off-by: Rafal Kozik <rk@semihalf.com>
 Signed-off-by: Michal Krawczyk <mk@semihalf.com>
@@ -56,5 +57,5 @@ index 80ce1f353..16a648206 100644
  
  static inline void ena_tx_mbuf_prepare(struct rte_mbuf *mbuf,
 -- 
-2.14.1
+2.20.1
 

--- a/userspace/dpdk/17.08/0002-net-ena-check-pointer-before-memset.patch
+++ b/userspace/dpdk/17.08/0002-net-ena-check-pointer-before-memset.patch
@@ -1,7 +1,7 @@
 From 64807cc751f5c59db091b4a4bbcd884225be1701 Mon Sep 17 00:00:00 2001
 From: Rafal Kozik <rk@semihalf.com>
 Date: Thu, 7 Jun 2018 11:43:18 +0200
-Subject: [PATCH 02/11] net/ena: check pointer before memset
+Subject: [PATCH 02/15] net/ena: check pointer before memset
 
 [ upstream commit 46916aa17d4b2007df8c0454f99ba0ca8b8cb93b ]
 
@@ -11,6 +11,7 @@ Using memset on NULL pointer cause segfault.
 Fixes: 9ba7981ec992 ("ena: add communication layer for DPDK")
 Cc: stable@dpdk.org
 
+Change-Id: I7f7d1150234fd49312d9104d9603752ee4a3a0c8
 Signed-off-by: Rafal Kozik <rk@semihalf.com>
 Acked-by: Michal Krawczyk <mk@semihalf.com>
 ---
@@ -59,5 +60,5 @@ index 71a8c1e22..955d6302d 100644
  
  #define ENA_MEM_ALLOC_NODE(dmadev, size, virt, node, dev_node) \
 -- 
-2.14.1
+2.20.1
 

--- a/userspace/dpdk/17.08/0003-net-ena-change-memory-type.patch
+++ b/userspace/dpdk/17.08/0003-net-ena-change-memory-type.patch
@@ -1,7 +1,7 @@
 From 9fb11622486a3ce3012f63f30edfd005cfa20735 Mon Sep 17 00:00:00 2001
 From: Rafal Kozik <rk@semihalf.com>
 Date: Thu, 7 Jun 2018 11:43:19 +0200
-Subject: [PATCH 03/11] net/ena: change memory type
+Subject: [PATCH 03/15] net/ena: change memory type
 
 [ upstream commit 9f32c7e7e6ce58ab772913f54f8328c1c0186a17 ]
 
@@ -14,6 +14,7 @@ To avoid both issue use rte_zmalloc_socket.
 Fixes: 3d3edc265fc8 ("net/ena: make coherent memory allocation NUMA-aware")
 Cc: stable@dpdk.org
 
+Change-Id: I09427bfc0d3b7f90771c5a7be16aef3b95bd9069
 Signed-off-by: Rafal Kozik <rk@semihalf.com>
 Acked-by: Michal Krawczyk <mk@semihalf.com>
 ---
@@ -41,5 +42,5 @@ index 955d6302d..977bee49f 100644
  
  #define ENA_MEM_ALLOC(dmadev, size) rte_zmalloc(NULL, size, 1)
 -- 
-2.14.1
+2.20.1
 

--- a/userspace/dpdk/17.08/0004-net-ena-fix-GENMASK_ULL-macro.patch
+++ b/userspace/dpdk/17.08/0004-net-ena-fix-GENMASK_ULL-macro.patch
@@ -1,7 +1,7 @@
 From c0c543e9bd15913f9516d827d718a5e6c039a66e Mon Sep 17 00:00:00 2001
 From: Rafal Kozik <rk@semihalf.com>
 Date: Thu, 7 Jun 2018 11:43:20 +0200
-Subject: [PATCH 04/11] net/ena: fix GENMASK_ULL macro
+Subject: [PATCH 04/15] net/ena: fix GENMASK_ULL macro
 
 [ upstream commit 7544aee8d0b4ae0262b1ba7e1539cf8171664df7 ]
 
@@ -12,6 +12,7 @@ is undefined operation and failed on some platforms.
 Fixes: 9ba7981ec992 ("ena: add communication layer for DPDK")
 Cc: stable@dpdk.org
 
+Change-Id: I2094d149a9ff038824ebdff734b2e47bcb0f003f
 Signed-off-by: Rafal Kozik <rk@semihalf.com>
 Acked-by: Michal Krawczyk <mk@semihalf.com>
 ---
@@ -38,5 +39,5 @@ index 977bee49f..06b637870 100644
  #ifdef RTE_LIBRTE_ENA_COM_DEBUG
  #define ena_trc_dbg(format, arg...)					\
 -- 
-2.14.1
+2.20.1
 

--- a/userspace/dpdk/17.08/0005-net-ena-set-link-speed-as-none.patch
+++ b/userspace/dpdk/17.08/0005-net-ena-set-link-speed-as-none.patch
@@ -1,7 +1,7 @@
 From 0886f240c7fea07345cd7e5f3148a06e64c66576 Mon Sep 17 00:00:00 2001
 From: Rafal Kozik <rk@semihalf.com>
 Date: Thu, 7 Jun 2018 11:43:22 +0200
-Subject: [PATCH 05/11] net/ena: set link speed as none
+Subject: [PATCH 05/15] net/ena: set link speed as none
 
 [ upstream commit 41e59028dd8ab2038a7655c6fc3098222661aa53 ]
 
@@ -13,6 +13,7 @@ rely on this value when using ENA PMD.
 Fixes: 1173fca25af9 ("ena: add polling-mode driver")
 Cc: stable@dpdk.org
 
+Change-Id: I046f53eb179ba5171c687038820045affee833f3
 Signed-off-by: Rafal Kozik <rk@semihalf.com>
 Acked-by: Michal Krawczyk <mk@semihalf.com>
 ---
@@ -33,5 +34,5 @@ index 16a648206..e5da94a59 100644
  
  	return 0;
 -- 
-2.14.1
+2.20.1
 

--- a/userspace/dpdk/17.08/0006-net-ena-fix-SIGFPE-with-0-Rx-queue.patch
+++ b/userspace/dpdk/17.08/0006-net-ena-fix-SIGFPE-with-0-Rx-queue.patch
@@ -1,7 +1,7 @@
 From b379064f88bbc91a6a6dd9a4f7838f88b9faff85 Mon Sep 17 00:00:00 2001
 From: Daria Kolistratova <daria.kolistratova@intel.com>
 Date: Tue, 26 Jun 2018 18:38:56 +0100
-Subject: [PATCH 06/11] net/ena: fix SIGFPE with 0 Rx queue
+Subject: [PATCH 06/15] net/ena: fix SIGFPE with 0 Rx queue
 
 [ upstream commit 361913ad6f8c05fc541fe4bfdae3b0dc095ae3af ]
 
@@ -11,6 +11,7 @@ It happens when the application is also requesting ETH_MQ_RX_RSS_FLAG
 in the rte_dev->data->dev_conf.rxmode.mq_mode.
 Fixed adding zero rx queues check.
 
+Change-Id: I04fff738df0134172be5443cdc1af3a3b35a2c32
 Signed-off-by: Daria Kolistratova <daria.kolistratova@intel.com>
 Acked-by: Michal Krawczyk <mk@semihalf.com>
 ---
@@ -31,5 +32,5 @@ index e5da94a59..01c463a33 100644
  		if (rc)
  			return rc;
 -- 
-2.14.1
+2.20.1
 

--- a/userspace/dpdk/17.08/0007-net-ena-fix-passing-RSS-hash-to-mbuf.patch
+++ b/userspace/dpdk/17.08/0007-net-ena-fix-passing-RSS-hash-to-mbuf.patch
@@ -1,7 +1,7 @@
 From 7eac04a7fae3075e05c9e53afb246c169f5f3dd2 Mon Sep 17 00:00:00 2001
 From: Stewart Allen <allenste@amazon.com>
 Date: Thu, 25 Oct 2018 19:59:22 +0200
-Subject: [PATCH 07/11] net/ena: fix passing RSS hash to mbuf
+Subject: [PATCH 07/15] net/ena: fix passing RSS hash to mbuf
 
 [ upstream commit e5df9f33db00eb9d322abaefff30da74fd0e625d ]
 
@@ -11,6 +11,7 @@ from the device. Now, the RSS hash from the Rx descriptor is being set.
 Fixes: 1173fca25af9 ("ena: add polling-mode driver")
 Cc: stable@dpdk.org
 
+Change-Id: Iea37e68a1d685800166fa3733f150ad79a2e0b25
 Signed-off-by: Stewart Allen <allenste@amazon.com>
 Acked-by: Michal Krawczyk <mk@semihalf.com>
 ---
@@ -31,5 +32,5 @@ index 01c463a33..434f2ecf2 100644
  		/* pass to DPDK application head mbuf */
  		rx_pkts[recv_idx] = mbuf_head;
 -- 
-2.14.1
+2.20.1
 

--- a/userspace/dpdk/17.08/0008-net-ena-add-supported-RSS-offloads-types.patch
+++ b/userspace/dpdk/17.08/0008-net-ena-add-supported-RSS-offloads-types.patch
@@ -1,7 +1,7 @@
 From 2ce776b0d20f4fc8892bf4511bff6afe5a01ca6b Mon Sep 17 00:00:00 2001
 From: Rafal Kozik <rk@semihalf.com>
 Date: Fri, 14 Dec 2018 14:18:38 +0100
-Subject: [PATCH 08/11] net/ena: add supported RSS offloads types
+Subject: [PATCH 08/15] net/ena: add supported RSS offloads types
 
 [ upstream commit b01ead202beb45346d7daeb2f2b1a608006af644 ]
 
@@ -12,6 +12,7 @@ missing information was added.
 Fixes: 1173fca25af9 ("ena: add polling-mode driver")
 Cc: stable@dpdk.org
 
+Change-Id: I1bd653526a00906db0d07673de73948ab8e67fec
 Signed-off-by: Rafal Kozik <rk@semihalf.com>
 Acked-by: Michal Krawczyk <mk@semihalf.com>
 ---
@@ -33,5 +34,5 @@ index 434f2ecf2..97d07adc9 100644
  	dev_info->max_rx_pktlen  = adapter->max_mtu;
  	dev_info->max_mac_addrs = 1;
 -- 
-2.14.1
+2.20.1
 

--- a/userspace/dpdk/17.08/0009-net-ena-update-completion-queue-after-cleanup.patch
+++ b/userspace/dpdk/17.08/0009-net-ena-update-completion-queue-after-cleanup.patch
@@ -1,7 +1,7 @@
 From b3bb9c7d7a41736042caaefeaf5803fe05b511a9 Mon Sep 17 00:00:00 2001
 From: Rafal Kozik <rk@semihalf.com>
 Date: Fri, 14 Dec 2018 14:18:44 +0100
-Subject: [PATCH 09/11] net/ena: update completion queue after cleanup
+Subject: [PATCH 09/15] net/ena: update completion queue after cleanup
 
 [ upstream commit a45462c507e98b49cb5c2302e0be3c72d2e20a1a ]
 
@@ -11,6 +11,7 @@ ena_com_update_dev_comp_head().
 Fixes: 1daff5260ff8 ("net/ena: use unmasked head and tail")
 Cc: stable@dpdk.org
 
+Change-Id: I6c540b6b20205571d8759a7ef4c5835a6c8466cf
 Signed-off-by: Rafal Kozik <rk@semihalf.com>
 Acked-by: Michal Krawczyk <mk@semihalf.com>
 ---
@@ -45,5 +46,5 @@ index 97d07adc9..0ec59a6df 100644
  
  	return sent_idx;
 -- 
-2.14.1
+2.20.1
 

--- a/userspace/dpdk/17.08/0010-net-ena-fix-dev-init-with-multi-process.patch
+++ b/userspace/dpdk/17.08/0010-net-ena-fix-dev-init-with-multi-process.patch
@@ -1,7 +1,7 @@
 From d634c0d8277fb9310918b5ccea0a133d6b4669e9 Mon Sep 17 00:00:00 2001
 From: Michal Krawczyk <mk@semihalf.com>
 Date: Fri, 25 Jan 2019 09:10:25 +0100
-Subject: [PATCH 10/11] net/ena: fix dev init with multi-process
+Subject: [PATCH 10/15] net/ena: fix dev init with multi-process
 
 [ upstream commit fd9768905870856a2340266d25f8c0100dfccfff ]
 
@@ -15,6 +15,7 @@ main process.
 Fixes: 1173fca25af9 ("ena: add polling-mode driver")
 Cc: stable@dpdk.org
 
+Change-Id: Icd37ab0bfc5324a7fbec4248e9e028f54e2026a2
 Signed-off-by: Michal Krawczyk <mk@semihalf.com>
 ---
  drivers/net/ena/ena_ethdev.c | 11 ++++++-----
@@ -51,5 +52,5 @@ index 0ec59a6df..3409fbbcb 100644
  	adapter->pdev = pci_dev;
  
 -- 
-2.14.1
+2.20.1
 

--- a/userspace/dpdk/17.08/0011-net-ena-fix-errno-to-positive-value.patch
+++ b/userspace/dpdk/17.08/0011-net-ena-fix-errno-to-positive-value.patch
@@ -1,7 +1,7 @@
 From 5bcc86fb48a7b6f8483f236e247319e2562c2abf Mon Sep 17 00:00:00 2001
 From: Michal Krawczyk <mk@semihalf.com>
 Date: Fri, 25 Jan 2019 09:10:26 +0100
-Subject: [PATCH 11/11] net/ena: fix errno to positive value
+Subject: [PATCH 11/15] net/ena: fix errno to positive value
 
 [ upstream commit baeed5f404dd1b049118cfec26a2fd3203671572 ]
 
@@ -11,6 +11,7 @@ to be fixed.
 Fixes: b3fc5a1ae10d ("net/ena: add Tx preparation")
 Cc: stable@dpdk.org
 
+Change-Id: If87b7246991ba450182fb48724b3a46977810602
 Signed-off-by: Michal Krawczyk <mk@semihalf.com>
 ---
  drivers/net/ena/ena_ethdev.c | 6 +++---
@@ -47,5 +48,5 @@ index 3409fbbcb..7480182ca 100644
  		}
  	}
 -- 
-2.14.1
+2.20.1
 

--- a/userspace/dpdk/17.08/0012-net-ena-get-device-info-statically.patch
+++ b/userspace/dpdk/17.08/0012-net-ena-get-device-info-statically.patch
@@ -1,0 +1,123 @@
+From 74655045af1cdaf8f974a9eb1f923c884ba6ed95 Mon Sep 17 00:00:00 2001
+From: Michal Krawczyk <mk@semihalf.com>
+Date: Fri, 15 Feb 2019 09:36:39 +0100
+Subject: [PATCH 12/15] net/ena: get device info statically
+
+[ upstream commit 117ba4a60488a0f96a5737f38ddba6d0f9a728b6 ]
+
+Whenever the app is calling rte_eth_dev_info_get(), it shouldn't use the
+admin command. It was causing problems, if it was called from the
+secondary process - the main process was crashing, and the secondary app
+wasn't getting any result, as the admin request couldn't be processed by
+the process which was requesting the data.
+
+To fix that, the data is being written to the adapter structure during
+device initialization routine.
+
+Change-Id: I94f61f51223725602f70ac9795acf02b7b014984
+Signed-off-by: Michal Krawczyk <mk@semihalf.com>
+---
+ drivers/net/ena/ena_ethdev.c | 31 ++++++++++++-------------------
+ drivers/net/ena/ena_ethdev.h |  8 +++++++-
+ 2 files changed, 19 insertions(+), 20 deletions(-)
+
+diff --git a/drivers/net/ena/ena_ethdev.c b/drivers/net/ena/ena_ethdev.c
+index 7480182ca..a3ccc1c40 100644
+--- a/drivers/net/ena/ena_ethdev.c
++++ b/drivers/net/ena/ena_ethdev.c
+@@ -1361,9 +1361,14 @@ static int eth_ena_dev_init(struct rte_eth_dev *eth_dev)
+ 	/* Set max MTU for this device */
+ 	adapter->max_mtu = get_feat_ctx.dev_attr.max_mtu;
+ 
+-	/* set device support for TSO */
+-	adapter->tso4_supported = get_feat_ctx.offload.tx &
+-				  ENA_ADMIN_FEATURE_OFFLOAD_DESC_TSO_IPV4_MASK;
++	/* set device support for offloads */
++	adapter->offloads.tso4_supported = (get_feat_ctx.offload.tx &
++		ENA_ADMIN_FEATURE_OFFLOAD_DESC_TSO_IPV4_MASK) != 0;
++	adapter->offloads.tx_csum_supported = (get_feat_ctx.offload.tx &
++		ENA_ADMIN_FEATURE_OFFLOAD_DESC_TX_L4_IPV4_CSUM_PART_MASK) != 0;
++	adapter->offloads.tx_csum_supported =
++		(get_feat_ctx.offload.rx_supported &
++		ENA_ADMIN_FEATURE_OFFLOAD_DESC_RX_L4_IPV4_CSUM_MASK) != 0;
+ 
+ 	/* Copy MAC address and point DPDK to it */
+ 	eth_dev->data->mac_addrs = (struct ether_addr *)adapter->mac_addr;
+@@ -1442,9 +1447,7 @@ static void ena_infos_get(struct rte_eth_dev *dev,
+ {
+ 	struct ena_adapter *adapter;
+ 	struct ena_com_dev *ena_dev;
+-	struct ena_com_dev_get_features_ctx feat;
+ 	uint32_t rx_feat = 0, tx_feat = 0;
+-	int rc = 0;
+ 
+ 	ena_assert_msg(dev->data != NULL, "Uninitialized device");
+ 	ena_assert_msg(dev->data->dev_private != NULL, "Uninitialized device");
+@@ -1465,26 +1468,16 @@ static void ena_infos_get(struct rte_eth_dev *dev,
+ 			ETH_LINK_SPEED_50G  |
+ 			ETH_LINK_SPEED_100G;
+ 
+-	/* Get supported features from HW */
+-	rc = ena_com_get_dev_attr_feat(ena_dev, &feat);
+-	if (unlikely(rc)) {
+-		RTE_LOG(ERR, PMD,
+-			"Cannot get attribute for ena device rc= %d\n", rc);
+-		return;
+-	}
+-
+ 	/* Set Tx & Rx features available for device */
+-	if (feat.offload.tx & ENA_ADMIN_FEATURE_OFFLOAD_DESC_TSO_IPV4_MASK)
++	if (adapter->offloads.tso4_supported)
+ 		tx_feat	|= DEV_TX_OFFLOAD_TCP_TSO;
+ 
+-	if (feat.offload.tx &
+-	    ENA_ADMIN_FEATURE_OFFLOAD_DESC_TX_L4_IPV4_CSUM_PART_MASK)
++	if (adapter->offloads.tx_csum_supported)
+ 		tx_feat |= DEV_TX_OFFLOAD_IPV4_CKSUM |
+ 			DEV_TX_OFFLOAD_UDP_CKSUM |
+ 			DEV_TX_OFFLOAD_TCP_CKSUM;
+ 
+-	if (feat.offload.rx_supported &
+-	    ENA_ADMIN_FEATURE_OFFLOAD_DESC_RX_L4_IPV4_CSUM_MASK)
++	if (adapter->offloads.rx_csum_supported)
+ 		rx_feat |= DEV_RX_OFFLOAD_IPV4_CKSUM |
+ 			DEV_RX_OFFLOAD_UDP_CKSUM  |
+ 			DEV_RX_OFFLOAD_TCP_CKSUM;
+@@ -1630,7 +1623,7 @@ eth_ena_prep_pkts(void *tx_queue, struct rte_mbuf **tx_pkts,
+ 			/* If IPv4 header has DF flag enabled and TSO support is
+ 			 * disabled, partial chcecksum should not be calculated.
+ 			 */
+-			if (!tx_ring->adapter->tso4_supported)
++			if (!tx_ring->adapter->offloads.tso4_supported)
+ 				continue;
+ 		}
+ 
+diff --git a/drivers/net/ena/ena_ethdev.h b/drivers/net/ena/ena_ethdev.h
+index dc3080ffd..4791c53b5 100644
+--- a/drivers/net/ena/ena_ethdev.h
++++ b/drivers/net/ena/ena_ethdev.h
+@@ -143,6 +143,12 @@ struct ena_stats_rx {
+ 	u64 small_copy_len_pkt;
+ };
+ 
++struct ena_offloads {
++	bool tso4_supported;
++	bool tx_csum_supported;
++	bool rx_csum_supported;
++};
++
+ /* board specific private data structure */
+ struct ena_adapter {
+ 	/* OS defined structs */
+@@ -162,7 +168,7 @@ struct ena_adapter {
+ 
+ 	u16 num_queues;
+ 	u16 max_mtu;
+-	u8 tso4_supported;
++	struct ena_offloads offloads;
+ 
+ 	int id_number;
+ 	char name[ENA_NAME_MAX_LEN];
+-- 
+2.20.1
+

--- a/userspace/dpdk/17.08/0013-net-ena-fix-checksum-feature-flag.patch
+++ b/userspace/dpdk/17.08/0013-net-ena-fix-checksum-feature-flag.patch
@@ -1,0 +1,35 @@
+From 45db0a95cf5999981bac2497b1ee8ebd1dc45ef6 Mon Sep 17 00:00:00 2001
+From: Michal Krawczyk <mk@semihalf.com>
+Date: Mon, 8 Apr 2019 12:27:44 +0200
+Subject: [PATCH 13/15] net/ena: fix checksum feature flag
+
+[ upstream commit ef538c1a7f565c9b58518375a500aa864445fd11 ]
+
+The boolean value was assigned to Tx flag twice, so it could cause bug
+whenever Rx checksum will not be supported and Tx will be.
+
+Coverity issue: 336831
+Fixes: 117ba4a60488 ("net/ena: get device info statically")
+
+Change-Id: Id1ca7bb11b566c35ab7c9691593dcab40263c0f7
+Signed-off-by: Michal Krawczyk <mk@semihalf.com>
+---
+ drivers/net/ena/ena_ethdev.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/drivers/net/ena/ena_ethdev.c b/drivers/net/ena/ena_ethdev.c
+index a3ccc1c40..97e6bbb85 100644
+--- a/drivers/net/ena/ena_ethdev.c
++++ b/drivers/net/ena/ena_ethdev.c
+@@ -1366,7 +1366,7 @@ static int eth_ena_dev_init(struct rte_eth_dev *eth_dev)
+ 		ENA_ADMIN_FEATURE_OFFLOAD_DESC_TSO_IPV4_MASK) != 0;
+ 	adapter->offloads.tx_csum_supported = (get_feat_ctx.offload.tx &
+ 		ENA_ADMIN_FEATURE_OFFLOAD_DESC_TX_L4_IPV4_CSUM_PART_MASK) != 0;
+-	adapter->offloads.tx_csum_supported =
++	adapter->offloads.rx_csum_supported =
+ 		(get_feat_ctx.offload.rx_supported &
+ 		ENA_ADMIN_FEATURE_OFFLOAD_DESC_RX_L4_IPV4_CSUM_MASK) != 0;
+ 
+-- 
+2.20.1
+

--- a/userspace/dpdk/17.08/0014-net-ena-fix-Rx-checksum-errors-statistics.patch
+++ b/userspace/dpdk/17.08/0014-net-ena-fix-Rx-checksum-errors-statistics.patch
@@ -1,0 +1,52 @@
+From 719088418df38c06bb6283ec65a76627233f3f00 Mon Sep 17 00:00:00 2001
+From: Michal Krawczyk <mk@semihalf.com>
+Date: Tue, 28 May 2019 10:28:34 +0200
+Subject: [PATCH 14/15] net/ena: fix Rx checksum errors statistics
+
+[ upstream commit ef74b5f7b69b9502ddab81121611243efcfe1dde ]
+
+Rx checksum flags and input errors shouldn't be updated on Tx, as it
+would work only for packets forwarding.
+
+The ierrors statistic should be updated on Rx, right after checking
+Rx checksum flags if the Rx checksum offload is enabled.
+
+Fixes: 1173fca25af9 ("ena: add polling-mode driver")
+Cc: stable@dpdk.org
+
+Change-Id: I4ccf68bcb1ef6b50d01c811fc7f050a3d7ec9966
+Signed-off-by: Michal Krawczyk <mk@semihalf.com>
+---
+ drivers/net/ena/ena_ethdev.c | 9 +++++----
+ 1 file changed, 5 insertions(+), 4 deletions(-)
+
+diff --git a/drivers/net/ena/ena_ethdev.c b/drivers/net/ena/ena_ethdev.c
+index 97e6bbb85..96aec5d08 100644
+--- a/drivers/net/ena/ena_ethdev.c
++++ b/drivers/net/ena/ena_ethdev.c
+@@ -1569,6 +1569,11 @@ static uint16_t eth_ena_recv_pkts(void *rx_queue, struct rte_mbuf **rx_pkts,
+ 
+ 		/* fill mbuf attributes if any */
+ 		ena_rx_mbuf_prepare(mbuf_head, &ena_rx_ctx);
++
++		if (unlikely(mbuf_head->ol_flags &
++				(PKT_RX_IP_CKSUM_BAD | PKT_RX_L4_CKSUM_BAD)))
++			rte_atomic64_inc(&rx_ring->adapter->drv_stats->ierrors);
++
+ 		mbuf_head->hash.rss = ena_rx_ctx.hash;
+ 
+ 		/* pass to DPDK application head mbuf */
+@@ -1716,10 +1721,6 @@ static uint16_t eth_ena_xmit_pkts(void *tx_queue, struct rte_mbuf **tx_pkts,
+ 		/* Set TX offloads flags, if applicable */
+ 		ena_tx_mbuf_prepare(mbuf, &ena_tx_ctx);
+ 
+-		if (unlikely(mbuf->ol_flags &
+-			     (PKT_RX_L4_CKSUM_BAD | PKT_RX_IP_CKSUM_BAD)))
+-			rte_atomic64_inc(&tx_ring->adapter->drv_stats->ierrors);
+-
+ 		rte_prefetch0(tx_pkts[(sent_idx + 4) & ring_mask]);
+ 
+ 		/* Process first segment taking into
+-- 
+2.20.1
+

--- a/userspace/dpdk/17.08/0015-net-ena-fix-assigning-NUMA-node-to-IO-queue.patch
+++ b/userspace/dpdk/17.08/0015-net-ena-fix-assigning-NUMA-node-to-IO-queue.patch
@@ -1,0 +1,123 @@
+From fde1f112ac3a6dc67b515c2ca68da113bebd563f Mon Sep 17 00:00:00 2001
+From: Michal Krawczyk <mk@semihalf.com>
+Date: Tue, 4 Jun 2019 12:59:36 +0200
+Subject: [PATCH 15/15] net/ena: fix assigning NUMA node to IO queue
+
+[ upstream commit 4217cb0b7d2c5385f06f531af7f14b860927aba7 ]
+
+Previous solution was using memzones in invalid way in hope to assign
+IO queue to the appropriate NUMA zone.
+
+The right way is to use socket_id from the rx/tx queue setup function
+and then pass it to the IO queue.
+
+Fixes: 3d3edc265fc8 ("net/ena: make coherent memory allocation NUMA-aware")
+Cc: stable@dpdk.org
+
+Change-Id: I252df018ca6aae9d566618b6967bec0c5b3d939a
+Signed-off-by: Michal Krawczyk <mk@semihalf.com>
+Reviewed-by: David Marchand <david.marchand@redhat.com>
+---
+ drivers/net/ena/ena_ethdev.c | 23 ++++++-----------------
+ drivers/net/ena/ena_ethdev.h |  2 ++
+ 2 files changed, 8 insertions(+), 17 deletions(-)
+
+diff --git a/drivers/net/ena/ena_ethdev.c b/drivers/net/ena/ena_ethdev.c
+index 96aec5d08..023ceb7f3 100644
+--- a/drivers/net/ena/ena_ethdev.c
++++ b/drivers/net/ena/ena_ethdev.c
+@@ -39,7 +39,6 @@
+ #include <rte_dev.h>
+ #include <rte_errno.h>
+ #include <rte_version.h>
+-#include <rte_eal_memconfig.h>
+ #include <rte_net.h>
+ 
+ #include "ena_ethdev.h"
+@@ -244,18 +243,6 @@ static const struct eth_dev_ops ena_dev_ops = {
+ 	.reta_query           = ena_rss_reta_query,
+ };
+ 
+-#define NUMA_NO_NODE	SOCKET_ID_ANY
+-
+-static inline int ena_cpu_to_node(int cpu)
+-{
+-	struct rte_config *config = rte_eal_get_configuration();
+-
+-	if (likely(cpu < RTE_MAX_MEMZONE))
+-		return config->mem_config->memzone[cpu].socket_id;
+-
+-	return NUMA_NO_NODE;
+-}
+-
+ static inline void ena_rx_mbuf_prepare(struct rte_mbuf *mbuf,
+ 				       struct ena_com_rx_ctx *ena_rx_ctx)
+ {
+@@ -945,7 +932,7 @@ static int ena_queue_restart(struct ena_ring *ring)
+ static int ena_tx_queue_setup(struct rte_eth_dev *dev,
+ 			      uint16_t queue_idx,
+ 			      uint16_t nb_desc,
+-			      __rte_unused unsigned int socket_id,
++			      unsigned int socket_id,
+ 			      __rte_unused const struct rte_eth_txconf *tx_conf)
+ {
+ 	struct ena_com_create_io_ctx ctx =
+@@ -990,7 +977,7 @@ static int ena_tx_queue_setup(struct rte_eth_dev *dev,
+ 	ctx.msix_vector = -1; /* admin interrupts not used */
+ 	ctx.mem_queue_type = ena_dev->tx_mem_queue_type;
+ 	ctx.queue_size = adapter->tx_ring_size;
+-	ctx.numa_node = ena_cpu_to_node(queue_idx);
++	ctx.numa_node = socket_id;
+ 
+ 	rc = ena_com_create_io_queue(ena_dev, &ctx);
+ 	if (rc) {
+@@ -1016,6 +1003,7 @@ static int ena_tx_queue_setup(struct rte_eth_dev *dev,
+ 	txq->next_to_clean = 0;
+ 	txq->next_to_use = 0;
+ 	txq->ring_size = nb_desc;
++	txq->numa_socket_id = socket_id;
+ 
+ 	txq->tx_buffer_info = rte_zmalloc("txq->tx_buffer_info",
+ 					  sizeof(struct ena_tx_buffer) *
+@@ -1047,7 +1035,7 @@ static int ena_tx_queue_setup(struct rte_eth_dev *dev,
+ static int ena_rx_queue_setup(struct rte_eth_dev *dev,
+ 			      uint16_t queue_idx,
+ 			      uint16_t nb_desc,
+-			      __rte_unused unsigned int socket_id,
++			      unsigned int socket_id,
+ 			      __rte_unused const struct rte_eth_rxconf *rx_conf,
+ 			      struct rte_mempool *mp)
+ {
+@@ -1091,7 +1079,7 @@ static int ena_rx_queue_setup(struct rte_eth_dev *dev,
+ 	ctx.mem_queue_type = ENA_ADMIN_PLACEMENT_POLICY_HOST;
+ 	ctx.msix_vector = -1; /* admin interrupts not used */
+ 	ctx.queue_size = adapter->rx_ring_size;
+-	ctx.numa_node = ena_cpu_to_node(queue_idx);
++	ctx.numa_node = socket_id;
+ 
+ 	rc = ena_com_create_io_queue(ena_dev, &ctx);
+ 	if (rc)
+@@ -1115,6 +1103,7 @@ static int ena_rx_queue_setup(struct rte_eth_dev *dev,
+ 	rxq->next_to_clean = 0;
+ 	rxq->next_to_use = 0;
+ 	rxq->ring_size = nb_desc;
++	rxq->numa_socket_id = socket_id;
+ 	rxq->mb_pool = mp;
+ 
+ 	rxq->rx_buffer_info = rte_zmalloc("rxq->buffer_info",
+diff --git a/drivers/net/ena/ena_ethdev.h b/drivers/net/ena/ena_ethdev.h
+index 4791c53b5..8d5eb5a7c 100644
+--- a/drivers/net/ena/ena_ethdev.h
++++ b/drivers/net/ena/ena_ethdev.h
+@@ -90,6 +90,8 @@ struct ena_ring {
+ 	uint8_t tx_max_header_size;
+ 	int configured;
+ 	struct ena_adapter *adapter;
++
++	unsigned int numa_socket_id;
+ } __rte_cache_aligned;
+ 
+ enum ena_adapter_state {
+-- 
+2.20.1
+

--- a/userspace/dpdk/17.11/0001-net-ena-do-not-set-Tx-L4-offloads-in-Rx-path.patch
+++ b/userspace/dpdk/17.11/0001-net-ena-do-not-set-Tx-L4-offloads-in-Rx-path.patch
@@ -1,7 +1,7 @@
 From 64096abb852296cb7329e753b26c941a8ed24281 Mon Sep 17 00:00:00 2001
 From: Rafal Kozik <rk@semihalf.com>
 Date: Tue, 9 Jan 2018 16:19:08 +0100
-Subject: [PATCH 01/11] net/ena: do not set Tx L4 offloads in Rx path
+Subject: [PATCH 01/15] net/ena: do not set Tx L4 offloads in Rx path
 
 [ upstream commit fd617795679019c7aea5ab1e8c85db02cf53f169 ]
 
@@ -14,6 +14,7 @@ correct.
 Fixes: 1173fca25af9 ("ena: add polling-mode driver")
 Cc: stable@dpdk.org
 
+Change-Id: Icd33c149403377cacf5663b21029cbdc30ccb125
 Reported-by: Matthew Smith <mgsmith@netgate.com>
 Signed-off-by: Rafal Kozik <rk@semihalf.com>
 Signed-off-by: Michal Krawczyk <mk@semihalf.com>
@@ -56,5 +57,5 @@ index 22db8951f..aa24ef36a 100644
  
  static inline void ena_tx_mbuf_prepare(struct rte_mbuf *mbuf,
 -- 
-2.14.1
+2.20.1
 

--- a/userspace/dpdk/17.11/0002-net-ena-check-pointer-before-memset.patch
+++ b/userspace/dpdk/17.11/0002-net-ena-check-pointer-before-memset.patch
@@ -1,7 +1,7 @@
 From 151a5a389bb985a987f8f79389b0f6026d88fb25 Mon Sep 17 00:00:00 2001
 From: Rafal Kozik <rk@semihalf.com>
 Date: Thu, 7 Jun 2018 11:43:18 +0200
-Subject: [PATCH 02/11] net/ena: check pointer before memset
+Subject: [PATCH 02/15] net/ena: check pointer before memset
 
 [ upstream commit 46916aa17d4b2007df8c0454f99ba0ca8b8cb93b ]
 
@@ -11,6 +11,7 @@ Using memset on NULL pointer cause segfault.
 Fixes: 9ba7981ec992 ("ena: add communication layer for DPDK")
 Cc: stable@dpdk.org
 
+Change-Id: I7f7d1150234fd49312d9104d9603752ee4a3a0c8
 Signed-off-by: Rafal Kozik <rk@semihalf.com>
 Acked-by: Michal Krawczyk <mk@semihalf.com>
 ---
@@ -59,5 +60,5 @@ index accecf518..362741aa2 100644
  
  #define ENA_MEM_ALLOC_NODE(dmadev, size, virt, node, dev_node) \
 -- 
-2.14.1
+2.20.1
 

--- a/userspace/dpdk/17.11/0003-net-ena-change-memory-type.patch
+++ b/userspace/dpdk/17.11/0003-net-ena-change-memory-type.patch
@@ -1,7 +1,7 @@
 From e3963399ec5f886d6ea6d9b3c16d7241f3684f9f Mon Sep 17 00:00:00 2001
 From: Rafal Kozik <rk@semihalf.com>
 Date: Thu, 7 Jun 2018 11:43:19 +0200
-Subject: [PATCH 03/11] net/ena: change memory type
+Subject: [PATCH 03/15] net/ena: change memory type
 
 [ upstream commit 9f32c7e7e6ce58ab772913f54f8328c1c0186a17 ]
 
@@ -14,6 +14,7 @@ To avoid both issue use rte_zmalloc_socket.
 Fixes: 3d3edc265fc8 ("net/ena: make coherent memory allocation NUMA-aware")
 Cc: stable@dpdk.org
 
+Change-Id: I09427bfc0d3b7f90771c5a7be16aef3b95bd9069
 Signed-off-by: Rafal Kozik <rk@semihalf.com>
 Acked-by: Michal Krawczyk <mk@semihalf.com>
 ---
@@ -41,5 +42,5 @@ index 362741aa2..8363fb482 100644
  
  #define ENA_MEM_ALLOC(dmadev, size) rte_zmalloc(NULL, size, 1)
 -- 
-2.14.1
+2.20.1
 

--- a/userspace/dpdk/17.11/0004-net-ena-fix-GENMASK_ULL-macro.patch
+++ b/userspace/dpdk/17.11/0004-net-ena-fix-GENMASK_ULL-macro.patch
@@ -1,7 +1,7 @@
 From 94769c8103486abbb01d5efdf34f76cb35c0ca54 Mon Sep 17 00:00:00 2001
 From: Rafal Kozik <rk@semihalf.com>
 Date: Thu, 7 Jun 2018 11:43:20 +0200
-Subject: [PATCH 04/11] net/ena: fix GENMASK_ULL macro
+Subject: [PATCH 04/15] net/ena: fix GENMASK_ULL macro
 
 [ upstream commit 7544aee8d0b4ae0262b1ba7e1539cf8171664df7 ]
 
@@ -12,6 +12,7 @@ is undefined operation and failed on some platforms.
 Fixes: 9ba7981ec992 ("ena: add communication layer for DPDK")
 Cc: stable@dpdk.org
 
+Change-Id: I2094d149a9ff038824ebdff734b2e47bcb0f003f
 Signed-off-by: Rafal Kozik <rk@semihalf.com>
 Acked-by: Michal Krawczyk <mk@semihalf.com>
 ---
@@ -38,5 +39,5 @@ index 8363fb482..ea78e8d72 100644
  #ifdef RTE_LIBRTE_ENA_COM_DEBUG
  #define ena_trc_dbg(format, arg...)					\
 -- 
-2.14.1
+2.20.1
 

--- a/userspace/dpdk/17.11/0005-net-ena-set-link-speed-as-none.patch
+++ b/userspace/dpdk/17.11/0005-net-ena-set-link-speed-as-none.patch
@@ -1,7 +1,7 @@
 From 62eaabd44f665778739c50ce2f4076928366add5 Mon Sep 17 00:00:00 2001
 From: Rafal Kozik <rk@semihalf.com>
 Date: Thu, 7 Jun 2018 11:43:22 +0200
-Subject: [PATCH 05/11] net/ena: set link speed as none
+Subject: [PATCH 05/15] net/ena: set link speed as none
 
 [ upstream commit 41e59028dd8ab2038a7655c6fc3098222661aa53 ]
 
@@ -13,6 +13,7 @@ rely on this value when using ENA PMD.
 Fixes: 1173fca25af9 ("ena: add polling-mode driver")
 Cc: stable@dpdk.org
 
+Change-Id: I046f53eb179ba5171c687038820045affee833f3
 Signed-off-by: Rafal Kozik <rk@semihalf.com>
 Acked-by: Michal Krawczyk <mk@semihalf.com>
 ---
@@ -33,5 +34,5 @@ index aa24ef36a..32fcc0dc8 100644
  
  	return 0;
 -- 
-2.14.1
+2.20.1
 

--- a/userspace/dpdk/17.11/0006-net-ena-fix-SIGFPE-with-0-Rx-queue.patch
+++ b/userspace/dpdk/17.11/0006-net-ena-fix-SIGFPE-with-0-Rx-queue.patch
@@ -1,7 +1,7 @@
 From d89b7d3288a278548b5ce9686effd57195f96510 Mon Sep 17 00:00:00 2001
 From: Daria Kolistratova <daria.kolistratova@intel.com>
 Date: Tue, 26 Jun 2018 18:38:56 +0100
-Subject: [PATCH 06/11] net/ena: fix SIGFPE with 0 Rx queue
+Subject: [PATCH 06/15] net/ena: fix SIGFPE with 0 Rx queue
 
 [ upstream commit 361913ad6f8c05fc541fe4bfdae3b0dc095ae3af ]
 
@@ -11,6 +11,7 @@ It happens when the application is also requesting ETH_MQ_RX_RSS_FLAG
 in the rte_dev->data->dev_conf.rxmode.mq_mode.
 Fixed adding zero rx queues check.
 
+Change-Id: I04fff738df0134172be5443cdc1af3a3b35a2c32
 Signed-off-by: Daria Kolistratova <daria.kolistratova@intel.com>
 Acked-by: Michal Krawczyk <mk@semihalf.com>
 ---
@@ -31,5 +32,5 @@ index 32fcc0dc8..4e5265679 100644
  		if (rc)
  			return rc;
 -- 
-2.14.1
+2.20.1
 

--- a/userspace/dpdk/17.11/0007-net-ena-fix-passing-RSS-hash-to-mbuf.patch
+++ b/userspace/dpdk/17.11/0007-net-ena-fix-passing-RSS-hash-to-mbuf.patch
@@ -1,7 +1,7 @@
 From 92768ea1c337a8b7826d9cd5580df1760ba63a52 Mon Sep 17 00:00:00 2001
 From: Stewart Allen <allenste@amazon.com>
 Date: Thu, 25 Oct 2018 19:59:22 +0200
-Subject: [PATCH 07/11] net/ena: fix passing RSS hash to mbuf
+Subject: [PATCH 07/15] net/ena: fix passing RSS hash to mbuf
 
 [ upstream commit e5df9f33db00eb9d322abaefff30da74fd0e625d ]
 
@@ -11,6 +11,7 @@ from the device. Now, the RSS hash from the Rx descriptor is being set.
 Fixes: 1173fca25af9 ("ena: add polling-mode driver")
 Cc: stable@dpdk.org
 
+Change-Id: Iea37e68a1d685800166fa3733f150ad79a2e0b25
 Signed-off-by: Stewart Allen <allenste@amazon.com>
 Acked-by: Michal Krawczyk <mk@semihalf.com>
 ---
@@ -31,5 +32,5 @@ index 4e5265679..6b96f4042 100644
  		/* pass to DPDK application head mbuf */
  		rx_pkts[recv_idx] = mbuf_head;
 -- 
-2.14.1
+2.20.1
 

--- a/userspace/dpdk/17.11/0008-net-ena-add-supported-RSS-offloads-types.patch
+++ b/userspace/dpdk/17.11/0008-net-ena-add-supported-RSS-offloads-types.patch
@@ -1,7 +1,7 @@
 From 4630c295a661a54912c5975cbfa92dfd808cfd81 Mon Sep 17 00:00:00 2001
 From: Rafal Kozik <rk@semihalf.com>
 Date: Fri, 14 Dec 2018 14:18:38 +0100
-Subject: [PATCH 08/11] net/ena: add supported RSS offloads types
+Subject: [PATCH 08/15] net/ena: add supported RSS offloads types
 
 [ upstream commit b01ead202beb45346d7daeb2f2b1a608006af644 ]
 
@@ -12,6 +12,7 @@ missing information was added.
 Fixes: 1173fca25af9 ("ena: add polling-mode driver")
 Cc: stable@dpdk.org
 
+Change-Id: I1bd653526a00906db0d07673de73948ab8e67fec
 Signed-off-by: Rafal Kozik <rk@semihalf.com>
 Acked-by: Michal Krawczyk <mk@semihalf.com>
 ---
@@ -33,5 +34,5 @@ index 6b96f4042..2c0a895c6 100644
  	dev_info->max_rx_pktlen  = adapter->max_mtu;
  	dev_info->max_mac_addrs = 1;
 -- 
-2.14.1
+2.20.1
 

--- a/userspace/dpdk/17.11/0009-net-ena-update-completion-queue-after-cleanup.patch
+++ b/userspace/dpdk/17.11/0009-net-ena-update-completion-queue-after-cleanup.patch
@@ -1,7 +1,7 @@
 From ce68644565f9289d42f8b7991e31459e56b77fc5 Mon Sep 17 00:00:00 2001
 From: Rafal Kozik <rk@semihalf.com>
 Date: Fri, 14 Dec 2018 14:18:44 +0100
-Subject: [PATCH 09/11] net/ena: update completion queue after cleanup
+Subject: [PATCH 09/15] net/ena: update completion queue after cleanup
 
 [ upstream commit a45462c507e98b49cb5c2302e0be3c72d2e20a1a ]
 
@@ -11,6 +11,7 @@ ena_com_update_dev_comp_head().
 Fixes: 1daff5260ff8 ("net/ena: use unmasked head and tail")
 Cc: stable@dpdk.org
 
+Change-Id: I6c540b6b20205571d8759a7ef4c5835a6c8466cf
 Signed-off-by: Rafal Kozik <rk@semihalf.com>
 Acked-by: Michal Krawczyk <mk@semihalf.com>
 ---
@@ -45,5 +46,5 @@ index 2c0a895c6..188938729 100644
  
  	return sent_idx;
 -- 
-2.14.1
+2.20.1
 

--- a/userspace/dpdk/17.11/0010-net-ena-fix-dev-init-with-multi-process.patch
+++ b/userspace/dpdk/17.11/0010-net-ena-fix-dev-init-with-multi-process.patch
@@ -1,7 +1,7 @@
 From 0fff3abf8d883768713a0dbbd5a9ab4a74e0c915 Mon Sep 17 00:00:00 2001
 From: Michal Krawczyk <mk@semihalf.com>
 Date: Fri, 25 Jan 2019 09:10:25 +0100
-Subject: [PATCH 10/11] net/ena: fix dev init with multi-process
+Subject: [PATCH 10/15] net/ena: fix dev init with multi-process
 
 [ upstream commit fd9768905870856a2340266d25f8c0100dfccfff ]
 
@@ -15,6 +15,7 @@ main process.
 Fixes: 1173fca25af9 ("ena: add polling-mode driver")
 Cc: stable@dpdk.org
 
+Change-Id: Icd37ab0bfc5324a7fbec4248e9e028f54e2026a2
 Signed-off-by: Michal Krawczyk <mk@semihalf.com>
 ---
  drivers/net/ena/ena_ethdev.c | 11 ++++++-----
@@ -51,5 +52,5 @@ index 188938729..4a43648a6 100644
  	adapter->pdev = pci_dev;
  
 -- 
-2.14.1
+2.20.1
 

--- a/userspace/dpdk/17.11/0011-net-ena-fix-errno-to-positive-value.patch
+++ b/userspace/dpdk/17.11/0011-net-ena-fix-errno-to-positive-value.patch
@@ -1,7 +1,7 @@
 From 6af8a4cf960192b2f3e1a4904bf2aeda87ea155d Mon Sep 17 00:00:00 2001
 From: Michal Krawczyk <mk@semihalf.com>
 Date: Fri, 25 Jan 2019 09:10:26 +0100
-Subject: [PATCH 11/11] net/ena: fix errno to positive value
+Subject: [PATCH 11/15] net/ena: fix errno to positive value
 
 [ upstream commit baeed5f404dd1b049118cfec26a2fd3203671572 ]
 
@@ -11,6 +11,7 @@ to be fixed.
 Fixes: b3fc5a1ae10d ("net/ena: add Tx preparation")
 Cc: stable@dpdk.org
 
+Change-Id: If87b7246991ba450182fb48724b3a46977810602
 Signed-off-by: Michal Krawczyk <mk@semihalf.com>
 ---
  drivers/net/ena/ena_ethdev.c | 6 +++---
@@ -47,5 +48,5 @@ index 4a43648a6..4b8eeeadd 100644
  		}
  	}
 -- 
-2.14.1
+2.20.1
 

--- a/userspace/dpdk/17.11/0012-net-ena-get-device-info-statically.patch
+++ b/userspace/dpdk/17.11/0012-net-ena-get-device-info-statically.patch
@@ -1,0 +1,123 @@
+From 40eb10c972a4312f27bb3c2a486b9227e18618b6 Mon Sep 17 00:00:00 2001
+From: Michal Krawczyk <mk@semihalf.com>
+Date: Fri, 15 Feb 2019 09:36:39 +0100
+Subject: [PATCH 12/15] net/ena: get device info statically
+
+[ upstream commit 117ba4a60488a0f96a5737f38ddba6d0f9a728b6 ]
+
+Whenever the app is calling rte_eth_dev_info_get(), it shouldn't use the
+admin command. It was causing problems, if it was called from the
+secondary process - the main process was crashing, and the secondary app
+wasn't getting any result, as the admin request couldn't be processed by
+the process which was requesting the data.
+
+To fix that, the data is being written to the adapter structure during
+device initialization routine.
+
+Change-Id: I94f61f51223725602f70ac9795acf02b7b014984
+Signed-off-by: Michal Krawczyk <mk@semihalf.com>
+---
+ drivers/net/ena/ena_ethdev.c | 31 ++++++++++++-------------------
+ drivers/net/ena/ena_ethdev.h |  8 +++++++-
+ 2 files changed, 19 insertions(+), 20 deletions(-)
+
+diff --git a/drivers/net/ena/ena_ethdev.c b/drivers/net/ena/ena_ethdev.c
+index 4b8eeeadd..2432714f3 100644
+--- a/drivers/net/ena/ena_ethdev.c
++++ b/drivers/net/ena/ena_ethdev.c
+@@ -1362,9 +1362,14 @@ static int eth_ena_dev_init(struct rte_eth_dev *eth_dev)
+ 	/* Set max MTU for this device */
+ 	adapter->max_mtu = get_feat_ctx.dev_attr.max_mtu;
+ 
+-	/* set device support for TSO */
+-	adapter->tso4_supported = get_feat_ctx.offload.tx &
+-				  ENA_ADMIN_FEATURE_OFFLOAD_DESC_TSO_IPV4_MASK;
++	/* set device support for offloads */
++	adapter->offloads.tso4_supported = (get_feat_ctx.offload.tx &
++		ENA_ADMIN_FEATURE_OFFLOAD_DESC_TSO_IPV4_MASK) != 0;
++	adapter->offloads.tx_csum_supported = (get_feat_ctx.offload.tx &
++		ENA_ADMIN_FEATURE_OFFLOAD_DESC_TX_L4_IPV4_CSUM_PART_MASK) != 0;
++	adapter->offloads.tx_csum_supported =
++		(get_feat_ctx.offload.rx_supported &
++		ENA_ADMIN_FEATURE_OFFLOAD_DESC_RX_L4_IPV4_CSUM_MASK) != 0;
+ 
+ 	/* Copy MAC address and point DPDK to it */
+ 	eth_dev->data->mac_addrs = (struct ether_addr *)adapter->mac_addr;
+@@ -1443,9 +1448,7 @@ static void ena_infos_get(struct rte_eth_dev *dev,
+ {
+ 	struct ena_adapter *adapter;
+ 	struct ena_com_dev *ena_dev;
+-	struct ena_com_dev_get_features_ctx feat;
+ 	uint32_t rx_feat = 0, tx_feat = 0;
+-	int rc = 0;
+ 
+ 	ena_assert_msg(dev->data != NULL, "Uninitialized device");
+ 	ena_assert_msg(dev->data->dev_private != NULL, "Uninitialized device");
+@@ -1466,26 +1469,16 @@ static void ena_infos_get(struct rte_eth_dev *dev,
+ 			ETH_LINK_SPEED_50G  |
+ 			ETH_LINK_SPEED_100G;
+ 
+-	/* Get supported features from HW */
+-	rc = ena_com_get_dev_attr_feat(ena_dev, &feat);
+-	if (unlikely(rc)) {
+-		RTE_LOG(ERR, PMD,
+-			"Cannot get attribute for ena device rc= %d\n", rc);
+-		return;
+-	}
+-
+ 	/* Set Tx & Rx features available for device */
+-	if (feat.offload.tx & ENA_ADMIN_FEATURE_OFFLOAD_DESC_TSO_IPV4_MASK)
++	if (adapter->offloads.tso4_supported)
+ 		tx_feat	|= DEV_TX_OFFLOAD_TCP_TSO;
+ 
+-	if (feat.offload.tx &
+-	    ENA_ADMIN_FEATURE_OFFLOAD_DESC_TX_L4_IPV4_CSUM_PART_MASK)
++	if (adapter->offloads.tx_csum_supported)
+ 		tx_feat |= DEV_TX_OFFLOAD_IPV4_CKSUM |
+ 			DEV_TX_OFFLOAD_UDP_CKSUM |
+ 			DEV_TX_OFFLOAD_TCP_CKSUM;
+ 
+-	if (feat.offload.rx_supported &
+-	    ENA_ADMIN_FEATURE_OFFLOAD_DESC_RX_L4_IPV4_CSUM_MASK)
++	if (adapter->offloads.rx_csum_supported)
+ 		rx_feat |= DEV_RX_OFFLOAD_IPV4_CKSUM |
+ 			DEV_RX_OFFLOAD_UDP_CKSUM  |
+ 			DEV_RX_OFFLOAD_TCP_CKSUM;
+@@ -1631,7 +1624,7 @@ eth_ena_prep_pkts(void *tx_queue, struct rte_mbuf **tx_pkts,
+ 			/* If IPv4 header has DF flag enabled and TSO support is
+ 			 * disabled, partial chcecksum should not be calculated.
+ 			 */
+-			if (!tx_ring->adapter->tso4_supported)
++			if (!tx_ring->adapter->offloads.tso4_supported)
+ 				continue;
+ 		}
+ 
+diff --git a/drivers/net/ena/ena_ethdev.h b/drivers/net/ena/ena_ethdev.h
+index be8bc9fa6..c4e4bee14 100644
+--- a/drivers/net/ena/ena_ethdev.h
++++ b/drivers/net/ena/ena_ethdev.h
+@@ -144,6 +144,12 @@ struct ena_stats_rx {
+ 	u64 small_copy_len_pkt;
+ };
+ 
++struct ena_offloads {
++	bool tso4_supported;
++	bool tx_csum_supported;
++	bool rx_csum_supported;
++};
++
+ /* board specific private data structure */
+ struct ena_adapter {
+ 	/* OS defined structs */
+@@ -163,7 +169,7 @@ struct ena_adapter {
+ 
+ 	u16 num_queues;
+ 	u16 max_mtu;
+-	u8 tso4_supported;
++	struct ena_offloads offloads;
+ 
+ 	int id_number;
+ 	char name[ENA_NAME_MAX_LEN];
+-- 
+2.20.1
+

--- a/userspace/dpdk/17.11/0013-net-ena-fix-checksum-feature-flag.patch
+++ b/userspace/dpdk/17.11/0013-net-ena-fix-checksum-feature-flag.patch
@@ -1,0 +1,35 @@
+From 5216b9b7d6eccf880e65829b894011f98d6990c7 Mon Sep 17 00:00:00 2001
+From: Michal Krawczyk <mk@semihalf.com>
+Date: Mon, 8 Apr 2019 12:27:44 +0200
+Subject: [PATCH 13/15] net/ena: fix checksum feature flag
+
+[ upstream commit ef538c1a7f565c9b58518375a500aa864445fd11 ]
+
+The boolean value was assigned to Tx flag twice, so it could cause bug
+whenever Rx checksum will not be supported and Tx will be.
+
+Coverity issue: 336831
+Fixes: 117ba4a60488 ("net/ena: get device info statically")
+
+Change-Id: Id1ca7bb11b566c35ab7c9691593dcab40263c0f7
+Signed-off-by: Michal Krawczyk <mk@semihalf.com>
+---
+ drivers/net/ena/ena_ethdev.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/drivers/net/ena/ena_ethdev.c b/drivers/net/ena/ena_ethdev.c
+index 2432714f3..ae63ec630 100644
+--- a/drivers/net/ena/ena_ethdev.c
++++ b/drivers/net/ena/ena_ethdev.c
+@@ -1367,7 +1367,7 @@ static int eth_ena_dev_init(struct rte_eth_dev *eth_dev)
+ 		ENA_ADMIN_FEATURE_OFFLOAD_DESC_TSO_IPV4_MASK) != 0;
+ 	adapter->offloads.tx_csum_supported = (get_feat_ctx.offload.tx &
+ 		ENA_ADMIN_FEATURE_OFFLOAD_DESC_TX_L4_IPV4_CSUM_PART_MASK) != 0;
+-	adapter->offloads.tx_csum_supported =
++	adapter->offloads.rx_csum_supported =
+ 		(get_feat_ctx.offload.rx_supported &
+ 		ENA_ADMIN_FEATURE_OFFLOAD_DESC_RX_L4_IPV4_CSUM_MASK) != 0;
+ 
+-- 
+2.20.1
+

--- a/userspace/dpdk/17.11/0014-net-ena-fix-Rx-checksum-errors-statistics.patch
+++ b/userspace/dpdk/17.11/0014-net-ena-fix-Rx-checksum-errors-statistics.patch
@@ -1,0 +1,52 @@
+From 17cd8edaeb85bb822c6314bfd34f200173352569 Mon Sep 17 00:00:00 2001
+From: Michal Krawczyk <mk@semihalf.com>
+Date: Tue, 28 May 2019 10:28:34 +0200
+Subject: [PATCH 14/15] net/ena: fix Rx checksum errors statistics
+
+[ upstream commit ef74b5f7b69b9502ddab81121611243efcfe1dde ]
+
+Rx checksum flags and input errors shouldn't be updated on Tx, as it
+would work only for packets forwarding.
+
+The ierrors statistic should be updated on Rx, right after checking
+Rx checksum flags if the Rx checksum offload is enabled.
+
+Fixes: 1173fca25af9 ("ena: add polling-mode driver")
+Cc: stable@dpdk.org
+
+Change-Id: I4ccf68bcb1ef6b50d01c811fc7f050a3d7ec9966
+Signed-off-by: Michal Krawczyk <mk@semihalf.com>
+---
+ drivers/net/ena/ena_ethdev.c | 9 +++++----
+ 1 file changed, 5 insertions(+), 4 deletions(-)
+
+diff --git a/drivers/net/ena/ena_ethdev.c b/drivers/net/ena/ena_ethdev.c
+index ae63ec630..806fa3fef 100644
+--- a/drivers/net/ena/ena_ethdev.c
++++ b/drivers/net/ena/ena_ethdev.c
+@@ -1570,6 +1570,11 @@ static uint16_t eth_ena_recv_pkts(void *rx_queue, struct rte_mbuf **rx_pkts,
+ 
+ 		/* fill mbuf attributes if any */
+ 		ena_rx_mbuf_prepare(mbuf_head, &ena_rx_ctx);
++
++		if (unlikely(mbuf_head->ol_flags &
++				(PKT_RX_IP_CKSUM_BAD | PKT_RX_L4_CKSUM_BAD)))
++			rte_atomic64_inc(&rx_ring->adapter->drv_stats->ierrors);
++
+ 		mbuf_head->hash.rss = ena_rx_ctx.hash;
+ 
+ 		/* pass to DPDK application head mbuf */
+@@ -1717,10 +1722,6 @@ static uint16_t eth_ena_xmit_pkts(void *tx_queue, struct rte_mbuf **tx_pkts,
+ 		/* Set TX offloads flags, if applicable */
+ 		ena_tx_mbuf_prepare(mbuf, &ena_tx_ctx);
+ 
+-		if (unlikely(mbuf->ol_flags &
+-			     (PKT_RX_L4_CKSUM_BAD | PKT_RX_IP_CKSUM_BAD)))
+-			rte_atomic64_inc(&tx_ring->adapter->drv_stats->ierrors);
+-
+ 		rte_prefetch0(tx_pkts[(sent_idx + 4) & ring_mask]);
+ 
+ 		/* Process first segment taking into
+-- 
+2.20.1
+

--- a/userspace/dpdk/17.11/0015-net-ena-fix-assigning-NUMA-node-to-IO-queue.patch
+++ b/userspace/dpdk/17.11/0015-net-ena-fix-assigning-NUMA-node-to-IO-queue.patch
@@ -1,0 +1,123 @@
+From 3e80ae703756491e32cb989e5bcea5ddef3a9b12 Mon Sep 17 00:00:00 2001
+From: Michal Krawczyk <mk@semihalf.com>
+Date: Tue, 4 Jun 2019 12:59:36 +0200
+Subject: [PATCH 15/15] net/ena: fix assigning NUMA node to IO queue
+
+[ upstream commit 4217cb0b7d2c5385f06f531af7f14b860927aba7 ]
+
+Previous solution was using memzones in invalid way in hope to assign
+IO queue to the appropriate NUMA zone.
+
+The right way is to use socket_id from the rx/tx queue setup function
+and then pass it to the IO queue.
+
+Fixes: 3d3edc265fc8 ("net/ena: make coherent memory allocation NUMA-aware")
+Cc: stable@dpdk.org
+
+Change-Id: I252df018ca6aae9d566618b6967bec0c5b3d939a
+Signed-off-by: Michal Krawczyk <mk@semihalf.com>
+Reviewed-by: David Marchand <david.marchand@redhat.com>
+---
+ drivers/net/ena/ena_ethdev.c | 23 ++++++-----------------
+ drivers/net/ena/ena_ethdev.h |  2 ++
+ 2 files changed, 8 insertions(+), 17 deletions(-)
+
+diff --git a/drivers/net/ena/ena_ethdev.c b/drivers/net/ena/ena_ethdev.c
+index 806fa3fef..54b381b0a 100644
+--- a/drivers/net/ena/ena_ethdev.c
++++ b/drivers/net/ena/ena_ethdev.c
+@@ -39,7 +39,6 @@
+ #include <rte_dev.h>
+ #include <rte_errno.h>
+ #include <rte_version.h>
+-#include <rte_eal_memconfig.h>
+ #include <rte_net.h>
+ 
+ #include "ena_ethdev.h"
+@@ -244,18 +243,6 @@ static const struct eth_dev_ops ena_dev_ops = {
+ 	.reta_query           = ena_rss_reta_query,
+ };
+ 
+-#define NUMA_NO_NODE	SOCKET_ID_ANY
+-
+-static inline int ena_cpu_to_node(int cpu)
+-{
+-	struct rte_config *config = rte_eal_get_configuration();
+-
+-	if (likely(cpu < RTE_MAX_MEMZONE))
+-		return config->mem_config->memzone[cpu].socket_id;
+-
+-	return NUMA_NO_NODE;
+-}
+-
+ static inline void ena_rx_mbuf_prepare(struct rte_mbuf *mbuf,
+ 				       struct ena_com_rx_ctx *ena_rx_ctx)
+ {
+@@ -946,7 +933,7 @@ static int ena_queue_restart(struct ena_ring *ring)
+ static int ena_tx_queue_setup(struct rte_eth_dev *dev,
+ 			      uint16_t queue_idx,
+ 			      uint16_t nb_desc,
+-			      __rte_unused unsigned int socket_id,
++			      unsigned int socket_id,
+ 			      __rte_unused const struct rte_eth_txconf *tx_conf)
+ {
+ 	struct ena_com_create_io_ctx ctx =
+@@ -991,7 +978,7 @@ static int ena_tx_queue_setup(struct rte_eth_dev *dev,
+ 	ctx.msix_vector = -1; /* admin interrupts not used */
+ 	ctx.mem_queue_type = ena_dev->tx_mem_queue_type;
+ 	ctx.queue_size = adapter->tx_ring_size;
+-	ctx.numa_node = ena_cpu_to_node(queue_idx);
++	ctx.numa_node = socket_id;
+ 
+ 	rc = ena_com_create_io_queue(ena_dev, &ctx);
+ 	if (rc) {
+@@ -1017,6 +1004,7 @@ static int ena_tx_queue_setup(struct rte_eth_dev *dev,
+ 	txq->next_to_clean = 0;
+ 	txq->next_to_use = 0;
+ 	txq->ring_size = nb_desc;
++	txq->numa_socket_id = socket_id;
+ 
+ 	txq->tx_buffer_info = rte_zmalloc("txq->tx_buffer_info",
+ 					  sizeof(struct ena_tx_buffer) *
+@@ -1048,7 +1036,7 @@ static int ena_tx_queue_setup(struct rte_eth_dev *dev,
+ static int ena_rx_queue_setup(struct rte_eth_dev *dev,
+ 			      uint16_t queue_idx,
+ 			      uint16_t nb_desc,
+-			      __rte_unused unsigned int socket_id,
++			      unsigned int socket_id,
+ 			      __rte_unused const struct rte_eth_rxconf *rx_conf,
+ 			      struct rte_mempool *mp)
+ {
+@@ -1092,7 +1080,7 @@ static int ena_rx_queue_setup(struct rte_eth_dev *dev,
+ 	ctx.mem_queue_type = ENA_ADMIN_PLACEMENT_POLICY_HOST;
+ 	ctx.msix_vector = -1; /* admin interrupts not used */
+ 	ctx.queue_size = adapter->rx_ring_size;
+-	ctx.numa_node = ena_cpu_to_node(queue_idx);
++	ctx.numa_node = socket_id;
+ 
+ 	rc = ena_com_create_io_queue(ena_dev, &ctx);
+ 	if (rc)
+@@ -1116,6 +1104,7 @@ static int ena_rx_queue_setup(struct rte_eth_dev *dev,
+ 	rxq->next_to_clean = 0;
+ 	rxq->next_to_use = 0;
+ 	rxq->ring_size = nb_desc;
++	rxq->numa_socket_id = socket_id;
+ 	rxq->mb_pool = mp;
+ 
+ 	rxq->rx_buffer_info = rte_zmalloc("rxq->buffer_info",
+diff --git a/drivers/net/ena/ena_ethdev.h b/drivers/net/ena/ena_ethdev.h
+index c4e4bee14..a64d2ee0d 100644
+--- a/drivers/net/ena/ena_ethdev.h
++++ b/drivers/net/ena/ena_ethdev.h
+@@ -91,6 +91,8 @@ struct ena_ring {
+ 	uint8_t tx_max_header_size;
+ 	int configured;
+ 	struct ena_adapter *adapter;
++
++	unsigned int numa_socket_id;
+ } __rte_cache_aligned;
+ 
+ enum ena_adapter_state {
+-- 
+2.20.1
+

--- a/userspace/dpdk/18.02/0001-net-ena-check-pointer-before-memset.patch
+++ b/userspace/dpdk/18.02/0001-net-ena-check-pointer-before-memset.patch
@@ -1,7 +1,7 @@
 From a81ebdfe8e3ef6224696a8d66b2daf0540903f19 Mon Sep 17 00:00:00 2001
 From: Rafal Kozik <rk@semihalf.com>
 Date: Thu, 7 Jun 2018 11:43:18 +0200
-Subject: [PATCH 01/10] net/ena: check pointer before memset
+Subject: [PATCH 01/15] net/ena: check pointer before memset
 
 [ upstream commit 46916aa17d4b2007df8c0454f99ba0ca8b8cb93b ]
 
@@ -11,6 +11,7 @@ Using memset on NULL pointer cause segfault.
 Fixes: 9ba7981ec992 ("ena: add communication layer for DPDK")
 Cc: stable@dpdk.org
 
+Change-Id: I7f7d1150234fd49312d9104d9603752ee4a3a0c8
 Signed-off-by: Rafal Kozik <rk@semihalf.com>
 Acked-by: Michal Krawczyk <mk@semihalf.com>
 ---
@@ -59,5 +60,5 @@ index 8cba319eb..95f2d9f6f 100644
  
  #define ENA_MEM_ALLOC_NODE(dmadev, size, virt, node, dev_node) \
 -- 
-2.14.1
+2.20.1
 

--- a/userspace/dpdk/18.02/0002-net-ena-change-memory-type.patch
+++ b/userspace/dpdk/18.02/0002-net-ena-change-memory-type.patch
@@ -1,7 +1,7 @@
 From 338c21f83954ea47a3288f3ee1f64e54837b2e1f Mon Sep 17 00:00:00 2001
 From: Rafal Kozik <rk@semihalf.com>
 Date: Thu, 7 Jun 2018 11:43:19 +0200
-Subject: [PATCH 02/10] net/ena: change memory type
+Subject: [PATCH 02/15] net/ena: change memory type
 
 [ upstream commit 9f32c7e7e6ce58ab772913f54f8328c1c0186a17 ]
 
@@ -14,6 +14,7 @@ To avoid both issue use rte_zmalloc_socket.
 Fixes: 3d3edc265fc8 ("net/ena: make coherent memory allocation NUMA-aware")
 Cc: stable@dpdk.org
 
+Change-Id: I09427bfc0d3b7f90771c5a7be16aef3b95bd9069
 Signed-off-by: Rafal Kozik <rk@semihalf.com>
 Acked-by: Michal Krawczyk <mk@semihalf.com>
 ---
@@ -41,5 +42,5 @@ index 95f2d9f6f..00ff9363c 100644
  
  #define ENA_MEM_ALLOC(dmadev, size) rte_zmalloc(NULL, size, 1)
 -- 
-2.14.1
+2.20.1
 

--- a/userspace/dpdk/18.02/0003-net-ena-fix-GENMASK_ULL-macro.patch
+++ b/userspace/dpdk/18.02/0003-net-ena-fix-GENMASK_ULL-macro.patch
@@ -1,7 +1,7 @@
 From 5960b6d766b0802a77bebe4887a6c633e4f8c3a9 Mon Sep 17 00:00:00 2001
 From: Rafal Kozik <rk@semihalf.com>
 Date: Thu, 7 Jun 2018 11:43:20 +0200
-Subject: [PATCH 03/10] net/ena: fix GENMASK_ULL macro
+Subject: [PATCH 03/15] net/ena: fix GENMASK_ULL macro
 
 [ upstream commit 7544aee8d0b4ae0262b1ba7e1539cf8171664df7 ]
 
@@ -12,6 +12,7 @@ is undefined operation and failed on some platforms.
 Fixes: 9ba7981ec992 ("ena: add communication layer for DPDK")
 Cc: stable@dpdk.org
 
+Change-Id: I2094d149a9ff038824ebdff734b2e47bcb0f003f
 Signed-off-by: Rafal Kozik <rk@semihalf.com>
 Acked-by: Michal Krawczyk <mk@semihalf.com>
 ---
@@ -38,5 +39,5 @@ index 00ff9363c..72d501538 100644
  #ifdef RTE_LIBRTE_ENA_COM_DEBUG
  #define ena_trc_dbg(format, arg...)					\
 -- 
-2.14.1
+2.20.1
 

--- a/userspace/dpdk/18.02/0004-net-ena-set-link-speed-as-none.patch
+++ b/userspace/dpdk/18.02/0004-net-ena-set-link-speed-as-none.patch
@@ -1,7 +1,7 @@
 From ab96831a8a190f887430181af291670826413568 Mon Sep 17 00:00:00 2001
 From: Rafal Kozik <rk@semihalf.com>
 Date: Thu, 7 Jun 2018 11:43:22 +0200
-Subject: [PATCH 04/10] net/ena: set link speed as none
+Subject: [PATCH 04/15] net/ena: set link speed as none
 
 [ upstream commit 41e59028dd8ab2038a7655c6fc3098222661aa53 ]
 
@@ -13,6 +13,7 @@ rely on this value when using ENA PMD.
 Fixes: 1173fca25af9 ("ena: add polling-mode driver")
 Cc: stable@dpdk.org
 
+Change-Id: I046f53eb179ba5171c687038820045affee833f3
 Signed-off-by: Rafal Kozik <rk@semihalf.com>
 Acked-by: Michal Krawczyk <mk@semihalf.com>
 ---
@@ -33,5 +34,5 @@ index 34b2a8d78..9eecb986e 100644
  
  	return 0;
 -- 
-2.14.1
+2.20.1
 

--- a/userspace/dpdk/18.02/0005-net-ena-fix-SIGFPE-with-0-Rx-queue.patch
+++ b/userspace/dpdk/18.02/0005-net-ena-fix-SIGFPE-with-0-Rx-queue.patch
@@ -1,7 +1,7 @@
 From 3d1ec83f9e963e57e731debc6c74e05a4e955687 Mon Sep 17 00:00:00 2001
 From: Daria Kolistratova <daria.kolistratova@intel.com>
 Date: Tue, 26 Jun 2018 18:38:56 +0100
-Subject: [PATCH 05/10] net/ena: fix SIGFPE with 0 Rx queue
+Subject: [PATCH 05/15] net/ena: fix SIGFPE with 0 Rx queue
 
 [ upstream commit 361913ad6f8c05fc541fe4bfdae3b0dc095ae3af ]
 
@@ -11,6 +11,7 @@ It happens when the application is also requesting ETH_MQ_RX_RSS_FLAG
 in the rte_dev->data->dev_conf.rxmode.mq_mode.
 Fixed adding zero rx queues check.
 
+Change-Id: I04fff738df0134172be5443cdc1af3a3b35a2c32
 Signed-off-by: Daria Kolistratova <daria.kolistratova@intel.com>
 Acked-by: Michal Krawczyk <mk@semihalf.com>
 ---
@@ -31,5 +32,5 @@ index 9eecb986e..ec72407f6 100644
  		if (rc)
  			return rc;
 -- 
-2.14.1
+2.20.1
 

--- a/userspace/dpdk/18.02/0006-net-ena-fix-passing-RSS-hash-to-mbuf.patch
+++ b/userspace/dpdk/18.02/0006-net-ena-fix-passing-RSS-hash-to-mbuf.patch
@@ -1,7 +1,7 @@
 From 2b705349532283b0c80d7ec7ea622fce7f177142 Mon Sep 17 00:00:00 2001
 From: Stewart Allen <allenste@amazon.com>
 Date: Thu, 25 Oct 2018 19:59:22 +0200
-Subject: [PATCH 06/10] net/ena: fix passing RSS hash to mbuf
+Subject: [PATCH 06/15] net/ena: fix passing RSS hash to mbuf
 
 [ upstream commit e5df9f33db00eb9d322abaefff30da74fd0e625d ]
 
@@ -11,6 +11,7 @@ from the device. Now, the RSS hash from the Rx descriptor is being set.
 Fixes: 1173fca25af9 ("ena: add polling-mode driver")
 Cc: stable@dpdk.org
 
+Change-Id: Iea37e68a1d685800166fa3733f150ad79a2e0b25
 Signed-off-by: Stewart Allen <allenste@amazon.com>
 Acked-by: Michal Krawczyk <mk@semihalf.com>
 ---
@@ -31,5 +32,5 @@ index ec72407f6..51b351a95 100644
  		/* pass to DPDK application head mbuf */
  		rx_pkts[recv_idx] = mbuf_head;
 -- 
-2.14.1
+2.20.1
 

--- a/userspace/dpdk/18.02/0007-net-ena-add-supported-RSS-offloads-types.patch
+++ b/userspace/dpdk/18.02/0007-net-ena-add-supported-RSS-offloads-types.patch
@@ -1,7 +1,7 @@
 From b12580f688e9fa3aab311b83ef09391ff664b27f Mon Sep 17 00:00:00 2001
 From: Rafal Kozik <rk@semihalf.com>
 Date: Fri, 14 Dec 2018 14:18:38 +0100
-Subject: [PATCH 07/10] net/ena: add supported RSS offloads types
+Subject: [PATCH 07/15] net/ena: add supported RSS offloads types
 
 [ upstream commit b01ead202beb45346d7daeb2f2b1a608006af644 ]
 
@@ -12,6 +12,7 @@ missing information was added.
 Fixes: 1173fca25af9 ("ena: add polling-mode driver")
 Cc: stable@dpdk.org
 
+Change-Id: I1bd653526a00906db0d07673de73948ab8e67fec
 Signed-off-by: Rafal Kozik <rk@semihalf.com>
 Acked-by: Michal Krawczyk <mk@semihalf.com>
 ---
@@ -33,5 +34,5 @@ index 51b351a95..21b9fa4c8 100644
  	dev_info->max_rx_pktlen  = adapter->max_mtu;
  	dev_info->max_mac_addrs = 1;
 -- 
-2.14.1
+2.20.1
 

--- a/userspace/dpdk/18.02/0008-net-ena-update-completion-queue-after-cleanup.patch
+++ b/userspace/dpdk/18.02/0008-net-ena-update-completion-queue-after-cleanup.patch
@@ -1,7 +1,7 @@
 From cc79443574e2d2047bdf8d5b15049c02927c9512 Mon Sep 17 00:00:00 2001
 From: Rafal Kozik <rk@semihalf.com>
 Date: Fri, 14 Dec 2018 14:18:44 +0100
-Subject: [PATCH 08/10] net/ena: update completion queue after cleanup
+Subject: [PATCH 08/15] net/ena: update completion queue after cleanup
 
 [ upstream commit a45462c507e98b49cb5c2302e0be3c72d2e20a1a ]
 
@@ -11,6 +11,7 @@ ena_com_update_dev_comp_head().
 Fixes: 1daff5260ff8 ("net/ena: use unmasked head and tail")
 Cc: stable@dpdk.org
 
+Change-Id: I6c540b6b20205571d8759a7ef4c5835a6c8466cf
 Signed-off-by: Rafal Kozik <rk@semihalf.com>
 Acked-by: Michal Krawczyk <mk@semihalf.com>
 ---
@@ -45,5 +46,5 @@ index 21b9fa4c8..bd9ec3f67 100644
  
  	return sent_idx;
 -- 
-2.14.1
+2.20.1
 

--- a/userspace/dpdk/18.02/0009-net-ena-fix-dev-init-with-multi-process.patch
+++ b/userspace/dpdk/18.02/0009-net-ena-fix-dev-init-with-multi-process.patch
@@ -1,7 +1,7 @@
 From 3194c83ab3a52d3486fb914acbad7fa55f2ed39c Mon Sep 17 00:00:00 2001
 From: Michal Krawczyk <mk@semihalf.com>
 Date: Fri, 25 Jan 2019 09:10:25 +0100
-Subject: [PATCH 09/10] net/ena: fix dev init with multi-process
+Subject: [PATCH 09/15] net/ena: fix dev init with multi-process
 
 [ upstream commit fd9768905870856a2340266d25f8c0100dfccfff ]
 
@@ -15,6 +15,7 @@ main process.
 Fixes: 1173fca25af9 ("ena: add polling-mode driver")
 Cc: stable@dpdk.org
 
+Change-Id: Icd37ab0bfc5324a7fbec4248e9e028f54e2026a2
 Signed-off-by: Michal Krawczyk <mk@semihalf.com>
 ---
  drivers/net/ena/ena_ethdev.c | 11 ++++++-----
@@ -51,5 +52,5 @@ index bd9ec3f67..309cf8e3f 100644
  	adapter->pdev = pci_dev;
  
 -- 
-2.14.1
+2.20.1
 

--- a/userspace/dpdk/18.02/0010-net-ena-fix-errno-to-positive-value.patch
+++ b/userspace/dpdk/18.02/0010-net-ena-fix-errno-to-positive-value.patch
@@ -1,7 +1,7 @@
 From 0eb5d2ca0b16edccf4495f5f71e3a0bc28493b0d Mon Sep 17 00:00:00 2001
 From: Michal Krawczyk <mk@semihalf.com>
 Date: Fri, 25 Jan 2019 09:10:26 +0100
-Subject: [PATCH 10/10] net/ena: fix errno to positive value
+Subject: [PATCH 10/15] net/ena: fix errno to positive value
 
 [ upstream commit baeed5f404dd1b049118cfec26a2fd3203671572 ]
 
@@ -11,6 +11,7 @@ to be fixed.
 Fixes: b3fc5a1ae10d ("net/ena: add Tx preparation")
 Cc: stable@dpdk.org
 
+Change-Id: If87b7246991ba450182fb48724b3a46977810602
 Signed-off-by: Michal Krawczyk <mk@semihalf.com>
 ---
  drivers/net/ena/ena_ethdev.c | 6 +++---
@@ -47,5 +48,5 @@ index 309cf8e3f..32ba585c8 100644
  		}
  	}
 -- 
-2.14.1
+2.20.1
 

--- a/userspace/dpdk/18.02/0011-net-ena-get-device-info-statically.patch
+++ b/userspace/dpdk/18.02/0011-net-ena-get-device-info-statically.patch
@@ -1,0 +1,123 @@
+From ae85348bac77233cfb9906b9576204a8ae2f47ce Mon Sep 17 00:00:00 2001
+From: Michal Krawczyk <mk@semihalf.com>
+Date: Fri, 15 Feb 2019 09:36:39 +0100
+Subject: [PATCH 11/15] net/ena: get device info statically
+
+[ upstream commit 117ba4a60488a0f96a5737f38ddba6d0f9a728b6 ]
+
+Whenever the app is calling rte_eth_dev_info_get(), it shouldn't use the
+admin command. It was causing problems, if it was called from the
+secondary process - the main process was crashing, and the secondary app
+wasn't getting any result, as the admin request couldn't be processed by
+the process which was requesting the data.
+
+To fix that, the data is being written to the adapter structure during
+device initialization routine.
+
+Change-Id: I94f61f51223725602f70ac9795acf02b7b014984
+Signed-off-by: Michal Krawczyk <mk@semihalf.com>
+---
+ drivers/net/ena/ena_ethdev.c | 31 ++++++++++++-------------------
+ drivers/net/ena/ena_ethdev.h |  8 +++++++-
+ 2 files changed, 19 insertions(+), 20 deletions(-)
+
+diff --git a/drivers/net/ena/ena_ethdev.c b/drivers/net/ena/ena_ethdev.c
+index 32ba585c8..32f597cb7 100644
+--- a/drivers/net/ena/ena_ethdev.c
++++ b/drivers/net/ena/ena_ethdev.c
+@@ -1392,9 +1392,14 @@ static int eth_ena_dev_init(struct rte_eth_dev *eth_dev)
+ 	/* Set max MTU for this device */
+ 	adapter->max_mtu = get_feat_ctx.dev_attr.max_mtu;
+ 
+-	/* set device support for TSO */
+-	adapter->tso4_supported = get_feat_ctx.offload.tx &
+-				  ENA_ADMIN_FEATURE_OFFLOAD_DESC_TSO_IPV4_MASK;
++	/* set device support for offloads */
++	adapter->offloads.tso4_supported = (get_feat_ctx.offload.tx &
++		ENA_ADMIN_FEATURE_OFFLOAD_DESC_TSO_IPV4_MASK) != 0;
++	adapter->offloads.tx_csum_supported = (get_feat_ctx.offload.tx &
++		ENA_ADMIN_FEATURE_OFFLOAD_DESC_TX_L4_IPV4_CSUM_PART_MASK) != 0;
++	adapter->offloads.tx_csum_supported =
++		(get_feat_ctx.offload.rx_supported &
++		ENA_ADMIN_FEATURE_OFFLOAD_DESC_RX_L4_IPV4_CSUM_MASK) != 0;
+ 
+ 	/* Copy MAC address and point DPDK to it */
+ 	eth_dev->data->mac_addrs = (struct ether_addr *)adapter->mac_addr;
+@@ -1517,9 +1522,7 @@ static void ena_infos_get(struct rte_eth_dev *dev,
+ {
+ 	struct ena_adapter *adapter;
+ 	struct ena_com_dev *ena_dev;
+-	struct ena_com_dev_get_features_ctx feat;
+ 	uint64_t rx_feat = 0, tx_feat = 0;
+-	int rc = 0;
+ 
+ 	ena_assert_msg(dev->data != NULL, "Uninitialized device");
+ 	ena_assert_msg(dev->data->dev_private != NULL, "Uninitialized device");
+@@ -1540,26 +1543,16 @@ static void ena_infos_get(struct rte_eth_dev *dev,
+ 			ETH_LINK_SPEED_50G  |
+ 			ETH_LINK_SPEED_100G;
+ 
+-	/* Get supported features from HW */
+-	rc = ena_com_get_dev_attr_feat(ena_dev, &feat);
+-	if (unlikely(rc)) {
+-		RTE_LOG(ERR, PMD,
+-			"Cannot get attribute for ena device rc= %d\n", rc);
+-		return;
+-	}
+-
+ 	/* Set Tx & Rx features available for device */
+-	if (feat.offload.tx & ENA_ADMIN_FEATURE_OFFLOAD_DESC_TSO_IPV4_MASK)
++	if (adapter->offloads.tso4_supported)
+ 		tx_feat	|= DEV_TX_OFFLOAD_TCP_TSO;
+ 
+-	if (feat.offload.tx &
+-	    ENA_ADMIN_FEATURE_OFFLOAD_DESC_TX_L4_IPV4_CSUM_PART_MASK)
++	if (adapter->offloads.tx_csum_supported)
+ 		tx_feat |= DEV_TX_OFFLOAD_IPV4_CKSUM |
+ 			DEV_TX_OFFLOAD_UDP_CKSUM |
+ 			DEV_TX_OFFLOAD_TCP_CKSUM;
+ 
+-	if (feat.offload.rx_supported &
+-	    ENA_ADMIN_FEATURE_OFFLOAD_DESC_RX_L4_IPV4_CSUM_MASK)
++	if (adapter->offloads.rx_csum_supported)
+ 		rx_feat |= DEV_RX_OFFLOAD_IPV4_CKSUM |
+ 			DEV_RX_OFFLOAD_UDP_CKSUM  |
+ 			DEV_RX_OFFLOAD_TCP_CKSUM;
+@@ -1712,7 +1705,7 @@ eth_ena_prep_pkts(void *tx_queue, struct rte_mbuf **tx_pkts,
+ 			/* If IPv4 header has DF flag enabled and TSO support is
+ 			 * disabled, partial chcecksum should not be calculated.
+ 			 */
+-			if (!tx_ring->adapter->tso4_supported)
++			if (!tx_ring->adapter->offloads.tso4_supported)
+ 				continue;
+ 		}
+ 
+diff --git a/drivers/net/ena/ena_ethdev.h b/drivers/net/ena/ena_ethdev.h
+index 394d05e02..2c98b4092 100644
+--- a/drivers/net/ena/ena_ethdev.h
++++ b/drivers/net/ena/ena_ethdev.h
+@@ -145,6 +145,12 @@ struct ena_stats_rx {
+ 	u64 small_copy_len_pkt;
+ };
+ 
++struct ena_offloads {
++	bool tso4_supported;
++	bool tx_csum_supported;
++	bool rx_csum_supported;
++};
++
+ /* board specific private data structure */
+ struct ena_adapter {
+ 	/* OS defined structs */
+@@ -164,7 +170,7 @@ struct ena_adapter {
+ 
+ 	u16 num_queues;
+ 	u16 max_mtu;
+-	u8 tso4_supported;
++	struct ena_offloads offloads;
+ 
+ 	int id_number;
+ 	char name[ENA_NAME_MAX_LEN];
+-- 
+2.20.1
+

--- a/userspace/dpdk/18.02/0012-net-ena-fix-checksum-feature-flag.patch
+++ b/userspace/dpdk/18.02/0012-net-ena-fix-checksum-feature-flag.patch
@@ -1,0 +1,35 @@
+From 824927c3514e5d4528605ddb867e163227c5fde4 Mon Sep 17 00:00:00 2001
+From: Michal Krawczyk <mk@semihalf.com>
+Date: Mon, 8 Apr 2019 12:27:44 +0200
+Subject: [PATCH 12/15] net/ena: fix checksum feature flag
+
+[ upstream commit ef538c1a7f565c9b58518375a500aa864445fd11 ]
+
+The boolean value was assigned to Tx flag twice, so it could cause bug
+whenever Rx checksum will not be supported and Tx will be.
+
+Coverity issue: 336831
+Fixes: 117ba4a60488 ("net/ena: get device info statically")
+
+Change-Id: Id1ca7bb11b566c35ab7c9691593dcab40263c0f7
+Signed-off-by: Michal Krawczyk <mk@semihalf.com>
+---
+ drivers/net/ena/ena_ethdev.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/drivers/net/ena/ena_ethdev.c b/drivers/net/ena/ena_ethdev.c
+index 32f597cb7..4b4a2dacb 100644
+--- a/drivers/net/ena/ena_ethdev.c
++++ b/drivers/net/ena/ena_ethdev.c
+@@ -1397,7 +1397,7 @@ static int eth_ena_dev_init(struct rte_eth_dev *eth_dev)
+ 		ENA_ADMIN_FEATURE_OFFLOAD_DESC_TSO_IPV4_MASK) != 0;
+ 	adapter->offloads.tx_csum_supported = (get_feat_ctx.offload.tx &
+ 		ENA_ADMIN_FEATURE_OFFLOAD_DESC_TX_L4_IPV4_CSUM_PART_MASK) != 0;
+-	adapter->offloads.tx_csum_supported =
++	adapter->offloads.rx_csum_supported =
+ 		(get_feat_ctx.offload.rx_supported &
+ 		ENA_ADMIN_FEATURE_OFFLOAD_DESC_RX_L4_IPV4_CSUM_MASK) != 0;
+ 
+-- 
+2.20.1
+

--- a/userspace/dpdk/18.02/0013-net-ena-fix-Rx-checksum-errors-statistics.patch
+++ b/userspace/dpdk/18.02/0013-net-ena-fix-Rx-checksum-errors-statistics.patch
@@ -1,0 +1,52 @@
+From 9e3a21bf95fcbf00d3b7e070440bf00f0af85e70 Mon Sep 17 00:00:00 2001
+From: Michal Krawczyk <mk@semihalf.com>
+Date: Tue, 28 May 2019 10:28:34 +0200
+Subject: [PATCH 13/15] net/ena: fix Rx checksum errors statistics
+
+[ upstream commit ef74b5f7b69b9502ddab81121611243efcfe1dde ]
+
+Rx checksum flags and input errors shouldn't be updated on Tx, as it
+would work only for packets forwarding.
+
+The ierrors statistic should be updated on Rx, right after checking
+Rx checksum flags if the Rx checksum offload is enabled.
+
+Fixes: 1173fca25af9 ("ena: add polling-mode driver")
+Cc: stable@dpdk.org
+
+Change-Id: I4ccf68bcb1ef6b50d01c811fc7f050a3d7ec9966
+Signed-off-by: Michal Krawczyk <mk@semihalf.com>
+---
+ drivers/net/ena/ena_ethdev.c | 9 +++++----
+ 1 file changed, 5 insertions(+), 4 deletions(-)
+
+diff --git a/drivers/net/ena/ena_ethdev.c b/drivers/net/ena/ena_ethdev.c
+index 4b4a2dacb..c96558b48 100644
+--- a/drivers/net/ena/ena_ethdev.c
++++ b/drivers/net/ena/ena_ethdev.c
+@@ -1651,6 +1651,11 @@ static uint16_t eth_ena_recv_pkts(void *rx_queue, struct rte_mbuf **rx_pkts,
+ 
+ 		/* fill mbuf attributes if any */
+ 		ena_rx_mbuf_prepare(mbuf_head, &ena_rx_ctx);
++
++		if (unlikely(mbuf_head->ol_flags &
++				(PKT_RX_IP_CKSUM_BAD | PKT_RX_L4_CKSUM_BAD)))
++			rte_atomic64_inc(&rx_ring->adapter->drv_stats->ierrors);
++
+ 		mbuf_head->hash.rss = ena_rx_ctx.hash;
+ 
+ 		/* pass to DPDK application head mbuf */
+@@ -1798,10 +1803,6 @@ static uint16_t eth_ena_xmit_pkts(void *tx_queue, struct rte_mbuf **tx_pkts,
+ 		/* Set TX offloads flags, if applicable */
+ 		ena_tx_mbuf_prepare(mbuf, &ena_tx_ctx, tx_ring->offloads);
+ 
+-		if (unlikely(mbuf->ol_flags &
+-			     (PKT_RX_L4_CKSUM_BAD | PKT_RX_IP_CKSUM_BAD)))
+-			rte_atomic64_inc(&tx_ring->adapter->drv_stats->ierrors);
+-
+ 		rte_prefetch0(tx_pkts[(sent_idx + 4) & ring_mask]);
+ 
+ 		/* Process first segment taking into
+-- 
+2.20.1
+

--- a/userspace/dpdk/18.02/0014-net-ena-fix-assigning-NUMA-node-to-IO-queue.patch
+++ b/userspace/dpdk/18.02/0014-net-ena-fix-assigning-NUMA-node-to-IO-queue.patch
@@ -1,0 +1,123 @@
+From 3469d75fda188b5c8f5b174737880e98f14e5c12 Mon Sep 17 00:00:00 2001
+From: Michal Krawczyk <mk@semihalf.com>
+Date: Tue, 4 Jun 2019 12:59:36 +0200
+Subject: [PATCH 14/15] net/ena: fix assigning NUMA node to IO queue
+
+[ upstream commit 4217cb0b7d2c5385f06f531af7f14b860927aba7 ]
+
+Previous solution was using memzones in invalid way in hope to assign
+IO queue to the appropriate NUMA zone.
+
+The right way is to use socket_id from the rx/tx queue setup function
+and then pass it to the IO queue.
+
+Fixes: 3d3edc265fc8 ("net/ena: make coherent memory allocation NUMA-aware")
+Cc: stable@dpdk.org
+
+Change-Id: I252df018ca6aae9d566618b6967bec0c5b3d939a
+Signed-off-by: Michal Krawczyk <mk@semihalf.com>
+Reviewed-by: David Marchand <david.marchand@redhat.com>
+---
+ drivers/net/ena/ena_ethdev.c | 23 ++++++-----------------
+ drivers/net/ena/ena_ethdev.h |  2 ++
+ 2 files changed, 8 insertions(+), 17 deletions(-)
+
+diff --git a/drivers/net/ena/ena_ethdev.c b/drivers/net/ena/ena_ethdev.c
+index c96558b48..be3442ec9 100644
+--- a/drivers/net/ena/ena_ethdev.c
++++ b/drivers/net/ena/ena_ethdev.c
+@@ -39,7 +39,6 @@
+ #include <rte_dev.h>
+ #include <rte_errno.h>
+ #include <rte_version.h>
+-#include <rte_eal_memconfig.h>
+ #include <rte_net.h>
+ 
+ #include "ena_ethdev.h"
+@@ -259,18 +258,6 @@ static const struct eth_dev_ops ena_dev_ops = {
+ 	.reta_query           = ena_rss_reta_query,
+ };
+ 
+-#define NUMA_NO_NODE	SOCKET_ID_ANY
+-
+-static inline int ena_cpu_to_node(int cpu)
+-{
+-	struct rte_config *config = rte_eal_get_configuration();
+-
+-	if (likely(cpu < RTE_MAX_MEMZONE))
+-		return config->mem_config->memzone[cpu].socket_id;
+-
+-	return NUMA_NO_NODE;
+-}
+-
+ static inline void ena_rx_mbuf_prepare(struct rte_mbuf *mbuf,
+ 				       struct ena_com_rx_ctx *ena_rx_ctx)
+ {
+@@ -963,7 +950,7 @@ static int ena_queue_restart(struct ena_ring *ring)
+ static int ena_tx_queue_setup(struct rte_eth_dev *dev,
+ 			      uint16_t queue_idx,
+ 			      uint16_t nb_desc,
+-			      __rte_unused unsigned int socket_id,
++			      unsigned int socket_id,
+ 			      const struct rte_eth_txconf *tx_conf)
+ {
+ 	struct ena_com_create_io_ctx ctx =
+@@ -1014,7 +1001,7 @@ static int ena_tx_queue_setup(struct rte_eth_dev *dev,
+ 	ctx.msix_vector = -1; /* admin interrupts not used */
+ 	ctx.mem_queue_type = ena_dev->tx_mem_queue_type;
+ 	ctx.queue_size = adapter->tx_ring_size;
+-	ctx.numa_node = ena_cpu_to_node(queue_idx);
++	ctx.numa_node = socket_id;
+ 
+ 	rc = ena_com_create_io_queue(ena_dev, &ctx);
+ 	if (rc) {
+@@ -1040,6 +1027,7 @@ static int ena_tx_queue_setup(struct rte_eth_dev *dev,
+ 	txq->next_to_clean = 0;
+ 	txq->next_to_use = 0;
+ 	txq->ring_size = nb_desc;
++	txq->numa_socket_id = socket_id;
+ 
+ 	txq->tx_buffer_info = rte_zmalloc("txq->tx_buffer_info",
+ 					  sizeof(struct ena_tx_buffer) *
+@@ -1073,7 +1061,7 @@ static int ena_tx_queue_setup(struct rte_eth_dev *dev,
+ static int ena_rx_queue_setup(struct rte_eth_dev *dev,
+ 			      uint16_t queue_idx,
+ 			      uint16_t nb_desc,
+-			      __rte_unused unsigned int socket_id,
++			      unsigned int socket_id,
+ 			      const struct rte_eth_rxconf *rx_conf,
+ 			      struct rte_mempool *mp)
+ {
+@@ -1122,7 +1110,7 @@ static int ena_rx_queue_setup(struct rte_eth_dev *dev,
+ 	ctx.mem_queue_type = ENA_ADMIN_PLACEMENT_POLICY_HOST;
+ 	ctx.msix_vector = -1; /* admin interrupts not used */
+ 	ctx.queue_size = adapter->rx_ring_size;
+-	ctx.numa_node = ena_cpu_to_node(queue_idx);
++	ctx.numa_node = socket_id;
+ 
+ 	rc = ena_com_create_io_queue(ena_dev, &ctx);
+ 	if (rc)
+@@ -1146,6 +1134,7 @@ static int ena_rx_queue_setup(struct rte_eth_dev *dev,
+ 	rxq->next_to_clean = 0;
+ 	rxq->next_to_use = 0;
+ 	rxq->ring_size = nb_desc;
++	rxq->numa_socket_id = socket_id;
+ 	rxq->mb_pool = mp;
+ 
+ 	rxq->rx_buffer_info = rte_zmalloc("rxq->buffer_info",
+diff --git a/drivers/net/ena/ena_ethdev.h b/drivers/net/ena/ena_ethdev.h
+index 2c98b4092..7dd8b2596 100644
+--- a/drivers/net/ena/ena_ethdev.h
++++ b/drivers/net/ena/ena_ethdev.h
+@@ -92,6 +92,8 @@ struct ena_ring {
+ 	int configured;
+ 	struct ena_adapter *adapter;
+ 	uint64_t offloads;
++
++	unsigned int numa_socket_id;
+ } __rte_cache_aligned;
+ 
+ enum ena_adapter_state {
+-- 
+2.20.1
+

--- a/userspace/dpdk/18.02/0015-net-ena-fix-L4-checksum-Tx-offload.patch
+++ b/userspace/dpdk/18.02/0015-net-ena-fix-L4-checksum-Tx-offload.patch
@@ -1,0 +1,52 @@
+From d199ead76aa31f68c6644a6fac6185b008f0c565 Mon Sep 17 00:00:00 2001
+From: Maciej Bielski <mba@semihalf.com>
+Date: Thu, 1 Aug 2019 13:45:36 +0200
+Subject: [PATCH 15/15] net/ena: fix L4 checksum Tx offload
+
+[ upstream commit 40e7c02155625f18a87faf5e6a8cec2e986146e8 ]
+
+During an if-condition evaluation, a 2-bit flag evaluates to 'true' for
+'0x1', '0x2' and '0x3'. Thus, from this perspective these flags are
+indistinguishable. To make them distinct, respective bits must be
+extracted with a mask and then checked for strict equality.
+
+Specifically here, even if `PKT_TX_UDP_CKSUM` (value '0x3') was set, the
+expression `mbuf->ol_flags & PKT_TX_TCP` (the second flag of value
+'0x1') is evaluated first and the result is 'true'. In consequence, for
+UDP packets the execution flow enters an incorrect branch.
+
+Fixes: 56b8b9b7e5d2 ("net/ena: convert to new Tx offloads API")
+Cc: stable@dpdk.org
+
+Change-Id: I7917b209856f24e5d0b6481a94b322d09266bc5b
+Reported-by: Eduard Serra <eserra@vmware.com>
+Signed-off-by: Maciej Bielski <mba@semihalf.com>
+Acked-by: Michal Krawczyk <mk@semihalf.com>
+---
+ drivers/net/ena/ena_ethdev.c | 7 ++++---
+ 1 file changed, 4 insertions(+), 3 deletions(-)
+
+diff --git a/drivers/net/ena/ena_ethdev.c b/drivers/net/ena/ena_ethdev.c
+index be3442ec9..28e561dc7 100644
+--- a/drivers/net/ena/ena_ethdev.c
++++ b/drivers/net/ena/ena_ethdev.c
+@@ -317,12 +317,13 @@ static inline void ena_tx_mbuf_prepare(struct rte_mbuf *mbuf,
+ 		}
+ 
+ 		/* check if L4 checksum is needed */
+-		if ((mbuf->ol_flags & PKT_TX_TCP_CKSUM) &&
++		if (((mbuf->ol_flags & PKT_TX_L4_MASK) == PKT_TX_TCP_CKSUM) &&
+ 		    (queue_offloads & DEV_TX_OFFLOAD_TCP_CKSUM)) {
+ 			ena_tx_ctx->l4_proto = ENA_ETH_IO_L4_PROTO_TCP;
+ 			ena_tx_ctx->l4_csum_enable = true;
+-		} else if ((mbuf->ol_flags & PKT_TX_UDP_CKSUM) &&
+-			   (queue_offloads & DEV_TX_OFFLOAD_UDP_CKSUM)) {
++		} else if (((mbuf->ol_flags & PKT_TX_L4_MASK) ==
++				PKT_TX_UDP_CKSUM) &&
++				(queue_offloads & DEV_TX_OFFLOAD_UDP_CKSUM)) {
+ 			ena_tx_ctx->l4_proto = ENA_ETH_IO_L4_PROTO_UDP;
+ 			ena_tx_ctx->l4_csum_enable = true;
+ 		} else {
+-- 
+2.20.1
+

--- a/userspace/dpdk/18.05/0001-net-ena-check-pointer-before-memset.patch
+++ b/userspace/dpdk/18.05/0001-net-ena-check-pointer-before-memset.patch
@@ -1,7 +1,7 @@
 From f130532579c8a60e7757cf315189fbe5087acc46 Mon Sep 17 00:00:00 2001
 From: Rafal Kozik <rk@semihalf.com>
 Date: Thu, 7 Jun 2018 11:43:18 +0200
-Subject: [PATCH 01/10] net/ena: check pointer before memset
+Subject: [PATCH 01/15] net/ena: check pointer before memset
 
 [ upstream commit 46916aa17d4b2007df8c0454f99ba0ca8b8cb93b ]
 
@@ -11,6 +11,7 @@ Using memset on NULL pointer cause segfault.
 Fixes: 9ba7981ec992 ("ena: add communication layer for DPDK")
 Cc: stable@dpdk.org
 
+Change-Id: I7f7d1150234fd49312d9104d9603752ee4a3a0c8
 Signed-off-by: Rafal Kozik <rk@semihalf.com>
 Acked-by: Michal Krawczyk <mk@semihalf.com>
 ---
@@ -59,5 +60,5 @@ index 93345199a..0ee440c21 100644
  
  #define ENA_MEM_ALLOC_NODE(dmadev, size, virt, node, dev_node) \
 -- 
-2.14.1
+2.20.1
 

--- a/userspace/dpdk/18.05/0002-net-ena-change-memory-type.patch
+++ b/userspace/dpdk/18.05/0002-net-ena-change-memory-type.patch
@@ -1,7 +1,7 @@
 From 52b4a8350aa705f1a0bf31d40db72d18fc1e24ea Mon Sep 17 00:00:00 2001
 From: Rafal Kozik <rk@semihalf.com>
 Date: Thu, 7 Jun 2018 11:43:19 +0200
-Subject: [PATCH 02/10] net/ena: change memory type
+Subject: [PATCH 02/15] net/ena: change memory type
 
 [ upstream commit 9f32c7e7e6ce58ab772913f54f8328c1c0186a17 ]
 
@@ -14,6 +14,7 @@ To avoid both issue use rte_zmalloc_socket.
 Fixes: 3d3edc265fc8 ("net/ena: make coherent memory allocation NUMA-aware")
 Cc: stable@dpdk.org
 
+Change-Id: I09427bfc0d3b7f90771c5a7be16aef3b95bd9069
 Signed-off-by: Rafal Kozik <rk@semihalf.com>
 Acked-by: Michal Krawczyk <mk@semihalf.com>
 ---
@@ -42,5 +43,5 @@ index 0ee440c21..e7917c506 100644
  
  #define ENA_MEM_ALLOC(dmadev, size) rte_zmalloc(NULL, size, 1)
 -- 
-2.14.1
+2.20.1
 

--- a/userspace/dpdk/18.05/0003-net-ena-fix-GENMASK_ULL-macro.patch
+++ b/userspace/dpdk/18.05/0003-net-ena-fix-GENMASK_ULL-macro.patch
@@ -1,7 +1,7 @@
 From 622fcfae471ebc7af522a43748649ec22e32a8ca Mon Sep 17 00:00:00 2001
 From: Rafal Kozik <rk@semihalf.com>
 Date: Thu, 7 Jun 2018 11:43:20 +0200
-Subject: [PATCH 03/10] net/ena: fix GENMASK_ULL macro
+Subject: [PATCH 03/15] net/ena: fix GENMASK_ULL macro
 
 [ upstream commit 7544aee8d0b4ae0262b1ba7e1539cf8171664df7 ]
 
@@ -12,6 +12,7 @@ is undefined operation and failed on some platforms.
 Fixes: 9ba7981ec992 ("ena: add communication layer for DPDK")
 Cc: stable@dpdk.org
 
+Change-Id: I2094d149a9ff038824ebdff734b2e47bcb0f003f
 Signed-off-by: Rafal Kozik <rk@semihalf.com>
 Acked-by: Michal Krawczyk <mk@semihalf.com>
 ---
@@ -38,5 +39,5 @@ index e7917c506..558966517 100644
  #ifdef RTE_LIBRTE_ENA_COM_DEBUG
  #define ena_trc_dbg(format, arg...)					\
 -- 
-2.14.1
+2.20.1
 

--- a/userspace/dpdk/18.05/0004-net-ena-set-link-speed-as-none.patch
+++ b/userspace/dpdk/18.05/0004-net-ena-set-link-speed-as-none.patch
@@ -1,7 +1,7 @@
 From fd3792a1316689d1fa54346fcbf1d71f6751eccd Mon Sep 17 00:00:00 2001
 From: Rafal Kozik <rk@semihalf.com>
 Date: Thu, 7 Jun 2018 11:43:22 +0200
-Subject: [PATCH 04/10] net/ena: set link speed as none
+Subject: [PATCH 04/15] net/ena: set link speed as none
 
 [ upstream commit 41e59028dd8ab2038a7655c6fc3098222661aa53 ]
 
@@ -13,6 +13,7 @@ rely on this value when using ENA PMD.
 Fixes: 1173fca25af9 ("ena: add polling-mode driver")
 Cc: stable@dpdk.org
 
+Change-Id: I046f53eb179ba5171c687038820045affee833f3
 Signed-off-by: Rafal Kozik <rk@semihalf.com>
 Acked-by: Michal Krawczyk <mk@semihalf.com>
 ---
@@ -33,5 +34,5 @@ index c595cc7e6..f10bee236 100644
  
  	return 0;
 -- 
-2.14.1
+2.20.1
 

--- a/userspace/dpdk/18.05/0005-net-ena-fix-SIGFPE-with-0-Rx-queue.patch
+++ b/userspace/dpdk/18.05/0005-net-ena-fix-SIGFPE-with-0-Rx-queue.patch
@@ -1,7 +1,7 @@
 From 68f8ac904a0079e519af7ddc191f4f22f66a2069 Mon Sep 17 00:00:00 2001
 From: Daria Kolistratova <daria.kolistratova@intel.com>
 Date: Tue, 26 Jun 2018 18:38:56 +0100
-Subject: [PATCH 05/10] net/ena: fix SIGFPE with 0 Rx queue
+Subject: [PATCH 05/15] net/ena: fix SIGFPE with 0 Rx queue
 
 [ upstream commit 361913ad6f8c05fc541fe4bfdae3b0dc095ae3af ]
 
@@ -11,6 +11,7 @@ It happens when the application is also requesting ETH_MQ_RX_RSS_FLAG
 in the rte_dev->data->dev_conf.rxmode.mq_mode.
 Fixed adding zero rx queues check.
 
+Change-Id: I04fff738df0134172be5443cdc1af3a3b35a2c32
 Signed-off-by: Daria Kolistratova <daria.kolistratova@intel.com>
 Acked-by: Michal Krawczyk <mk@semihalf.com>
 ---
@@ -31,5 +32,5 @@ index f10bee236..ebc911168 100644
  		if (rc)
  			return rc;
 -- 
-2.14.1
+2.20.1
 

--- a/userspace/dpdk/18.05/0006-net-ena-fix-passing-RSS-hash-to-mbuf.patch
+++ b/userspace/dpdk/18.05/0006-net-ena-fix-passing-RSS-hash-to-mbuf.patch
@@ -1,7 +1,7 @@
 From 952581ced26c55856be49a2e8220debd940966ab Mon Sep 17 00:00:00 2001
 From: Stewart Allen <allenste@amazon.com>
 Date: Thu, 25 Oct 2018 19:59:22 +0200
-Subject: [PATCH 06/10] net/ena: fix passing RSS hash to mbuf
+Subject: [PATCH 06/15] net/ena: fix passing RSS hash to mbuf
 
 [ upstream commit e5df9f33db00eb9d322abaefff30da74fd0e625d ]
 
@@ -11,6 +11,7 @@ from the device. Now, the RSS hash from the Rx descriptor is being set.
 Fixes: 1173fca25af9 ("ena: add polling-mode driver")
 Cc: stable@dpdk.org
 
+Change-Id: Iea37e68a1d685800166fa3733f150ad79a2e0b25
 Signed-off-by: Stewart Allen <allenste@amazon.com>
 Acked-by: Michal Krawczyk <mk@semihalf.com>
 ---
@@ -31,5 +32,5 @@ index ebc911168..f0849a455 100644
  		/* pass to DPDK application head mbuf */
  		rx_pkts[recv_idx] = mbuf_head;
 -- 
-2.14.1
+2.20.1
 

--- a/userspace/dpdk/18.05/0007-net-ena-add-supported-RSS-offloads-types.patch
+++ b/userspace/dpdk/18.05/0007-net-ena-add-supported-RSS-offloads-types.patch
@@ -1,7 +1,7 @@
 From 88726d133639d9f03382af7a3f18da7c2337dc8e Mon Sep 17 00:00:00 2001
 From: Rafal Kozik <rk@semihalf.com>
 Date: Fri, 14 Dec 2018 14:18:38 +0100
-Subject: [PATCH 07/10] net/ena: add supported RSS offloads types
+Subject: [PATCH 07/15] net/ena: add supported RSS offloads types
 
 [ upstream commit b01ead202beb45346d7daeb2f2b1a608006af644 ]
 
@@ -12,6 +12,7 @@ missing information was added.
 Fixes: 1173fca25af9 ("ena: add polling-mode driver")
 Cc: stable@dpdk.org
 
+Change-Id: I1bd653526a00906db0d07673de73948ab8e67fec
 Signed-off-by: Rafal Kozik <rk@semihalf.com>
 Acked-by: Michal Krawczyk <mk@semihalf.com>
 ---
@@ -33,5 +34,5 @@ index f0849a455..27717e739 100644
  	dev_info->max_rx_pktlen  = adapter->max_mtu;
  	dev_info->max_mac_addrs = 1;
 -- 
-2.14.1
+2.20.1
 

--- a/userspace/dpdk/18.05/0008-net-ena-update-completion-queue-after-cleanup.patch
+++ b/userspace/dpdk/18.05/0008-net-ena-update-completion-queue-after-cleanup.patch
@@ -1,7 +1,7 @@
 From f5003710a264d8e510e1c88cadaec2779ae64369 Mon Sep 17 00:00:00 2001
 From: Rafal Kozik <rk@semihalf.com>
 Date: Fri, 14 Dec 2018 14:18:44 +0100
-Subject: [PATCH 08/10] net/ena: update completion queue after cleanup
+Subject: [PATCH 08/15] net/ena: update completion queue after cleanup
 
 [ upstream commit a45462c507e98b49cb5c2302e0be3c72d2e20a1a ]
 
@@ -11,6 +11,7 @@ ena_com_update_dev_comp_head().
 Fixes: 1daff5260ff8 ("net/ena: use unmasked head and tail")
 Cc: stable@dpdk.org
 
+Change-Id: I6c540b6b20205571d8759a7ef4c5835a6c8466cf
 Signed-off-by: Rafal Kozik <rk@semihalf.com>
 Acked-by: Michal Krawczyk <mk@semihalf.com>
 ---
@@ -45,5 +46,5 @@ index 27717e739..ef6bc4067 100644
  
  	return sent_idx;
 -- 
-2.14.1
+2.20.1
 

--- a/userspace/dpdk/18.05/0009-net-ena-fix-dev-init-with-multi-process.patch
+++ b/userspace/dpdk/18.05/0009-net-ena-fix-dev-init-with-multi-process.patch
@@ -1,7 +1,7 @@
 From f6b50ee14ce8433701ce0e5d356081a509f68782 Mon Sep 17 00:00:00 2001
 From: Michal Krawczyk <mk@semihalf.com>
 Date: Fri, 25 Jan 2019 09:10:25 +0100
-Subject: [PATCH 09/10] net/ena: fix dev init with multi-process
+Subject: [PATCH 09/15] net/ena: fix dev init with multi-process
 
 [ upstream commit fd9768905870856a2340266d25f8c0100dfccfff ]
 
@@ -15,6 +15,7 @@ main process.
 Fixes: 1173fca25af9 ("ena: add polling-mode driver")
 Cc: stable@dpdk.org
 
+Change-Id: Icd37ab0bfc5324a7fbec4248e9e028f54e2026a2
 Signed-off-by: Michal Krawczyk <mk@semihalf.com>
 ---
  drivers/net/ena/ena_ethdev.c | 11 ++++++-----
@@ -51,5 +52,5 @@ index ef6bc4067..6bbfd62c0 100644
  	adapter->pdev = pci_dev;
  
 -- 
-2.14.1
+2.20.1
 

--- a/userspace/dpdk/18.05/0010-net-ena-fix-errno-to-positive-value.patch
+++ b/userspace/dpdk/18.05/0010-net-ena-fix-errno-to-positive-value.patch
@@ -1,7 +1,7 @@
 From 3a207a2ce92ded436d0f25fb26b3b529f22dafdb Mon Sep 17 00:00:00 2001
 From: Michal Krawczyk <mk@semihalf.com>
 Date: Fri, 25 Jan 2019 09:10:26 +0100
-Subject: [PATCH 10/10] net/ena: fix errno to positive value
+Subject: [PATCH 10/15] net/ena: fix errno to positive value
 
 [ upstream commit baeed5f404dd1b049118cfec26a2fd3203671572 ]
 
@@ -11,6 +11,7 @@ to be fixed.
 Fixes: b3fc5a1ae10d ("net/ena: add Tx preparation")
 Cc: stable@dpdk.org
 
+Change-Id: If87b7246991ba450182fb48724b3a46977810602
 Signed-off-by: Michal Krawczyk <mk@semihalf.com>
 ---
  drivers/net/ena/ena_ethdev.c | 6 +++---
@@ -47,5 +48,5 @@ index 6bbfd62c0..d09633912 100644
  		}
  	}
 -- 
-2.14.1
+2.20.1
 

--- a/userspace/dpdk/18.05/0011-net-ena-get-device-info-statically.patch
+++ b/userspace/dpdk/18.05/0011-net-ena-get-device-info-statically.patch
@@ -1,0 +1,123 @@
+From d07a557dce8d3adc5f5b434418473f7ab36e6129 Mon Sep 17 00:00:00 2001
+From: Michal Krawczyk <mk@semihalf.com>
+Date: Fri, 15 Feb 2019 09:36:39 +0100
+Subject: [PATCH 11/15] net/ena: get device info statically
+
+[ upstream commit 117ba4a60488a0f96a5737f38ddba6d0f9a728b6 ]
+
+Whenever the app is calling rte_eth_dev_info_get(), it shouldn't use the
+admin command. It was causing problems, if it was called from the
+secondary process - the main process was crashing, and the secondary app
+wasn't getting any result, as the admin request couldn't be processed by
+the process which was requesting the data.
+
+To fix that, the data is being written to the adapter structure during
+device initialization routine.
+
+Change-Id: I94f61f51223725602f70ac9795acf02b7b014984
+Signed-off-by: Michal Krawczyk <mk@semihalf.com>
+---
+ drivers/net/ena/ena_ethdev.c | 31 ++++++++++++-------------------
+ drivers/net/ena/ena_ethdev.h |  8 +++++++-
+ 2 files changed, 19 insertions(+), 20 deletions(-)
+
+diff --git a/drivers/net/ena/ena_ethdev.c b/drivers/net/ena/ena_ethdev.c
+index d09633912..a4ae53920 100644
+--- a/drivers/net/ena/ena_ethdev.c
++++ b/drivers/net/ena/ena_ethdev.c
+@@ -1381,9 +1381,14 @@ static int eth_ena_dev_init(struct rte_eth_dev *eth_dev)
+ 	/* Set max MTU for this device */
+ 	adapter->max_mtu = get_feat_ctx.dev_attr.max_mtu;
+ 
+-	/* set device support for TSO */
+-	adapter->tso4_supported = get_feat_ctx.offload.tx &
+-				  ENA_ADMIN_FEATURE_OFFLOAD_DESC_TSO_IPV4_MASK;
++	/* set device support for offloads */
++	adapter->offloads.tso4_supported = (get_feat_ctx.offload.tx &
++		ENA_ADMIN_FEATURE_OFFLOAD_DESC_TSO_IPV4_MASK) != 0;
++	adapter->offloads.tx_csum_supported = (get_feat_ctx.offload.tx &
++		ENA_ADMIN_FEATURE_OFFLOAD_DESC_TX_L4_IPV4_CSUM_PART_MASK) != 0;
++	adapter->offloads.tx_csum_supported =
++		(get_feat_ctx.offload.rx_supported &
++		ENA_ADMIN_FEATURE_OFFLOAD_DESC_RX_L4_IPV4_CSUM_MASK) != 0;
+ 
+ 	/* Copy MAC address and point DPDK to it */
+ 	eth_dev->data->mac_addrs = (struct ether_addr *)adapter->mac_addr;
+@@ -1464,9 +1469,7 @@ static void ena_infos_get(struct rte_eth_dev *dev,
+ {
+ 	struct ena_adapter *adapter;
+ 	struct ena_com_dev *ena_dev;
+-	struct ena_com_dev_get_features_ctx feat;
+ 	uint64_t rx_feat = 0, tx_feat = 0;
+-	int rc = 0;
+ 
+ 	ena_assert_msg(dev->data != NULL, "Uninitialized device");
+ 	ena_assert_msg(dev->data->dev_private != NULL, "Uninitialized device");
+@@ -1485,26 +1488,16 @@ static void ena_infos_get(struct rte_eth_dev *dev,
+ 			ETH_LINK_SPEED_50G  |
+ 			ETH_LINK_SPEED_100G;
+ 
+-	/* Get supported features from HW */
+-	rc = ena_com_get_dev_attr_feat(ena_dev, &feat);
+-	if (unlikely(rc)) {
+-		RTE_LOG(ERR, PMD,
+-			"Cannot get attribute for ena device rc= %d\n", rc);
+-		return;
+-	}
+-
+ 	/* Set Tx & Rx features available for device */
+-	if (feat.offload.tx & ENA_ADMIN_FEATURE_OFFLOAD_DESC_TSO_IPV4_MASK)
++	if (adapter->offloads.tso4_supported)
+ 		tx_feat	|= DEV_TX_OFFLOAD_TCP_TSO;
+ 
+-	if (feat.offload.tx &
+-	    ENA_ADMIN_FEATURE_OFFLOAD_DESC_TX_L4_IPV4_CSUM_PART_MASK)
++	if (adapter->offloads.tx_csum_supported)
+ 		tx_feat |= DEV_TX_OFFLOAD_IPV4_CKSUM |
+ 			DEV_TX_OFFLOAD_UDP_CKSUM |
+ 			DEV_TX_OFFLOAD_TCP_CKSUM;
+ 
+-	if (feat.offload.rx_supported &
+-	    ENA_ADMIN_FEATURE_OFFLOAD_DESC_RX_L4_IPV4_CSUM_MASK)
++	if (adapter->offloads.rx_csum_supported)
+ 		rx_feat |= DEV_RX_OFFLOAD_IPV4_CKSUM |
+ 			DEV_RX_OFFLOAD_UDP_CKSUM  |
+ 			DEV_RX_OFFLOAD_TCP_CKSUM;
+@@ -1657,7 +1650,7 @@ eth_ena_prep_pkts(void *tx_queue, struct rte_mbuf **tx_pkts,
+ 			/* If IPv4 header has DF flag enabled and TSO support is
+ 			 * disabled, partial chcecksum should not be calculated.
+ 			 */
+-			if (!tx_ring->adapter->tso4_supported)
++			if (!tx_ring->adapter->offloads.tso4_supported)
+ 				continue;
+ 		}
+ 
+diff --git a/drivers/net/ena/ena_ethdev.h b/drivers/net/ena/ena_ethdev.h
+index 394d05e02..2c98b4092 100644
+--- a/drivers/net/ena/ena_ethdev.h
++++ b/drivers/net/ena/ena_ethdev.h
+@@ -145,6 +145,12 @@ struct ena_stats_rx {
+ 	u64 small_copy_len_pkt;
+ };
+ 
++struct ena_offloads {
++	bool tso4_supported;
++	bool tx_csum_supported;
++	bool rx_csum_supported;
++};
++
+ /* board specific private data structure */
+ struct ena_adapter {
+ 	/* OS defined structs */
+@@ -164,7 +170,7 @@ struct ena_adapter {
+ 
+ 	u16 num_queues;
+ 	u16 max_mtu;
+-	u8 tso4_supported;
++	struct ena_offloads offloads;
+ 
+ 	int id_number;
+ 	char name[ENA_NAME_MAX_LEN];
+-- 
+2.20.1
+

--- a/userspace/dpdk/18.05/0012-net-ena-fix-checksum-feature-flag.patch
+++ b/userspace/dpdk/18.05/0012-net-ena-fix-checksum-feature-flag.patch
@@ -1,0 +1,35 @@
+From 5188eb77f07ac1c3b3542e2812b3a8f15df27c7d Mon Sep 17 00:00:00 2001
+From: Michal Krawczyk <mk@semihalf.com>
+Date: Mon, 8 Apr 2019 12:27:44 +0200
+Subject: [PATCH 12/15] net/ena: fix checksum feature flag
+
+[ upstream commit ef538c1a7f565c9b58518375a500aa864445fd11 ]
+
+The boolean value was assigned to Tx flag twice, so it could cause bug
+whenever Rx checksum will not be supported and Tx will be.
+
+Coverity issue: 336831
+Fixes: 117ba4a60488 ("net/ena: get device info statically")
+
+Change-Id: Id1ca7bb11b566c35ab7c9691593dcab40263c0f7
+Signed-off-by: Michal Krawczyk <mk@semihalf.com>
+---
+ drivers/net/ena/ena_ethdev.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/drivers/net/ena/ena_ethdev.c b/drivers/net/ena/ena_ethdev.c
+index a4ae53920..72aa7c758 100644
+--- a/drivers/net/ena/ena_ethdev.c
++++ b/drivers/net/ena/ena_ethdev.c
+@@ -1386,7 +1386,7 @@ static int eth_ena_dev_init(struct rte_eth_dev *eth_dev)
+ 		ENA_ADMIN_FEATURE_OFFLOAD_DESC_TSO_IPV4_MASK) != 0;
+ 	adapter->offloads.tx_csum_supported = (get_feat_ctx.offload.tx &
+ 		ENA_ADMIN_FEATURE_OFFLOAD_DESC_TX_L4_IPV4_CSUM_PART_MASK) != 0;
+-	adapter->offloads.tx_csum_supported =
++	adapter->offloads.rx_csum_supported =
+ 		(get_feat_ctx.offload.rx_supported &
+ 		ENA_ADMIN_FEATURE_OFFLOAD_DESC_RX_L4_IPV4_CSUM_MASK) != 0;
+ 
+-- 
+2.20.1
+

--- a/userspace/dpdk/18.05/0013-net-ena-fix-Rx-checksum-errors-statistics.patch
+++ b/userspace/dpdk/18.05/0013-net-ena-fix-Rx-checksum-errors-statistics.patch
@@ -1,0 +1,52 @@
+From a7591a5a9ea623198f01adac7e209a0a5e234b89 Mon Sep 17 00:00:00 2001
+From: Michal Krawczyk <mk@semihalf.com>
+Date: Tue, 28 May 2019 10:28:34 +0200
+Subject: [PATCH 13/15] net/ena: fix Rx checksum errors statistics
+
+[ upstream commit ef74b5f7b69b9502ddab81121611243efcfe1dde ]
+
+Rx checksum flags and input errors shouldn't be updated on Tx, as it
+would work only for packets forwarding.
+
+The ierrors statistic should be updated on Rx, right after checking
+Rx checksum flags if the Rx checksum offload is enabled.
+
+Fixes: 1173fca25af9 ("ena: add polling-mode driver")
+Cc: stable@dpdk.org
+
+Change-Id: I4ccf68bcb1ef6b50d01c811fc7f050a3d7ec9966
+Signed-off-by: Michal Krawczyk <mk@semihalf.com>
+---
+ drivers/net/ena/ena_ethdev.c | 9 +++++----
+ 1 file changed, 5 insertions(+), 4 deletions(-)
+
+diff --git a/drivers/net/ena/ena_ethdev.c b/drivers/net/ena/ena_ethdev.c
+index 72aa7c758..758cdfa15 100644
+--- a/drivers/net/ena/ena_ethdev.c
++++ b/drivers/net/ena/ena_ethdev.c
+@@ -1596,6 +1596,11 @@ static uint16_t eth_ena_recv_pkts(void *rx_queue, struct rte_mbuf **rx_pkts,
+ 
+ 		/* fill mbuf attributes if any */
+ 		ena_rx_mbuf_prepare(mbuf_head, &ena_rx_ctx);
++
++		if (unlikely(mbuf_head->ol_flags &
++				(PKT_RX_IP_CKSUM_BAD | PKT_RX_L4_CKSUM_BAD)))
++			rte_atomic64_inc(&rx_ring->adapter->drv_stats->ierrors);
++
+ 		mbuf_head->hash.rss = ena_rx_ctx.hash;
+ 
+ 		/* pass to DPDK application head mbuf */
+@@ -1743,10 +1748,6 @@ static uint16_t eth_ena_xmit_pkts(void *tx_queue, struct rte_mbuf **tx_pkts,
+ 		/* Set TX offloads flags, if applicable */
+ 		ena_tx_mbuf_prepare(mbuf, &ena_tx_ctx, tx_ring->offloads);
+ 
+-		if (unlikely(mbuf->ol_flags &
+-			     (PKT_RX_L4_CKSUM_BAD | PKT_RX_IP_CKSUM_BAD)))
+-			rte_atomic64_inc(&tx_ring->adapter->drv_stats->ierrors);
+-
+ 		rte_prefetch0(tx_pkts[(sent_idx + 4) & ring_mask]);
+ 
+ 		/* Process first segment taking into
+-- 
+2.20.1
+

--- a/userspace/dpdk/18.05/0014-net-ena-fix-assigning-NUMA-node-to-IO-queue.patch
+++ b/userspace/dpdk/18.05/0014-net-ena-fix-assigning-NUMA-node-to-IO-queue.patch
@@ -1,0 +1,127 @@
+From 5c6ad2dc2a94612aaf68ab48f5e945747f0d79eb Mon Sep 17 00:00:00 2001
+From: Michal Krawczyk <mk@semihalf.com>
+Date: Tue, 4 Jun 2019 12:59:36 +0200
+Subject: [PATCH 14/15] net/ena: fix assigning NUMA node to IO queue
+
+[ upstream commit 4217cb0b7d2c5385f06f531af7f14b860927aba7 ]
+
+Previous solution was using memzones in invalid way in hope to assign
+IO queue to the appropriate NUMA zone.
+
+The right way is to use socket_id from the rx/tx queue setup function
+and then pass it to the IO queue.
+
+Fixes: 3d3edc265fc8 ("net/ena: make coherent memory allocation NUMA-aware")
+Cc: stable@dpdk.org
+
+Change-Id: I252df018ca6aae9d566618b6967bec0c5b3d939a
+Signed-off-by: Michal Krawczyk <mk@semihalf.com>
+Reviewed-by: David Marchand <david.marchand@redhat.com>
+---
+ drivers/net/ena/ena_ethdev.c | 27 ++++++---------------------
+ drivers/net/ena/ena_ethdev.h |  2 ++
+ 2 files changed, 8 insertions(+), 21 deletions(-)
+
+diff --git a/drivers/net/ena/ena_ethdev.c b/drivers/net/ena/ena_ethdev.c
+index 758cdfa15..58ce419fd 100644
+--- a/drivers/net/ena/ena_ethdev.c
++++ b/drivers/net/ena/ena_ethdev.c
+@@ -39,7 +39,6 @@
+ #include <rte_dev.h>
+ #include <rte_errno.h>
+ #include <rte_version.h>
+-#include <rte_eal_memconfig.h>
+ #include <rte_net.h>
+ 
+ #include "ena_ethdev.h"
+@@ -255,22 +254,6 @@ static const struct eth_dev_ops ena_dev_ops = {
+ 	.reta_query           = ena_rss_reta_query,
+ };
+ 
+-#define NUMA_NO_NODE	SOCKET_ID_ANY
+-
+-static inline int ena_cpu_to_node(int cpu)
+-{
+-	struct rte_config *config = rte_eal_get_configuration();
+-	struct rte_fbarray *arr = &config->mem_config->memzones;
+-	const struct rte_memzone *mz;
+-
+-	if (unlikely(cpu >= RTE_MAX_MEMZONE))
+-		return NUMA_NO_NODE;
+-
+-	mz = rte_fbarray_get(arr, cpu);
+-
+-	return mz->socket_id;
+-}
+-
+ static inline void ena_rx_mbuf_prepare(struct rte_mbuf *mbuf,
+ 				       struct ena_com_rx_ctx *ena_rx_ctx)
+ {
+@@ -963,7 +946,7 @@ static int ena_queue_restart(struct ena_ring *ring)
+ static int ena_tx_queue_setup(struct rte_eth_dev *dev,
+ 			      uint16_t queue_idx,
+ 			      uint16_t nb_desc,
+-			      __rte_unused unsigned int socket_id,
++			      unsigned int socket_id,
+ 			      const struct rte_eth_txconf *tx_conf)
+ {
+ 	struct ena_com_create_io_ctx ctx =
+@@ -1008,7 +991,7 @@ static int ena_tx_queue_setup(struct rte_eth_dev *dev,
+ 	ctx.msix_vector = -1; /* admin interrupts not used */
+ 	ctx.mem_queue_type = ena_dev->tx_mem_queue_type;
+ 	ctx.queue_size = adapter->tx_ring_size;
+-	ctx.numa_node = ena_cpu_to_node(queue_idx);
++	ctx.numa_node = socket_id;
+ 
+ 	rc = ena_com_create_io_queue(ena_dev, &ctx);
+ 	if (rc) {
+@@ -1034,6 +1017,7 @@ static int ena_tx_queue_setup(struct rte_eth_dev *dev,
+ 	txq->next_to_clean = 0;
+ 	txq->next_to_use = 0;
+ 	txq->ring_size = nb_desc;
++	txq->numa_socket_id = socket_id;
+ 
+ 	txq->tx_buffer_info = rte_zmalloc("txq->tx_buffer_info",
+ 					  sizeof(struct ena_tx_buffer) *
+@@ -1067,7 +1051,7 @@ static int ena_tx_queue_setup(struct rte_eth_dev *dev,
+ static int ena_rx_queue_setup(struct rte_eth_dev *dev,
+ 			      uint16_t queue_idx,
+ 			      uint16_t nb_desc,
+-			      __rte_unused unsigned int socket_id,
++			      unsigned int socket_id,
+ 			      __rte_unused const struct rte_eth_rxconf *rx_conf,
+ 			      struct rte_mempool *mp)
+ {
+@@ -1111,7 +1095,7 @@ static int ena_rx_queue_setup(struct rte_eth_dev *dev,
+ 	ctx.mem_queue_type = ENA_ADMIN_PLACEMENT_POLICY_HOST;
+ 	ctx.msix_vector = -1; /* admin interrupts not used */
+ 	ctx.queue_size = adapter->rx_ring_size;
+-	ctx.numa_node = ena_cpu_to_node(queue_idx);
++	ctx.numa_node = socket_id;
+ 
+ 	rc = ena_com_create_io_queue(ena_dev, &ctx);
+ 	if (rc)
+@@ -1135,6 +1119,7 @@ static int ena_rx_queue_setup(struct rte_eth_dev *dev,
+ 	rxq->next_to_clean = 0;
+ 	rxq->next_to_use = 0;
+ 	rxq->ring_size = nb_desc;
++	rxq->numa_socket_id = socket_id;
+ 	rxq->mb_pool = mp;
+ 
+ 	rxq->rx_buffer_info = rte_zmalloc("rxq->buffer_info",
+diff --git a/drivers/net/ena/ena_ethdev.h b/drivers/net/ena/ena_ethdev.h
+index 2c98b4092..7dd8b2596 100644
+--- a/drivers/net/ena/ena_ethdev.h
++++ b/drivers/net/ena/ena_ethdev.h
+@@ -92,6 +92,8 @@ struct ena_ring {
+ 	int configured;
+ 	struct ena_adapter *adapter;
+ 	uint64_t offloads;
++
++	unsigned int numa_socket_id;
+ } __rte_cache_aligned;
+ 
+ enum ena_adapter_state {
+-- 
+2.20.1
+

--- a/userspace/dpdk/18.05/0015-net-ena-fix-L4-checksum-Tx-offload.patch
+++ b/userspace/dpdk/18.05/0015-net-ena-fix-L4-checksum-Tx-offload.patch
@@ -1,0 +1,52 @@
+From 731eed0e60a4dbfce98b9dc3860f713ac0671b10 Mon Sep 17 00:00:00 2001
+From: Maciej Bielski <mba@semihalf.com>
+Date: Thu, 1 Aug 2019 13:45:36 +0200
+Subject: [PATCH 15/15] net/ena: fix L4 checksum Tx offload
+
+[ upstream commit 40e7c02155625f18a87faf5e6a8cec2e986146e8 ]
+
+During an if-condition evaluation, a 2-bit flag evaluates to 'true' for
+'0x1', '0x2' and '0x3'. Thus, from this perspective these flags are
+indistinguishable. To make them distinct, respective bits must be
+extracted with a mask and then checked for strict equality.
+
+Specifically here, even if `PKT_TX_UDP_CKSUM` (value '0x3') was set, the
+expression `mbuf->ol_flags & PKT_TX_TCP` (the second flag of value
+'0x1') is evaluated first and the result is 'true'. In consequence, for
+UDP packets the execution flow enters an incorrect branch.
+
+Fixes: 56b8b9b7e5d2 ("net/ena: convert to new Tx offloads API")
+Cc: stable@dpdk.org
+
+Change-Id: I7917b209856f24e5d0b6481a94b322d09266bc5b
+Reported-by: Eduard Serra <eserra@vmware.com>
+Signed-off-by: Maciej Bielski <mba@semihalf.com>
+Acked-by: Michal Krawczyk <mk@semihalf.com>
+---
+ drivers/net/ena/ena_ethdev.c | 7 ++++---
+ 1 file changed, 4 insertions(+), 3 deletions(-)
+
+diff --git a/drivers/net/ena/ena_ethdev.c b/drivers/net/ena/ena_ethdev.c
+index 58ce419fd..1ef7809a1 100644
+--- a/drivers/net/ena/ena_ethdev.c
++++ b/drivers/net/ena/ena_ethdev.c
+@@ -313,12 +313,13 @@ static inline void ena_tx_mbuf_prepare(struct rte_mbuf *mbuf,
+ 		}
+ 
+ 		/* check if L4 checksum is needed */
+-		if ((mbuf->ol_flags & PKT_TX_TCP_CKSUM) &&
++		if (((mbuf->ol_flags & PKT_TX_L4_MASK) == PKT_TX_TCP_CKSUM) &&
+ 		    (queue_offloads & DEV_TX_OFFLOAD_TCP_CKSUM)) {
+ 			ena_tx_ctx->l4_proto = ENA_ETH_IO_L4_PROTO_TCP;
+ 			ena_tx_ctx->l4_csum_enable = true;
+-		} else if ((mbuf->ol_flags & PKT_TX_UDP_CKSUM) &&
+-			   (queue_offloads & DEV_TX_OFFLOAD_UDP_CKSUM)) {
++		} else if (((mbuf->ol_flags & PKT_TX_L4_MASK) ==
++				PKT_TX_UDP_CKSUM) &&
++				(queue_offloads & DEV_TX_OFFLOAD_UDP_CKSUM)) {
+ 			ena_tx_ctx->l4_proto = ENA_ETH_IO_L4_PROTO_UDP;
+ 			ena_tx_ctx->l4_csum_enable = true;
+ 		} else {
+-- 
+2.20.1
+

--- a/userspace/dpdk/18.08/0001-net-ena-recreate-HW-IO-rings-on-start-and-stop.patch
+++ b/userspace/dpdk/18.08/0001-net-ena-recreate-HW-IO-rings-on-start-and-stop.patch
@@ -1,7 +1,7 @@
 From 126e0497aa41ff7b6fb6f2569626e6fed44bfe78 Mon Sep 17 00:00:00 2001
 From: Michal Krawczyk <mk@semihalf.com>
 Date: Thu, 25 Oct 2018 19:59:21 +0200
-Subject: [PATCH 01/14] net/ena: recreate HW IO rings on start and stop
+Subject: [PATCH 01/19] net/ena: recreate HW IO rings on start and stop
 
 [ upstream commit df238f84c0a21d642bb9517d0c75ba831eeceb46 ]
 
@@ -18,9 +18,10 @@ created on start and not destroyed on stop.
 Fixes: eb0ef49dd5d5 ("net/ena: add stop and uninit routines")
 Cc: stable@dpdk.org
 
+Change-Id: I12bd19b6246b49acba56c3c6e463e88187cecd1f
 Signed-off-by: Michal Krawczyk <mk@semihalf.com>
 ---
- drivers/net/ena/ena_ethdev.c | 196 ++++++++++++++++++++-----------------------
+ drivers/net/ena/ena_ethdev.c | 196 ++++++++++++++++-------------------
  1 file changed, 91 insertions(+), 105 deletions(-)
 
 diff --git a/drivers/net/ena/ena_ethdev.c b/drivers/net/ena/ena_ethdev.c
@@ -359,5 +360,5 @@ index c255dc6db..de5d2edc2 100644
  
  static int ena_populate_rx_queue(struct ena_ring *rxq, unsigned int count)
 -- 
-2.14.1
+2.20.1
 

--- a/userspace/dpdk/18.08/0002-net-ena-fix-passing-RSS-hash-to-mbuf.patch
+++ b/userspace/dpdk/18.08/0002-net-ena-fix-passing-RSS-hash-to-mbuf.patch
@@ -1,7 +1,7 @@
 From 8e68880600b5ac56dc55850d5f9b9db03823e668 Mon Sep 17 00:00:00 2001
 From: Stewart Allen <allenste@amazon.com>
 Date: Thu, 25 Oct 2018 19:59:22 +0200
-Subject: [PATCH 02/14] net/ena: fix passing RSS hash to mbuf
+Subject: [PATCH 02/19] net/ena: fix passing RSS hash to mbuf
 
 [ upstream commit e5df9f33db00eb9d322abaefff30da74fd0e625d ]
 
@@ -11,6 +11,7 @@ from the device. Now, the RSS hash from the Rx descriptor is being set.
 Fixes: 1173fca25af9 ("ena: add polling-mode driver")
 Cc: stable@dpdk.org
 
+Change-Id: I3ecaf5b74eabdbb92ac92ef342836d74970fb793
 Signed-off-by: Stewart Allen <allenste@amazon.com>
 Acked-by: Michal Krawczyk <mk@semihalf.com>
 ---
@@ -31,5 +32,5 @@ index de5d2edc2..acb1a08e0 100644
  		/* pass to DPDK application head mbuf */
  		rx_pkts[recv_idx] = mbuf_head;
 -- 
-2.14.1
+2.20.1
 

--- a/userspace/dpdk/18.08/0003-net-ena-fix-cleaning-HW-IO-rings-configuration.patch
+++ b/userspace/dpdk/18.08/0003-net-ena-fix-cleaning-HW-IO-rings-configuration.patch
@@ -1,7 +1,7 @@
 From 79f7b061bfc354f660d4db0173bec4d47e6c43dd Mon Sep 17 00:00:00 2001
 From: Rafal Kozik <rk@semihalf.com>
 Date: Wed, 14 Nov 2018 10:59:45 +0100
-Subject: [PATCH 03/14] net/ena: fix cleaning HW IO rings configuration
+Subject: [PATCH 03/19] net/ena: fix cleaning HW IO rings configuration
 
 [ upstream commit 778677dcb20cf29d966f239972b043f0640f55ef ]
 
@@ -11,6 +11,7 @@ During start initialize array of empty Tx/Rx reqs with default values.
 Fixes: df238f84c0a2 ("net/ena: recreate HW IO rings on start and stop")
 Cc: stable@dpdk.org
 
+Change-Id: I9ac17d21e03957abc03291b13c795cb15168174d
 Signed-off-by: Rafal Kozik <rk@semihalf.com>
 Acked-by: Michal Krawczyk <mk@semihalf.com>
 ---
@@ -54,5 +55,5 @@ index acb1a08e0..9e462099f 100644
  
  	for (i = 0; i < nb_rxq; ++i) {
 -- 
-2.14.1
+2.20.1
 

--- a/userspace/dpdk/18.08/0004-net-ena-fix-out-of-order-completion.patch
+++ b/userspace/dpdk/18.08/0004-net-ena-fix-out-of-order-completion.patch
@@ -1,7 +1,7 @@
 From 53253faf9e1064d1571eed8d95d3be1cc47cbff9 Mon Sep 17 00:00:00 2001
 From: Rafal Kozik <rk@semihalf.com>
 Date: Wed, 21 Nov 2018 09:21:14 +0100
-Subject: [PATCH 04/14] net/ena: fix out of order completion
+Subject: [PATCH 04/19] net/ena: fix out of order completion
 
 [ upstream commit 79405ee175857cfdbb508f9d55e2a51d95483be6 ]
 
@@ -16,10 +16,11 @@ In case of error unused mbufs are put back to pool.
 Fixes: c2034976673d ("net/ena: add Rx out of order completion")
 Cc: stable@dpdk.org
 
+Change-Id: I68dece48189852fd0b068174adde03602ca1ec94
 Signed-off-by: Rafal Kozik <rk@semihalf.com>
 Acked-by: Michal Krawczyk <mk@semihalf.com>
 ---
- drivers/net/ena/ena_ethdev.c | 40 ++++++++++++++++++++++++++++------------
+ drivers/net/ena/ena_ethdev.c | 40 +++++++++++++++++++++++++-----------
  drivers/net/ena/ena_ethdev.h |  1 +
  2 files changed, 29 insertions(+), 12 deletions(-)
 
@@ -145,5 +146,5 @@ index 2dc8129e0..322e90ace 100644
  
  	struct ena_com_io_cq *ena_com_io_cq;
 -- 
-2.14.1
+2.20.1
 

--- a/userspace/dpdk/18.08/0005-net-ena-add-reset-reason-in-Rx-error.patch
+++ b/userspace/dpdk/18.08/0005-net-ena-add-reset-reason-in-Rx-error.patch
@@ -1,7 +1,7 @@
 From 9b101ebef9993996594c00756ef6c0e2817e3037 Mon Sep 17 00:00:00 2001
 From: Rafal Kozik <rk@semihalf.com>
 Date: Fri, 14 Dec 2018 14:18:29 +0100
-Subject: [PATCH 05/14] net/ena: add reset reason in Rx error
+Subject: [PATCH 05/19] net/ena: add reset reason in Rx error
 
 [ upstream commit 9b260dbf7412819f9a5fc544872b1447d6938afe ]
 
@@ -12,6 +12,7 @@ ENA_REGS_RESET_TOO_MANY_RX_DESCS.
 Fixes: 241da076b1f7 ("net/ena: adjust error checking and cleaning")
 Cc: stable@dpdk.org
 
+Change-Id: I45b4627f3cfd9cb080e989c8a7a9edd41cb9ec44
 Signed-off-by: Rafal Kozik <rk@semihalf.com>
 Acked-by: Michal Krawczyk <mk@semihalf.com>
 ---
@@ -32,5 +33,5 @@ index 87c95b2e7..b74276d98 100644
  			return 0;
  		}
 -- 
-2.14.1
+2.20.1
 

--- a/userspace/dpdk/18.08/0006-net-ena-skip-packet-with-wrong-request-id.patch
+++ b/userspace/dpdk/18.08/0006-net-ena-skip-packet-with-wrong-request-id.patch
@@ -1,7 +1,7 @@
 From 9056e84fe8cea67e116be9663a56586b16bf96c4 Mon Sep 17 00:00:00 2001
 From: Rafal Kozik <rk@semihalf.com>
 Date: Fri, 14 Dec 2018 14:18:31 +0100
-Subject: [PATCH 06/14] net/ena: skip packet with wrong request id
+Subject: [PATCH 06/19] net/ena: skip packet with wrong request id
 
 [ upstream commit f00930d929151fc09914e6d61b827f9f81645324 ]
 
@@ -12,6 +12,7 @@ is not making any sense.
 Fixes: c2034976673d ("net/ena: add Rx out of order completion")
 Cc: stable@dpdk.org
 
+Change-Id: I1738e5749e3003fe81bd1564ad5444b0b0aeee80
 Signed-off-by: Rafal Kozik <rk@semihalf.com>
 Acked-by: Michal Krawczyk <mk@semihalf.com>
 ---
@@ -32,5 +33,5 @@ index b74276d98..f050dea82 100644
  		/* fill mbuf attributes if any */
  		ena_rx_mbuf_prepare(mbuf_head, &ena_rx_ctx);
 -- 
-2.14.1
+2.20.1
 

--- a/userspace/dpdk/18.08/0007-net-ena-do-not-reconfigure-queues-on-reset.patch
+++ b/userspace/dpdk/18.08/0007-net-ena-do-not-reconfigure-queues-on-reset.patch
@@ -1,7 +1,7 @@
 From 348d89e8be808017512a318b64108552b97a5fa8 Mon Sep 17 00:00:00 2001
 From: Rafal Kozik <rk@semihalf.com>
 Date: Fri, 14 Dec 2018 14:18:36 +0100
-Subject: [PATCH 07/14] net/ena: do not reconfigure queues on reset
+Subject: [PATCH 07/19] net/ena: do not reconfigure queues on reset
 
 [ upstream commit e457bc70e5d6d589b1c3e1e93979aa42a64fbc06 ]
 
@@ -18,10 +18,11 @@ during stop.
 Fixes: 2081d5e2e92d ("net/ena: add reset routine")
 Cc: stable@dpdk.org
 
+Change-Id: I50ca54aad44d8c1f4d8659f965b8564e8dcabea6
 Signed-off-by: Rafal Kozik <rk@semihalf.com>
 Acked-by: Michal Krawczyk <mk@semihalf.com>
 ---
- drivers/net/ena/ena_ethdev.c | 119 +++++++++++++++++--------------------------
+ drivers/net/ena/ena_ethdev.c | 119 ++++++++++++++---------------------
  1 file changed, 46 insertions(+), 73 deletions(-)
 
 diff --git a/drivers/net/ena/ena_ethdev.c b/drivers/net/ena/ena_ethdev.c
@@ -216,5 +217,5 @@ index f050dea82..383028318 100644
  	return 0;
  }
 -- 
-2.14.1
+2.20.1
 

--- a/userspace/dpdk/18.08/0008-net-ena-add-supported-RSS-offloads-types.patch
+++ b/userspace/dpdk/18.08/0008-net-ena-add-supported-RSS-offloads-types.patch
@@ -1,7 +1,7 @@
 From eec4b9335239bbb7468314bbc2e4f7e96ef66795 Mon Sep 17 00:00:00 2001
 From: Rafal Kozik <rk@semihalf.com>
 Date: Fri, 14 Dec 2018 14:18:38 +0100
-Subject: [PATCH 08/14] net/ena: add supported RSS offloads types
+Subject: [PATCH 08/19] net/ena: add supported RSS offloads types
 
 [ upstream commit b01ead202beb45346d7daeb2f2b1a608006af644 ]
 
@@ -12,6 +12,7 @@ missing information was added.
 Fixes: 1173fca25af9 ("ena: add polling-mode driver")
 Cc: stable@dpdk.org
 
+Change-Id: I286197a12e40a1c73779c40dc0acadac1fa15ff3
 Signed-off-by: Rafal Kozik <rk@semihalf.com>
 Acked-by: Michal Krawczyk <mk@semihalf.com>
 ---
@@ -33,5 +34,5 @@ index 383028318..9cab09b57 100644
  	dev_info->max_rx_pktlen  = adapter->max_mtu;
  	dev_info->max_mac_addrs = 1;
 -- 
-2.14.1
+2.20.1
 

--- a/userspace/dpdk/18.08/0009-net-ena-fix-invalid-reference-to-variable-in-union.patch
+++ b/userspace/dpdk/18.08/0009-net-ena-fix-invalid-reference-to-variable-in-union.patch
@@ -1,7 +1,7 @@
 From a1aa40a4e7d291f9cb389dc5ca3988ce2c30b92b Mon Sep 17 00:00:00 2001
 From: Rafal Kozik <rk@semihalf.com>
 Date: Fri, 14 Dec 2018 14:18:39 +0100
-Subject: [PATCH 09/14] net/ena: fix invalid reference to variable in union
+Subject: [PATCH 09/19] net/ena: fix invalid reference to variable in union
 
 [ upstream commit eccbe2ffdc755a9e759c6ba480f6c15ccb1163c7 ]
 
@@ -12,6 +12,7 @@ any failure, but for consistency should be changed.
 Fixes: c2034976673d ("net/ena: add Rx out of order completion")
 Cc: stable@dpdk.org
 
+Change-Id: Ica129f31dfe6cec83f5ef9efd06e64f837a222a7
 Signed-off-by: Rafal Kozik <rk@semihalf.com>
 Acked-by: Michal Krawczyk <mk@semihalf.com>
 ---
@@ -32,5 +33,5 @@ index 9cab09b57..59375dd2f 100644
  	/* Store pointer to this queue in upper layer */
  	rxq->configured = 1;
 -- 
-2.14.1
+2.20.1
 

--- a/userspace/dpdk/18.08/0010-net-ena-fix-cleanup-for-out-of-order-packets.patch
+++ b/userspace/dpdk/18.08/0010-net-ena-fix-cleanup-for-out-of-order-packets.patch
@@ -1,7 +1,7 @@
 From 96a79e7e9e8904fb742ab223cfae0ad6a695cec7 Mon Sep 17 00:00:00 2001
 From: Rafal Kozik <rk@semihalf.com>
 Date: Mon, 17 Dec 2018 12:06:18 +0100
-Subject: [PATCH 10/14] net/ena: fix cleanup for out of order packets
+Subject: [PATCH 10/19] net/ena: fix cleanup for out of order packets
 
 [ upstream commit 709b1dcb73adebb3fc1a838b57d72028feb97e47 ]
 
@@ -19,6 +19,7 @@ are not used updating of next_to_clean pointer is not necessary.
 Fixes: c2034976673d ("net/ena: add Rx out of order completion")
 Cc: stable@dpdk.org
 
+Change-Id: I2f7190170dd958415aa84968de4901fde7b42b87
 Signed-off-by: Rafal Kozik <rk@semihalf.com>
 Acked-by: Michal Krawczyk <mk@semihalf.com>
 ---
@@ -79,5 +80,5 @@ index 59375dd2f..96880aa87 100644
  			mbuf->data_off = RTE_PKTMBUF_HEADROOM;
  			mbuf->refcnt = 1;
 -- 
-2.14.1
+2.20.1
 

--- a/userspace/dpdk/18.08/0011-net-ena-add-new-way-of-getting-Rx-drops.patch
+++ b/userspace/dpdk/18.08/0011-net-ena-add-new-way-of-getting-Rx-drops.patch
@@ -1,13 +1,14 @@
 From ea9b91a8a853dd97380de080f878c034e16240ec Mon Sep 17 00:00:00 2001
 From: Rafal Kozik <rk@semihalf.com>
 Date: Fri, 14 Dec 2018 14:18:43 +0100
-Subject: [PATCH 11/14] net/ena: add new way of getting Rx drops
+Subject: [PATCH 11/19] net/ena: add new way of getting Rx drops
 
 [ upstream commit 94c3e3765d9e0366acf145668d32d5eee3200c2b ]
 
 The Rx drops cannot be acquired using the older API. Now, it must be
 read in keep alive message.
 
+Change-Id: I9a9740a001e79121681f244900d8c445fb73d5ff
 Signed-off-by: Rafal Kozik <rk@semihalf.com>
 Acked-by: Michal Krawczyk <mk@semihalf.com>
 ---
@@ -67,5 +68,5 @@ index 322e90ace..8eb8543c2 100644
  
  struct ena_stats_dev {
 -- 
-2.14.1
+2.20.1
 

--- a/userspace/dpdk/18.08/0012-net-ena-update-completion-queue-after-cleanup.patch
+++ b/userspace/dpdk/18.08/0012-net-ena-update-completion-queue-after-cleanup.patch
@@ -1,7 +1,7 @@
 From 28a3fd0a5fd89a61c5992c2acc7626b844f5a60d Mon Sep 17 00:00:00 2001
 From: Rafal Kozik <rk@semihalf.com>
 Date: Fri, 14 Dec 2018 14:18:44 +0100
-Subject: [PATCH 12/14] net/ena: update completion queue after cleanup
+Subject: [PATCH 12/19] net/ena: update completion queue after cleanup
 
 [ upstream commit a45462c507e98b49cb5c2302e0be3c72d2e20a1a ]
 
@@ -11,6 +11,7 @@ ena_com_update_dev_comp_head().
 Fixes: 1daff5260ff8 ("net/ena: use unmasked head and tail")
 Cc: stable@dpdk.org
 
+Change-Id: I86e07cdaedbeefc581aed75137d06b9259a5190a
 Signed-off-by: Rafal Kozik <rk@semihalf.com>
 Acked-by: Michal Krawczyk <mk@semihalf.com>
 ---
@@ -45,5 +46,5 @@ index ee7605a3b..813e95e95 100644
  
  	return sent_idx;
 -- 
-2.14.1
+2.20.1
 

--- a/userspace/dpdk/18.08/0013-net-ena-fix-dev-init-with-multi-process.patch
+++ b/userspace/dpdk/18.08/0013-net-ena-fix-dev-init-with-multi-process.patch
@@ -1,7 +1,7 @@
 From 1278928ed5362188fa9003da082dfa97aa5b5678 Mon Sep 17 00:00:00 2001
 From: Michal Krawczyk <mk@semihalf.com>
 Date: Fri, 25 Jan 2019 09:10:25 +0100
-Subject: [PATCH 13/14] net/ena: fix dev init with multi-process
+Subject: [PATCH 13/19] net/ena: fix dev init with multi-process
 
 [ upstream commit fd9768905870856a2340266d25f8c0100dfccfff ]
 
@@ -15,6 +15,7 @@ main process.
 Fixes: 1173fca25af9 ("ena: add polling-mode driver")
 Cc: stable@dpdk.org
 
+Change-Id: Iff9f6ffbaec9dc55408788f62a43d690534048ed
 Signed-off-by: Michal Krawczyk <mk@semihalf.com>
 ---
  drivers/net/ena/ena_ethdev.c | 11 ++++++-----
@@ -51,5 +52,5 @@ index 813e95e95..a96ec6975 100644
  	adapter->pdev = pci_dev;
  
 -- 
-2.14.1
+2.20.1
 

--- a/userspace/dpdk/18.08/0014-net-ena-fix-errno-to-positive-value.patch
+++ b/userspace/dpdk/18.08/0014-net-ena-fix-errno-to-positive-value.patch
@@ -1,7 +1,7 @@
 From a453fb83d52bdcd1e74bfbcccf9185c9f3d4ca36 Mon Sep 17 00:00:00 2001
 From: Michal Krawczyk <mk@semihalf.com>
 Date: Fri, 25 Jan 2019 09:10:26 +0100
-Subject: [PATCH 14/14] net/ena: fix errno to positive value
+Subject: [PATCH 14/19] net/ena: fix errno to positive value
 
 [ upstream commit baeed5f404dd1b049118cfec26a2fd3203671572 ]
 
@@ -11,6 +11,7 @@ to be fixed.
 Fixes: b3fc5a1ae10d ("net/ena: add Tx preparation")
 Cc: stable@dpdk.org
 
+Change-Id: I976ecf0058ce98fdb63cb843d6b5f026ea004835
 Signed-off-by: Michal Krawczyk <mk@semihalf.com>
 ---
  drivers/net/ena/ena_ethdev.c | 6 +++---
@@ -47,5 +48,5 @@ index a96ec6975..26316fa75 100644
  		}
  	}
 -- 
-2.14.1
+2.20.1
 

--- a/userspace/dpdk/18.08/0015-net-ena-get-device-info-statically.patch
+++ b/userspace/dpdk/18.08/0015-net-ena-get-device-info-statically.patch
@@ -1,0 +1,135 @@
+From 2b83153af74ba5661c3b65164a48d14aa043b01c Mon Sep 17 00:00:00 2001
+From: Michal Krawczyk <mk@semihalf.com>
+Date: Fri, 15 Feb 2019 09:36:39 +0100
+Subject: [PATCH 15/19] net/ena: get device info statically
+
+[ upstream commit 117ba4a60488a0f96a5737f38ddba6d0f9a728b6 ]
+
+Whenever the app is calling rte_eth_dev_info_get(), it shouldn't use the
+admin command. It was causing problems, if it was called from the
+secondary process - the main process was crashing, and the secondary app
+wasn't getting any result, as the admin request couldn't be processed by
+the process which was requesting the data.
+
+To fix that, the data is being written to the adapter structure during
+device initialization routine.
+
+Change-Id: I94f61f51223725602f70ac9795acf02b7b014984
+Signed-off-by: Michal Krawczyk <mk@semihalf.com>
+---
+ drivers/net/ena/ena_ethdev.c | 35 ++++++++++++++---------------------
+ drivers/net/ena/ena_ethdev.h |  8 +++++++-
+ 2 files changed, 21 insertions(+), 22 deletions(-)
+
+diff --git a/drivers/net/ena/ena_ethdev.c b/drivers/net/ena/ena_ethdev.c
+index 26316fa75..05624cc64 100644
+--- a/drivers/net/ena/ena_ethdev.c
++++ b/drivers/net/ena/ena_ethdev.c
+@@ -1604,9 +1604,14 @@ static int eth_ena_dev_init(struct rte_eth_dev *eth_dev)
+ 	/* Set max MTU for this device */
+ 	adapter->max_mtu = get_feat_ctx.dev_attr.max_mtu;
+ 
+-	/* set device support for TSO */
+-	adapter->tso4_supported = get_feat_ctx.offload.tx &
+-				  ENA_ADMIN_FEATURE_OFFLOAD_DESC_TSO_IPV4_MASK;
++	/* set device support for offloads */
++	adapter->offloads.tso4_supported = (get_feat_ctx.offload.tx &
++		ENA_ADMIN_FEATURE_OFFLOAD_DESC_TSO_IPV4_MASK) != 0;
++	adapter->offloads.tx_csum_supported = (get_feat_ctx.offload.tx &
++		ENA_ADMIN_FEATURE_OFFLOAD_DESC_TX_L4_IPV4_CSUM_PART_MASK) != 0;
++	adapter->offloads.tx_csum_supported =
++		(get_feat_ctx.offload.rx_supported &
++		ENA_ADMIN_FEATURE_OFFLOAD_DESC_RX_L4_IPV4_CSUM_MASK) != 0;
+ 
+ 	/* Copy MAC address and point DPDK to it */
+ 	eth_dev->data->mac_addrs = (struct ether_addr *)adapter->mac_addr;
+@@ -1746,9 +1751,7 @@ static void ena_infos_get(struct rte_eth_dev *dev,
+ {
+ 	struct ena_adapter *adapter;
+ 	struct ena_com_dev *ena_dev;
+-	struct ena_com_dev_get_features_ctx feat;
+ 	uint64_t rx_feat = 0, tx_feat = 0;
+-	int rc = 0;
+ 
+ 	ena_assert_msg(dev->data != NULL, "Uninitialized device");
+ 	ena_assert_msg(dev->data->dev_private != NULL, "Uninitialized device");
+@@ -1767,26 +1770,16 @@ static void ena_infos_get(struct rte_eth_dev *dev,
+ 			ETH_LINK_SPEED_50G  |
+ 			ETH_LINK_SPEED_100G;
+ 
+-	/* Get supported features from HW */
+-	rc = ena_com_get_dev_attr_feat(ena_dev, &feat);
+-	if (unlikely(rc)) {
+-		RTE_LOG(ERR, PMD,
+-			"Cannot get attribute for ena device rc= %d\n", rc);
+-		return;
+-	}
+-
+ 	/* Set Tx & Rx features available for device */
+-	if (feat.offload.tx & ENA_ADMIN_FEATURE_OFFLOAD_DESC_TSO_IPV4_MASK)
++	if (adapter->offloads.tso4_supported)
+ 		tx_feat	|= DEV_TX_OFFLOAD_TCP_TSO;
+ 
+-	if (feat.offload.tx &
+-	    ENA_ADMIN_FEATURE_OFFLOAD_DESC_TX_L4_IPV4_CSUM_PART_MASK)
++	if (adapter->offloads.tx_csum_supported)
+ 		tx_feat |= DEV_TX_OFFLOAD_IPV4_CKSUM |
+ 			DEV_TX_OFFLOAD_UDP_CKSUM |
+ 			DEV_TX_OFFLOAD_TCP_CKSUM;
+ 
+-	if (feat.offload.rx_supported &
+-	    ENA_ADMIN_FEATURE_OFFLOAD_DESC_RX_L4_IPV4_CSUM_MASK)
++	if (adapter->offloads.rx_csum_supported)
+ 		rx_feat |= DEV_RX_OFFLOAD_IPV4_CKSUM |
+ 			DEV_RX_OFFLOAD_UDP_CKSUM  |
+ 			DEV_RX_OFFLOAD_TCP_CKSUM;
+@@ -1819,9 +1812,9 @@ static void ena_infos_get(struct rte_eth_dev *dev,
+ 	dev_info->tx_desc_lim.nb_max = ENA_MAX_RING_DESC;
+ 	dev_info->tx_desc_lim.nb_min = ENA_MIN_RING_DESC;
+ 	dev_info->tx_desc_lim.nb_seg_max = RTE_MIN(ENA_PKT_MAX_BUFS,
+-					feat.max_queues.max_packet_tx_descs);
++		adapter->max_tx_sgl_size);
+ 	dev_info->tx_desc_lim.nb_mtu_seg_max = RTE_MIN(ENA_PKT_MAX_BUFS,
+-					feat.max_queues.max_packet_tx_descs);
++		adapter->max_tx_sgl_size);
+ }
+ 
+ static uint16_t eth_ena_recv_pkts(void *rx_queue, struct rte_mbuf **rx_pkts,
+@@ -1966,7 +1959,7 @@ eth_ena_prep_pkts(void *tx_queue, struct rte_mbuf **tx_pkts,
+ 			/* If IPv4 header has DF flag enabled and TSO support is
+ 			 * disabled, partial chcecksum should not be calculated.
+ 			 */
+-			if (!tx_ring->adapter->tso4_supported)
++			if (!tx_ring->adapter->offloads.tso4_supported)
+ 				continue;
+ 		}
+ 
+diff --git a/drivers/net/ena/ena_ethdev.h b/drivers/net/ena/ena_ethdev.h
+index 8eb8543c2..982ad7854 100644
+--- a/drivers/net/ena/ena_ethdev.h
++++ b/drivers/net/ena/ena_ethdev.h
+@@ -160,6 +160,12 @@ struct ena_stats_rx {
+ 	u64 small_copy_len_pkt;
+ };
+ 
++struct ena_offloads {
++	bool tso4_supported;
++	bool tx_csum_supported;
++	bool rx_csum_supported;
++};
++
+ /* board specific private data structure */
+ struct ena_adapter {
+ 	/* OS defined structs */
+@@ -180,7 +186,7 @@ struct ena_adapter {
+ 
+ 	u16 num_queues;
+ 	u16 max_mtu;
+-	u8 tso4_supported;
++	struct ena_offloads offloads;
+ 
+ 	int id_number;
+ 	char name[ENA_NAME_MAX_LEN];
+-- 
+2.20.1
+

--- a/userspace/dpdk/18.08/0016-net-ena-fix-checksum-feature-flag.patch
+++ b/userspace/dpdk/18.08/0016-net-ena-fix-checksum-feature-flag.patch
@@ -1,0 +1,35 @@
+From fdeb1ff02b47b10bfc9b11f8fa1b2dd12ee59af5 Mon Sep 17 00:00:00 2001
+From: Michal Krawczyk <mk@semihalf.com>
+Date: Mon, 8 Apr 2019 12:27:44 +0200
+Subject: [PATCH 16/19] net/ena: fix checksum feature flag
+
+[ upstream commit ef538c1a7f565c9b58518375a500aa864445fd11 ]
+
+The boolean value was assigned to Tx flag twice, so it could cause bug
+whenever Rx checksum will not be supported and Tx will be.
+
+Coverity issue: 336831
+Fixes: 117ba4a60488 ("net/ena: get device info statically")
+
+Change-Id: Id1ca7bb11b566c35ab7c9691593dcab40263c0f7
+Signed-off-by: Michal Krawczyk <mk@semihalf.com>
+---
+ drivers/net/ena/ena_ethdev.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/drivers/net/ena/ena_ethdev.c b/drivers/net/ena/ena_ethdev.c
+index 05624cc64..65596db92 100644
+--- a/drivers/net/ena/ena_ethdev.c
++++ b/drivers/net/ena/ena_ethdev.c
+@@ -1609,7 +1609,7 @@ static int eth_ena_dev_init(struct rte_eth_dev *eth_dev)
+ 		ENA_ADMIN_FEATURE_OFFLOAD_DESC_TSO_IPV4_MASK) != 0;
+ 	adapter->offloads.tx_csum_supported = (get_feat_ctx.offload.tx &
+ 		ENA_ADMIN_FEATURE_OFFLOAD_DESC_TX_L4_IPV4_CSUM_PART_MASK) != 0;
+-	adapter->offloads.tx_csum_supported =
++	adapter->offloads.rx_csum_supported =
+ 		(get_feat_ctx.offload.rx_supported &
+ 		ENA_ADMIN_FEATURE_OFFLOAD_DESC_RX_L4_IPV4_CSUM_MASK) != 0;
+ 
+-- 
+2.20.1
+

--- a/userspace/dpdk/18.08/0017-net-ena-fix-Rx-checksum-errors-statistics.patch
+++ b/userspace/dpdk/18.08/0017-net-ena-fix-Rx-checksum-errors-statistics.patch
@@ -1,0 +1,52 @@
+From 5fb459c3a479ce3afcfe8215ae903afa0c9fd0e9 Mon Sep 17 00:00:00 2001
+From: Michal Krawczyk <mk@semihalf.com>
+Date: Tue, 28 May 2019 10:28:34 +0200
+Subject: [PATCH 17/19] net/ena: fix Rx checksum errors statistics
+
+[ upstream commit ef74b5f7b69b9502ddab81121611243efcfe1dde ]
+
+Rx checksum flags and input errors shouldn't be updated on Tx, as it
+would work only for packets forwarding.
+
+The ierrors statistic should be updated on Rx, right after checking
+Rx checksum flags if the Rx checksum offload is enabled.
+
+Fixes: 1173fca25af9 ("ena: add polling-mode driver")
+Cc: stable@dpdk.org
+
+Change-Id: I4ccf68bcb1ef6b50d01c811fc7f050a3d7ec9966
+Signed-off-by: Michal Krawczyk <mk@semihalf.com>
+---
+ drivers/net/ena/ena_ethdev.c | 9 +++++----
+ 1 file changed, 5 insertions(+), 4 deletions(-)
+
+diff --git a/drivers/net/ena/ena_ethdev.c b/drivers/net/ena/ena_ethdev.c
+index 65596db92..c03ce3ab3 100644
+--- a/drivers/net/ena/ena_ethdev.c
++++ b/drivers/net/ena/ena_ethdev.c
+@@ -1905,6 +1905,11 @@ static uint16_t eth_ena_recv_pkts(void *rx_queue, struct rte_mbuf **rx_pkts,
+ 
+ 		/* fill mbuf attributes if any */
+ 		ena_rx_mbuf_prepare(mbuf_head, &ena_rx_ctx);
++
++		if (unlikely(mbuf_head->ol_flags &
++				(PKT_RX_IP_CKSUM_BAD | PKT_RX_L4_CKSUM_BAD)))
++			rte_atomic64_inc(&rx_ring->adapter->drv_stats->ierrors);
++
+ 		mbuf_head->hash.rss = ena_rx_ctx.hash;
+ 
+ 		/* pass to DPDK application head mbuf */
+@@ -2096,10 +2101,6 @@ static uint16_t eth_ena_xmit_pkts(void *tx_queue, struct rte_mbuf **tx_pkts,
+ 		/* Set TX offloads flags, if applicable */
+ 		ena_tx_mbuf_prepare(mbuf, &ena_tx_ctx, tx_ring->offloads);
+ 
+-		if (unlikely(mbuf->ol_flags &
+-			     (PKT_RX_L4_CKSUM_BAD | PKT_RX_IP_CKSUM_BAD)))
+-			rte_atomic64_inc(&tx_ring->adapter->drv_stats->ierrors);
+-
+ 		rte_prefetch0(tx_pkts[(sent_idx + 4) & ring_mask]);
+ 
+ 		/* Process first segment taking into
+-- 
+2.20.1
+

--- a/userspace/dpdk/18.08/0018-net-ena-fix-assigning-NUMA-node-to-IO-queue.patch
+++ b/userspace/dpdk/18.08/0018-net-ena-fix-assigning-NUMA-node-to-IO-queue.patch
@@ -1,0 +1,118 @@
+From c1ab86b1dca90567b768291644149e2f06c94bae Mon Sep 17 00:00:00 2001
+From: Michal Krawczyk <mk@semihalf.com>
+Date: Tue, 4 Jun 2019 12:59:36 +0200
+Subject: [PATCH 18/19] net/ena: fix assigning NUMA node to IO queue
+
+[ upstream commit 4217cb0b7d2c5385f06f531af7f14b860927aba7 ]
+
+Previous solution was using memzones in invalid way in hope to assign
+IO queue to the appropriate NUMA zone.
+
+The right way is to use socket_id from the rx/tx queue setup function
+and then pass it to the IO queue.
+
+Fixes: 3d3edc265fc8 ("net/ena: make coherent memory allocation NUMA-aware")
+Cc: stable@dpdk.org
+
+Change-Id: I252df018ca6aae9d566618b6967bec0c5b3d939a
+Signed-off-by: Michal Krawczyk <mk@semihalf.com>
+Reviewed-by: David Marchand <david.marchand@redhat.com>
+---
+ drivers/net/ena/ena_ethdev.c | 25 +++++--------------------
+ drivers/net/ena/ena_ethdev.h |  2 ++
+ 2 files changed, 7 insertions(+), 20 deletions(-)
+
+diff --git a/drivers/net/ena/ena_ethdev.c b/drivers/net/ena/ena_ethdev.c
+index c03ce3ab3..f25e5ba82 100644
+--- a/drivers/net/ena/ena_ethdev.c
++++ b/drivers/net/ena/ena_ethdev.c
+@@ -39,7 +39,6 @@
+ #include <rte_dev.h>
+ #include <rte_errno.h>
+ #include <rte_version.h>
+-#include <rte_eal_memconfig.h>
+ #include <rte_net.h>
+ 
+ #include "ena_ethdev.h"
+@@ -277,22 +276,6 @@ static const struct eth_dev_ops ena_dev_ops = {
+ 	.reta_query           = ena_rss_reta_query,
+ };
+ 
+-#define NUMA_NO_NODE	SOCKET_ID_ANY
+-
+-static inline int ena_cpu_to_node(int cpu)
+-{
+-	struct rte_config *config = rte_eal_get_configuration();
+-	struct rte_fbarray *arr = &config->mem_config->memzones;
+-	const struct rte_memzone *mz;
+-
+-	if (unlikely(cpu >= RTE_MAX_MEMZONE))
+-		return NUMA_NO_NODE;
+-
+-	mz = rte_fbarray_get(arr, cpu);
+-
+-	return mz->socket_id;
+-}
+-
+ static inline void ena_rx_mbuf_prepare(struct rte_mbuf *mbuf,
+ 				       struct ena_com_rx_ctx *ena_rx_ctx)
+ {
+@@ -1050,7 +1033,7 @@ static int ena_create_io_queue(struct ena_ring *ring)
+ 	}
+ 	ctx.qid = ena_qid;
+ 	ctx.msix_vector = -1; /* interrupts not used */
+-	ctx.numa_node = ena_cpu_to_node(ring->id);
++	ctx.numa_node = ring->numa_socket_id;
+ 
+ 	rc = ena_com_create_io_queue(ena_dev, &ctx);
+ 	if (rc) {
+@@ -1133,7 +1116,7 @@ static int ena_queue_restart(struct ena_ring *ring)
+ static int ena_tx_queue_setup(struct rte_eth_dev *dev,
+ 			      uint16_t queue_idx,
+ 			      uint16_t nb_desc,
+-			      __rte_unused unsigned int socket_id,
++			      unsigned int socket_id,
+ 			      const struct rte_eth_txconf *tx_conf)
+ {
+ 	struct ena_ring *txq = NULL;
+@@ -1168,6 +1151,7 @@ static int ena_tx_queue_setup(struct rte_eth_dev *dev,
+ 	txq->next_to_clean = 0;
+ 	txq->next_to_use = 0;
+ 	txq->ring_size = nb_desc;
++	txq->numa_socket_id = socket_id;
+ 
+ 	txq->tx_buffer_info = rte_zmalloc("txq->tx_buffer_info",
+ 					  sizeof(struct ena_tx_buffer) *
+@@ -1205,7 +1189,7 @@ static int ena_tx_queue_setup(struct rte_eth_dev *dev,
+ static int ena_rx_queue_setup(struct rte_eth_dev *dev,
+ 			      uint16_t queue_idx,
+ 			      uint16_t nb_desc,
+-			      __rte_unused unsigned int socket_id,
++			      unsigned int socket_id,
+ 			      __rte_unused const struct rte_eth_rxconf *rx_conf,
+ 			      struct rte_mempool *mp)
+ {
+@@ -1240,6 +1224,7 @@ static int ena_rx_queue_setup(struct rte_eth_dev *dev,
+ 	rxq->next_to_clean = 0;
+ 	rxq->next_to_use = 0;
+ 	rxq->ring_size = nb_desc;
++	rxq->numa_socket_id = socket_id;
+ 	rxq->mb_pool = mp;
+ 
+ 	rxq->rx_buffer_info = rte_zmalloc("rxq->buffer_info",
+diff --git a/drivers/net/ena/ena_ethdev.h b/drivers/net/ena/ena_ethdev.h
+index 982ad7854..2ce0eb79e 100644
+--- a/drivers/net/ena/ena_ethdev.h
++++ b/drivers/net/ena/ena_ethdev.h
+@@ -105,6 +105,8 @@ struct ena_ring {
+ 	struct ena_adapter *adapter;
+ 	uint64_t offloads;
+ 	u16 sgl_size;
++
++	unsigned int numa_socket_id;
+ } __rte_cache_aligned;
+ 
+ enum ena_adapter_state {
+-- 
+2.20.1
+

--- a/userspace/dpdk/18.08/0019-net-ena-fix-L4-checksum-Tx-offload.patch
+++ b/userspace/dpdk/18.08/0019-net-ena-fix-L4-checksum-Tx-offload.patch
@@ -1,0 +1,52 @@
+From 4d2331ea6805d5fb1e6f5509618317bfe91ee4a2 Mon Sep 17 00:00:00 2001
+From: Maciej Bielski <mba@semihalf.com>
+Date: Thu, 1 Aug 2019 13:45:36 +0200
+Subject: [PATCH 19/19] net/ena: fix L4 checksum Tx offload
+
+[ upstream commit 40e7c02155625f18a87faf5e6a8cec2e986146e8 ]
+
+During an if-condition evaluation, a 2-bit flag evaluates to 'true' for
+'0x1', '0x2' and '0x3'. Thus, from this perspective these flags are
+indistinguishable. To make them distinct, respective bits must be
+extracted with a mask and then checked for strict equality.
+
+Specifically here, even if `PKT_TX_UDP_CKSUM` (value '0x3') was set, the
+expression `mbuf->ol_flags & PKT_TX_TCP` (the second flag of value
+'0x1') is evaluated first and the result is 'true'. In consequence, for
+UDP packets the execution flow enters an incorrect branch.
+
+Fixes: 56b8b9b7e5d2 ("net/ena: convert to new Tx offloads API")
+Cc: stable@dpdk.org
+
+Change-Id: I7917b209856f24e5d0b6481a94b322d09266bc5b
+Reported-by: Eduard Serra <eserra@vmware.com>
+Signed-off-by: Maciej Bielski <mba@semihalf.com>
+Acked-by: Michal Krawczyk <mk@semihalf.com>
+---
+ drivers/net/ena/ena_ethdev.c | 7 ++++---
+ 1 file changed, 4 insertions(+), 3 deletions(-)
+
+diff --git a/drivers/net/ena/ena_ethdev.c b/drivers/net/ena/ena_ethdev.c
+index f25e5ba82..7768eabba 100644
+--- a/drivers/net/ena/ena_ethdev.c
++++ b/drivers/net/ena/ena_ethdev.c
+@@ -335,12 +335,13 @@ static inline void ena_tx_mbuf_prepare(struct rte_mbuf *mbuf,
+ 		}
+ 
+ 		/* check if L4 checksum is needed */
+-		if ((mbuf->ol_flags & PKT_TX_TCP_CKSUM) &&
++		if (((mbuf->ol_flags & PKT_TX_L4_MASK) == PKT_TX_TCP_CKSUM) &&
+ 		    (queue_offloads & DEV_TX_OFFLOAD_TCP_CKSUM)) {
+ 			ena_tx_ctx->l4_proto = ENA_ETH_IO_L4_PROTO_TCP;
+ 			ena_tx_ctx->l4_csum_enable = true;
+-		} else if ((mbuf->ol_flags & PKT_TX_UDP_CKSUM) &&
+-			   (queue_offloads & DEV_TX_OFFLOAD_UDP_CKSUM)) {
++		} else if (((mbuf->ol_flags & PKT_TX_L4_MASK) ==
++				PKT_TX_UDP_CKSUM) &&
++				(queue_offloads & DEV_TX_OFFLOAD_UDP_CKSUM)) {
+ 			ena_tx_ctx->l4_proto = ENA_ETH_IO_L4_PROTO_UDP;
+ 			ena_tx_ctx->l4_csum_enable = true;
+ 		} else {
+-- 
+2.20.1
+

--- a/userspace/dpdk/18.11/0001-net-ena-add-reset-reason-in-Rx-error.patch
+++ b/userspace/dpdk/18.11/0001-net-ena-add-reset-reason-in-Rx-error.patch
@@ -1,7 +1,7 @@
 From 067b480529882526471322001562002b8f23a1d7 Mon Sep 17 00:00:00 2001
 From: Rafal Kozik <rk@semihalf.com>
 Date: Fri, 14 Dec 2018 14:18:29 +0100
-Subject: [PATCH 01/11] net/ena: add reset reason in Rx error
+Subject: [PATCH 01/16] net/ena: add reset reason in Rx error
 
 [ upstream commit 9b260dbf7412819f9a5fc544872b1447d6938afe ]
 
@@ -12,6 +12,7 @@ ENA_REGS_RESET_TOO_MANY_RX_DESCS.
 Fixes: 241da076b1f7 ("net/ena: adjust error checking and cleaning")
 Cc: stable@dpdk.org
 
+Change-Id: Ieaa7628ea608aa1c5af960eae81bd01b66350c8c
 Signed-off-by: Rafal Kozik <rk@semihalf.com>
 Acked-by: Michal Krawczyk <mk@semihalf.com>
 ---
@@ -32,5 +33,5 @@ index a07bd2b49..7a84783b6 100644
  			return 0;
  		}
 -- 
-2.14.1
+2.20.1
 

--- a/userspace/dpdk/18.11/0002-net-ena-skip-packet-with-wrong-request-id.patch
+++ b/userspace/dpdk/18.11/0002-net-ena-skip-packet-with-wrong-request-id.patch
@@ -1,7 +1,7 @@
 From aa598c8325215876567bb3c785090c56c7fb618c Mon Sep 17 00:00:00 2001
 From: Rafal Kozik <rk@semihalf.com>
 Date: Fri, 14 Dec 2018 14:18:31 +0100
-Subject: [PATCH 02/11] net/ena: skip packet with wrong request id
+Subject: [PATCH 02/16] net/ena: skip packet with wrong request id
 
 [ upstream commit f00930d929151fc09914e6d61b827f9f81645324 ]
 
@@ -12,6 +12,7 @@ is not making any sense.
 Fixes: c2034976673d ("net/ena: add Rx out of order completion")
 Cc: stable@dpdk.org
 
+Change-Id: Icf8b42409e116cc7edc978878a8cc6eb95bb1b7d
 Signed-off-by: Rafal Kozik <rk@semihalf.com>
 Acked-by: Michal Krawczyk <mk@semihalf.com>
 ---
@@ -32,5 +33,5 @@ index 7a84783b6..6d3a60c7a 100644
  		/* fill mbuf attributes if any */
  		ena_rx_mbuf_prepare(mbuf_head, &ena_rx_ctx);
 -- 
-2.14.1
+2.20.1
 

--- a/userspace/dpdk/18.11/0003-net-ena-destroy-queues-if-start-failed.patch
+++ b/userspace/dpdk/18.11/0003-net-ena-destroy-queues-if-start-failed.patch
@@ -1,7 +1,7 @@
 From b497931c27c5641df96f82dc844e0322ef14bd65 Mon Sep 17 00:00:00 2001
 From: Rafal Kozik <rk@semihalf.com>
 Date: Fri, 14 Dec 2018 14:18:35 +0100
-Subject: [PATCH 03/11] net/ena: destroy queues if start failed
+Subject: [PATCH 03/16] net/ena: destroy queues if start failed
 
 [ upstream commit 26e5543dc85b3be23879ba90ddb00e3456179805 ]
 
@@ -15,10 +15,11 @@ ena_free_io_queues_all() is renamed to ena_queue_stop_all().
 Fixes: df238f84c0a2 ("net/ena: recreate HW IO rings on start and stop")
 Cc: stable@dpdk.org
 
+Change-Id: I58b546f78c9c9fae4f645a0a494ca38606462650
 Signed-off-by: Rafal Kozik <rk@semihalf.com>
 Acked-by: Michal Krawczyk <mk@semihalf.com>
 ---
- drivers/net/ena/ena_ethdev.c | 95 ++++++++++++++++++++++++++++----------------
+ drivers/net/ena/ena_ethdev.c | 95 +++++++++++++++++++++++-------------
  1 file changed, 60 insertions(+), 35 deletions(-)
 
 diff --git a/drivers/net/ena/ena_ethdev.c b/drivers/net/ena/ena_ethdev.c
@@ -214,5 +215,5 @@ index 6d3a60c7a..f41c8b8e8 100644
  		return ENA_COM_FAULT;
  	}
 -- 
-2.14.1
+2.20.1
 

--- a/userspace/dpdk/18.11/0004-net-ena-do-not-reconfigure-queues-on-reset.patch
+++ b/userspace/dpdk/18.11/0004-net-ena-do-not-reconfigure-queues-on-reset.patch
@@ -1,7 +1,7 @@
 From bc12ed25639cc0bdda4fd294137e97e56f666af1 Mon Sep 17 00:00:00 2001
 From: Rafal Kozik <rk@semihalf.com>
 Date: Fri, 14 Dec 2018 14:18:36 +0100
-Subject: [PATCH 04/11] net/ena: do not reconfigure queues on reset
+Subject: [PATCH 04/16] net/ena: do not reconfigure queues on reset
 
 [ upstream commit e457bc70e5d6d589b1c3e1e93979aa42a64fbc06 ]
 
@@ -18,10 +18,11 @@ during stop.
 Fixes: 2081d5e2e92d ("net/ena: add reset routine")
 Cc: stable@dpdk.org
 
+Change-Id: I8e582e45c8dba3c0c752a06d609170d04f08f08f
 Signed-off-by: Rafal Kozik <rk@semihalf.com>
 Acked-by: Michal Krawczyk <mk@semihalf.com>
 ---
- drivers/net/ena/ena_ethdev.c | 107 +++++++++++++++----------------------------
+ drivers/net/ena/ena_ethdev.c | 107 +++++++++++++----------------------
  1 file changed, 38 insertions(+), 69 deletions(-)
 
 diff --git a/drivers/net/ena/ena_ethdev.c b/drivers/net/ena/ena_ethdev.c
@@ -200,5 +201,5 @@ index f41c8b8e8..6bfda3516 100644
  }
  
 -- 
-2.14.1
+2.20.1
 

--- a/userspace/dpdk/18.11/0005-net-ena-add-supported-RSS-offloads-types.patch
+++ b/userspace/dpdk/18.11/0005-net-ena-add-supported-RSS-offloads-types.patch
@@ -1,7 +1,7 @@
 From 6b822a13ac30962df62aa1ab537d7795ef1ec154 Mon Sep 17 00:00:00 2001
 From: Rafal Kozik <rk@semihalf.com>
 Date: Fri, 14 Dec 2018 14:18:38 +0100
-Subject: [PATCH 05/11] net/ena: add supported RSS offloads types
+Subject: [PATCH 05/16] net/ena: add supported RSS offloads types
 
 [ upstream commit b01ead202beb45346d7daeb2f2b1a608006af644 ]
 
@@ -12,6 +12,7 @@ missing information was added.
 Fixes: 1173fca25af9 ("ena: add polling-mode driver")
 Cc: stable@dpdk.org
 
+Change-Id: I91366df39fdc4290a479fe1cb1c552c3a9394f2e
 Signed-off-by: Rafal Kozik <rk@semihalf.com>
 Acked-by: Michal Krawczyk <mk@semihalf.com>
 ---
@@ -33,5 +34,5 @@ index 6bfda3516..73cebe843 100644
  	dev_info->max_rx_pktlen  = adapter->max_mtu;
  	dev_info->max_mac_addrs = 1;
 -- 
-2.14.1
+2.20.1
 

--- a/userspace/dpdk/18.11/0006-net-ena-fix-invalid-reference-to-variable-in-union.patch
+++ b/userspace/dpdk/18.11/0006-net-ena-fix-invalid-reference-to-variable-in-union.patch
@@ -1,7 +1,7 @@
 From 143b491d07c872ad1b0517013efe42ea399610c7 Mon Sep 17 00:00:00 2001
 From: Rafal Kozik <rk@semihalf.com>
 Date: Fri, 14 Dec 2018 14:18:39 +0100
-Subject: [PATCH 06/11] net/ena: fix invalid reference to variable in union
+Subject: [PATCH 06/16] net/ena: fix invalid reference to variable in union
 
 [ upstream commit eccbe2ffdc755a9e759c6ba480f6c15ccb1163c7 ]
 
@@ -12,6 +12,7 @@ any failure, but for consistency should be changed.
 Fixes: c2034976673d ("net/ena: add Rx out of order completion")
 Cc: stable@dpdk.org
 
+Change-Id: Ib4f46e8abaa340d9a84bf987a0f6c5406617a47b
 Signed-off-by: Rafal Kozik <rk@semihalf.com>
 Acked-by: Michal Krawczyk <mk@semihalf.com>
 ---
@@ -32,5 +33,5 @@ index 73cebe843..bd3d256da 100644
  	/* Store pointer to this queue in upper layer */
  	rxq->configured = 1;
 -- 
-2.14.1
+2.20.1
 

--- a/userspace/dpdk/18.11/0007-net-ena-fix-cleanup-for-out-of-order-packets.patch
+++ b/userspace/dpdk/18.11/0007-net-ena-fix-cleanup-for-out-of-order-packets.patch
@@ -1,7 +1,7 @@
 From ee05f98f3ad55e4509922c707220c1d47027ca35 Mon Sep 17 00:00:00 2001
 From: Rafal Kozik <rk@semihalf.com>
 Date: Mon, 17 Dec 2018 12:06:18 +0100
-Subject: [PATCH 07/11] net/ena: fix cleanup for out of order packets
+Subject: [PATCH 07/16] net/ena: fix cleanup for out of order packets
 
 [ upstream commit 709b1dcb73adebb3fc1a838b57d72028feb97e47 ]
 
@@ -19,6 +19,7 @@ are not used updating of next_to_clean pointer is not necessary.
 Fixes: c2034976673d ("net/ena: add Rx out of order completion")
 Cc: stable@dpdk.org
 
+Change-Id: I70ccc15725deabf7520f340a806acca605ef31c4
 Signed-off-by: Rafal Kozik <rk@semihalf.com>
 Acked-by: Michal Krawczyk <mk@semihalf.com>
 ---
@@ -79,5 +80,5 @@ index bd3d256da..79266d17e 100644
  			mbuf->data_off = RTE_PKTMBUF_HEADROOM;
  			mbuf->refcnt = 1;
 -- 
-2.14.1
+2.20.1
 

--- a/userspace/dpdk/18.11/0008-net-ena-add-new-way-of-getting-Rx-drops.patch
+++ b/userspace/dpdk/18.11/0008-net-ena-add-new-way-of-getting-Rx-drops.patch
@@ -1,13 +1,14 @@
 From 8927533a74100b6620a2c2bd264a1cff7afe4170 Mon Sep 17 00:00:00 2001
 From: Rafal Kozik <rk@semihalf.com>
 Date: Fri, 14 Dec 2018 14:18:43 +0100
-Subject: [PATCH 08/11] net/ena: add new way of getting Rx drops
+Subject: [PATCH 08/16] net/ena: add new way of getting Rx drops
 
 [ upstream commit 94c3e3765d9e0366acf145668d32d5eee3200c2b ]
 
 The Rx drops cannot be acquired using the older API. Now, it must be
 read in keep alive message.
 
+Change-Id: I67a5d331933b2326943b33aaf3336c730fc6f091
 Signed-off-by: Rafal Kozik <rk@semihalf.com>
 Acked-by: Michal Krawczyk <mk@semihalf.com>
 ---
@@ -67,5 +68,5 @@ index 322e90ace..8eb8543c2 100644
  
  struct ena_stats_dev {
 -- 
-2.14.1
+2.20.1
 

--- a/userspace/dpdk/18.11/0009-net-ena-update-completion-queue-after-cleanup.patch
+++ b/userspace/dpdk/18.11/0009-net-ena-update-completion-queue-after-cleanup.patch
@@ -1,7 +1,7 @@
 From 24bc59ab5b1cf17255cb36287bb2601741164736 Mon Sep 17 00:00:00 2001
 From: Rafal Kozik <rk@semihalf.com>
 Date: Fri, 14 Dec 2018 14:18:44 +0100
-Subject: [PATCH 09/11] net/ena: update completion queue after cleanup
+Subject: [PATCH 09/16] net/ena: update completion queue after cleanup
 
 [ upstream commit a45462c507e98b49cb5c2302e0be3c72d2e20a1a ]
 
@@ -11,6 +11,7 @@ ena_com_update_dev_comp_head().
 Fixes: 1daff5260ff8 ("net/ena: use unmasked head and tail")
 Cc: stable@dpdk.org
 
+Change-Id: If8cd7cb594f0afb56ba6ca46d7b30b2983e40a12
 Signed-off-by: Rafal Kozik <rk@semihalf.com>
 Acked-by: Michal Krawczyk <mk@semihalf.com>
 ---
@@ -45,5 +46,5 @@ index ee35c9793..309e358ad 100644
  
  	return sent_idx;
 -- 
-2.14.1
+2.20.1
 

--- a/userspace/dpdk/18.11/0010-net-ena-fix-dev-init-with-multi-process.patch
+++ b/userspace/dpdk/18.11/0010-net-ena-fix-dev-init-with-multi-process.patch
@@ -1,7 +1,7 @@
 From 6d3a043c4139b84a1aa2df8a7b7f4a576c44770d Mon Sep 17 00:00:00 2001
 From: Michal Krawczyk <mk@semihalf.com>
 Date: Fri, 25 Jan 2019 09:10:25 +0100
-Subject: [PATCH 10/11] net/ena: fix dev init with multi-process
+Subject: [PATCH 10/16] net/ena: fix dev init with multi-process
 
 [ upstream commit fd9768905870856a2340266d25f8c0100dfccfff ]
 
@@ -15,6 +15,7 @@ main process.
 Fixes: 1173fca25af9 ("ena: add polling-mode driver")
 Cc: stable@dpdk.org
 
+Change-Id: I5347af657b07bdb4a9438333ca491d7fb1576637
 Signed-off-by: Michal Krawczyk <mk@semihalf.com>
 ---
  drivers/net/ena/ena_ethdev.c | 11 ++++++-----
@@ -51,5 +52,5 @@ index 309e358ad..3507e69ab 100644
  	adapter->pdev = pci_dev;
  
 -- 
-2.14.1
+2.20.1
 

--- a/userspace/dpdk/18.11/0011-net-ena-fix-errno-to-positive-value.patch
+++ b/userspace/dpdk/18.11/0011-net-ena-fix-errno-to-positive-value.patch
@@ -1,7 +1,7 @@
 From 80cb46cd599694535d26a5c6d77fb4e06de3a2cc Mon Sep 17 00:00:00 2001
 From: Michal Krawczyk <mk@semihalf.com>
 Date: Fri, 25 Jan 2019 09:10:26 +0100
-Subject: [PATCH 11/11] net/ena: fix errno to positive value
+Subject: [PATCH 11/16] net/ena: fix errno to positive value
 
 [ upstream commit baeed5f404dd1b049118cfec26a2fd3203671572 ]
 
@@ -11,6 +11,7 @@ to be fixed.
 Fixes: b3fc5a1ae10d ("net/ena: add Tx preparation")
 Cc: stable@dpdk.org
 
+Change-Id: I18449563866b6344f236d696395166383f3238e6
 Signed-off-by: Michal Krawczyk <mk@semihalf.com>
 ---
  drivers/net/ena/ena_ethdev.c | 6 +++---
@@ -47,5 +48,5 @@ index 3507e69ab..04b989347 100644
  		}
  	}
 -- 
-2.14.1
+2.20.1
 

--- a/userspace/dpdk/18.11/0012-net-ena-get-device-info-statically.patch
+++ b/userspace/dpdk/18.11/0012-net-ena-get-device-info-statically.patch
@@ -1,0 +1,135 @@
+From efb706142341fd3d3b6bc4c5a83d958a1e031d2d Mon Sep 17 00:00:00 2001
+From: Michal Krawczyk <mk@semihalf.com>
+Date: Fri, 15 Feb 2019 09:36:39 +0100
+Subject: [PATCH 12/16] net/ena: get device info statically
+
+[ upstream commit 117ba4a60488a0f96a5737f38ddba6d0f9a728b6 ]
+
+Whenever the app is calling rte_eth_dev_info_get(), it shouldn't use the
+admin command. It was causing problems, if it was called from the
+secondary process - the main process was crashing, and the secondary app
+wasn't getting any result, as the admin request couldn't be processed by
+the process which was requesting the data.
+
+To fix that, the data is being written to the adapter structure during
+device initialization routine.
+
+Change-Id: I94f61f51223725602f70ac9795acf02b7b014984
+Signed-off-by: Michal Krawczyk <mk@semihalf.com>
+---
+ drivers/net/ena/ena_ethdev.c | 35 ++++++++++++++---------------------
+ drivers/net/ena/ena_ethdev.h |  8 +++++++-
+ 2 files changed, 21 insertions(+), 22 deletions(-)
+
+diff --git a/drivers/net/ena/ena_ethdev.c b/drivers/net/ena/ena_ethdev.c
+index 04b989347..4a816e259 100644
+--- a/drivers/net/ena/ena_ethdev.c
++++ b/drivers/net/ena/ena_ethdev.c
+@@ -1645,9 +1645,14 @@ static int eth_ena_dev_init(struct rte_eth_dev *eth_dev)
+ 	/* Set max MTU for this device */
+ 	adapter->max_mtu = get_feat_ctx.dev_attr.max_mtu;
+ 
+-	/* set device support for TSO */
+-	adapter->tso4_supported = get_feat_ctx.offload.tx &
+-				  ENA_ADMIN_FEATURE_OFFLOAD_DESC_TSO_IPV4_MASK;
++	/* set device support for offloads */
++	adapter->offloads.tso4_supported = (get_feat_ctx.offload.tx &
++		ENA_ADMIN_FEATURE_OFFLOAD_DESC_TSO_IPV4_MASK) != 0;
++	adapter->offloads.tx_csum_supported = (get_feat_ctx.offload.tx &
++		ENA_ADMIN_FEATURE_OFFLOAD_DESC_TX_L4_IPV4_CSUM_PART_MASK) != 0;
++	adapter->offloads.tx_csum_supported =
++		(get_feat_ctx.offload.rx_supported &
++		ENA_ADMIN_FEATURE_OFFLOAD_DESC_RX_L4_IPV4_CSUM_MASK) != 0;
+ 
+ 	/* Copy MAC address and point DPDK to it */
+ 	eth_dev->data->mac_addrs = (struct ether_addr *)adapter->mac_addr;
+@@ -1779,9 +1784,7 @@ static void ena_infos_get(struct rte_eth_dev *dev,
+ {
+ 	struct ena_adapter *adapter;
+ 	struct ena_com_dev *ena_dev;
+-	struct ena_com_dev_get_features_ctx feat;
+ 	uint64_t rx_feat = 0, tx_feat = 0;
+-	int rc = 0;
+ 
+ 	ena_assert_msg(dev->data != NULL, "Uninitialized device");
+ 	ena_assert_msg(dev->data->dev_private != NULL, "Uninitialized device");
+@@ -1800,26 +1803,16 @@ static void ena_infos_get(struct rte_eth_dev *dev,
+ 			ETH_LINK_SPEED_50G  |
+ 			ETH_LINK_SPEED_100G;
+ 
+-	/* Get supported features from HW */
+-	rc = ena_com_get_dev_attr_feat(ena_dev, &feat);
+-	if (unlikely(rc)) {
+-		RTE_LOG(ERR, PMD,
+-			"Cannot get attribute for ena device rc= %d\n", rc);
+-		return;
+-	}
+-
+ 	/* Set Tx & Rx features available for device */
+-	if (feat.offload.tx & ENA_ADMIN_FEATURE_OFFLOAD_DESC_TSO_IPV4_MASK)
++	if (adapter->offloads.tso4_supported)
+ 		tx_feat	|= DEV_TX_OFFLOAD_TCP_TSO;
+ 
+-	if (feat.offload.tx &
+-	    ENA_ADMIN_FEATURE_OFFLOAD_DESC_TX_L4_IPV4_CSUM_PART_MASK)
++	if (adapter->offloads.tx_csum_supported)
+ 		tx_feat |= DEV_TX_OFFLOAD_IPV4_CKSUM |
+ 			DEV_TX_OFFLOAD_UDP_CKSUM |
+ 			DEV_TX_OFFLOAD_TCP_CKSUM;
+ 
+-	if (feat.offload.rx_supported &
+-	    ENA_ADMIN_FEATURE_OFFLOAD_DESC_RX_L4_IPV4_CSUM_MASK)
++	if (adapter->offloads.rx_csum_supported)
+ 		rx_feat |= DEV_RX_OFFLOAD_IPV4_CKSUM |
+ 			DEV_RX_OFFLOAD_UDP_CKSUM  |
+ 			DEV_RX_OFFLOAD_TCP_CKSUM;
+@@ -1852,9 +1845,9 @@ static void ena_infos_get(struct rte_eth_dev *dev,
+ 	dev_info->tx_desc_lim.nb_max = ENA_MAX_RING_DESC;
+ 	dev_info->tx_desc_lim.nb_min = ENA_MIN_RING_DESC;
+ 	dev_info->tx_desc_lim.nb_seg_max = RTE_MIN(ENA_PKT_MAX_BUFS,
+-					feat.max_queues.max_packet_tx_descs);
++		adapter->max_tx_sgl_size);
+ 	dev_info->tx_desc_lim.nb_mtu_seg_max = RTE_MIN(ENA_PKT_MAX_BUFS,
+-					feat.max_queues.max_packet_tx_descs);
++		adapter->max_tx_sgl_size);
+ }
+ 
+ static uint16_t eth_ena_recv_pkts(void *rx_queue, struct rte_mbuf **rx_pkts,
+@@ -1999,7 +1992,7 @@ eth_ena_prep_pkts(void *tx_queue, struct rte_mbuf **tx_pkts,
+ 			/* If IPv4 header has DF flag enabled and TSO support is
+ 			 * disabled, partial chcecksum should not be calculated.
+ 			 */
+-			if (!tx_ring->adapter->tso4_supported)
++			if (!tx_ring->adapter->offloads.tso4_supported)
+ 				continue;
+ 		}
+ 
+diff --git a/drivers/net/ena/ena_ethdev.h b/drivers/net/ena/ena_ethdev.h
+index 8eb8543c2..982ad7854 100644
+--- a/drivers/net/ena/ena_ethdev.h
++++ b/drivers/net/ena/ena_ethdev.h
+@@ -160,6 +160,12 @@ struct ena_stats_rx {
+ 	u64 small_copy_len_pkt;
+ };
+ 
++struct ena_offloads {
++	bool tso4_supported;
++	bool tx_csum_supported;
++	bool rx_csum_supported;
++};
++
+ /* board specific private data structure */
+ struct ena_adapter {
+ 	/* OS defined structs */
+@@ -180,7 +186,7 @@ struct ena_adapter {
+ 
+ 	u16 num_queues;
+ 	u16 max_mtu;
+-	u8 tso4_supported;
++	struct ena_offloads offloads;
+ 
+ 	int id_number;
+ 	char name[ENA_NAME_MAX_LEN];
+-- 
+2.20.1
+

--- a/userspace/dpdk/18.11/0013-net-ena-fix-checksum-feature-flag.patch
+++ b/userspace/dpdk/18.11/0013-net-ena-fix-checksum-feature-flag.patch
@@ -1,0 +1,35 @@
+From 199fd19db0850be70555e7a591584e41856be865 Mon Sep 17 00:00:00 2001
+From: Michal Krawczyk <mk@semihalf.com>
+Date: Mon, 8 Apr 2019 12:27:44 +0200
+Subject: [PATCH 13/16] net/ena: fix checksum feature flag
+
+[ upstream commit ef538c1a7f565c9b58518375a500aa864445fd11 ]
+
+The boolean value was assigned to Tx flag twice, so it could cause bug
+whenever Rx checksum will not be supported and Tx will be.
+
+Coverity issue: 336831
+Fixes: 117ba4a60488 ("net/ena: get device info statically")
+
+Change-Id: Id1ca7bb11b566c35ab7c9691593dcab40263c0f7
+Signed-off-by: Michal Krawczyk <mk@semihalf.com>
+---
+ drivers/net/ena/ena_ethdev.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/drivers/net/ena/ena_ethdev.c b/drivers/net/ena/ena_ethdev.c
+index 4a816e259..e04441d26 100644
+--- a/drivers/net/ena/ena_ethdev.c
++++ b/drivers/net/ena/ena_ethdev.c
+@@ -1650,7 +1650,7 @@ static int eth_ena_dev_init(struct rte_eth_dev *eth_dev)
+ 		ENA_ADMIN_FEATURE_OFFLOAD_DESC_TSO_IPV4_MASK) != 0;
+ 	adapter->offloads.tx_csum_supported = (get_feat_ctx.offload.tx &
+ 		ENA_ADMIN_FEATURE_OFFLOAD_DESC_TX_L4_IPV4_CSUM_PART_MASK) != 0;
+-	adapter->offloads.tx_csum_supported =
++	adapter->offloads.rx_csum_supported =
+ 		(get_feat_ctx.offload.rx_supported &
+ 		ENA_ADMIN_FEATURE_OFFLOAD_DESC_RX_L4_IPV4_CSUM_MASK) != 0;
+ 
+-- 
+2.20.1
+

--- a/userspace/dpdk/18.11/0014-net-ena-fix-Rx-checksum-errors-statistics.patch
+++ b/userspace/dpdk/18.11/0014-net-ena-fix-Rx-checksum-errors-statistics.patch
@@ -1,0 +1,52 @@
+From 1526143b9b0184510c5c9b19e81f3dd8319cc3ac Mon Sep 17 00:00:00 2001
+From: Michal Krawczyk <mk@semihalf.com>
+Date: Tue, 28 May 2019 10:28:34 +0200
+Subject: [PATCH 14/16] net/ena: fix Rx checksum errors statistics
+
+[ upstream commit ef74b5f7b69b9502ddab81121611243efcfe1dde ]
+
+Rx checksum flags and input errors shouldn't be updated on Tx, as it
+would work only for packets forwarding.
+
+The ierrors statistic should be updated on Rx, right after checking
+Rx checksum flags if the Rx checksum offload is enabled.
+
+Fixes: 1173fca25af9 ("ena: add polling-mode driver")
+Cc: stable@dpdk.org
+
+Change-Id: I4ccf68bcb1ef6b50d01c811fc7f050a3d7ec9966
+Signed-off-by: Michal Krawczyk <mk@semihalf.com>
+---
+ drivers/net/ena/ena_ethdev.c | 9 +++++----
+ 1 file changed, 5 insertions(+), 4 deletions(-)
+
+diff --git a/drivers/net/ena/ena_ethdev.c b/drivers/net/ena/ena_ethdev.c
+index e04441d26..4e3f6d611 100644
+--- a/drivers/net/ena/ena_ethdev.c
++++ b/drivers/net/ena/ena_ethdev.c
+@@ -1938,6 +1938,11 @@ static uint16_t eth_ena_recv_pkts(void *rx_queue, struct rte_mbuf **rx_pkts,
+ 
+ 		/* fill mbuf attributes if any */
+ 		ena_rx_mbuf_prepare(mbuf_head, &ena_rx_ctx);
++
++		if (unlikely(mbuf_head->ol_flags &
++				(PKT_RX_IP_CKSUM_BAD | PKT_RX_L4_CKSUM_BAD)))
++			rte_atomic64_inc(&rx_ring->adapter->drv_stats->ierrors);
++
+ 		mbuf_head->hash.rss = ena_rx_ctx.hash;
+ 
+ 		/* pass to DPDK application head mbuf */
+@@ -2129,10 +2134,6 @@ static uint16_t eth_ena_xmit_pkts(void *tx_queue, struct rte_mbuf **tx_pkts,
+ 		/* Set TX offloads flags, if applicable */
+ 		ena_tx_mbuf_prepare(mbuf, &ena_tx_ctx, tx_ring->offloads);
+ 
+-		if (unlikely(mbuf->ol_flags &
+-			     (PKT_RX_L4_CKSUM_BAD | PKT_RX_IP_CKSUM_BAD)))
+-			rte_atomic64_inc(&tx_ring->adapter->drv_stats->ierrors);
+-
+ 		rte_prefetch0(tx_pkts[(sent_idx + 4) & ring_mask]);
+ 
+ 		/* Process first segment taking into
+-- 
+2.20.1
+

--- a/userspace/dpdk/18.11/0015-net-ena-fix-assigning-NUMA-node-to-IO-queue.patch
+++ b/userspace/dpdk/18.11/0015-net-ena-fix-assigning-NUMA-node-to-IO-queue.patch
@@ -1,0 +1,118 @@
+From 8532d00113a8b61eca1ef2dd3f1cf3cd5dfe6dd8 Mon Sep 17 00:00:00 2001
+From: Michal Krawczyk <mk@semihalf.com>
+Date: Tue, 4 Jun 2019 12:59:36 +0200
+Subject: [PATCH 15/16] net/ena: fix assigning NUMA node to IO queue
+
+[ upstream commit 4217cb0b7d2c5385f06f531af7f14b860927aba7 ]
+
+Previous solution was using memzones in invalid way in hope to assign
+IO queue to the appropriate NUMA zone.
+
+The right way is to use socket_id from the rx/tx queue setup function
+and then pass it to the IO queue.
+
+Fixes: 3d3edc265fc8 ("net/ena: make coherent memory allocation NUMA-aware")
+Cc: stable@dpdk.org
+
+Change-Id: I252df018ca6aae9d566618b6967bec0c5b3d939a
+Signed-off-by: Michal Krawczyk <mk@semihalf.com>
+Reviewed-by: David Marchand <david.marchand@redhat.com>
+---
+ drivers/net/ena/ena_ethdev.c | 25 +++++--------------------
+ drivers/net/ena/ena_ethdev.h |  2 ++
+ 2 files changed, 7 insertions(+), 20 deletions(-)
+
+diff --git a/drivers/net/ena/ena_ethdev.c b/drivers/net/ena/ena_ethdev.c
+index 4e3f6d611..0cb183ea0 100644
+--- a/drivers/net/ena/ena_ethdev.c
++++ b/drivers/net/ena/ena_ethdev.c
+@@ -39,7 +39,6 @@
+ #include <rte_dev.h>
+ #include <rte_errno.h>
+ #include <rte_version.h>
+-#include <rte_eal_memconfig.h>
+ #include <rte_net.h>
+ 
+ #include "ena_ethdev.h"
+@@ -279,22 +278,6 @@ static const struct eth_dev_ops ena_dev_ops = {
+ 	.reta_query           = ena_rss_reta_query,
+ };
+ 
+-#define NUMA_NO_NODE	SOCKET_ID_ANY
+-
+-static inline int ena_cpu_to_node(int cpu)
+-{
+-	struct rte_config *config = rte_eal_get_configuration();
+-	struct rte_fbarray *arr = &config->mem_config->memzones;
+-	const struct rte_memzone *mz;
+-
+-	if (unlikely(cpu >= RTE_MAX_MEMZONE))
+-		return NUMA_NO_NODE;
+-
+-	mz = rte_fbarray_get(arr, cpu);
+-
+-	return mz->socket_id;
+-}
+-
+ static inline void ena_rx_mbuf_prepare(struct rte_mbuf *mbuf,
+ 				       struct ena_com_rx_ctx *ena_rx_ctx)
+ {
+@@ -1079,7 +1062,7 @@ static int ena_create_io_queue(struct ena_ring *ring)
+ 	}
+ 	ctx.qid = ena_qid;
+ 	ctx.msix_vector = -1; /* interrupts not used */
+-	ctx.numa_node = ena_cpu_to_node(ring->id);
++	ctx.numa_node = ring->numa_socket_id;
+ 
+ 	rc = ena_com_create_io_queue(ena_dev, &ctx);
+ 	if (rc) {
+@@ -1174,7 +1157,7 @@ static int ena_queue_start(struct ena_ring *ring)
+ static int ena_tx_queue_setup(struct rte_eth_dev *dev,
+ 			      uint16_t queue_idx,
+ 			      uint16_t nb_desc,
+-			      __rte_unused unsigned int socket_id,
++			      unsigned int socket_id,
+ 			      const struct rte_eth_txconf *tx_conf)
+ {
+ 	struct ena_ring *txq = NULL;
+@@ -1209,6 +1192,7 @@ static int ena_tx_queue_setup(struct rte_eth_dev *dev,
+ 	txq->next_to_clean = 0;
+ 	txq->next_to_use = 0;
+ 	txq->ring_size = nb_desc;
++	txq->numa_socket_id = socket_id;
+ 
+ 	txq->tx_buffer_info = rte_zmalloc("txq->tx_buffer_info",
+ 					  sizeof(struct ena_tx_buffer) *
+@@ -1246,7 +1230,7 @@ static int ena_tx_queue_setup(struct rte_eth_dev *dev,
+ static int ena_rx_queue_setup(struct rte_eth_dev *dev,
+ 			      uint16_t queue_idx,
+ 			      uint16_t nb_desc,
+-			      __rte_unused unsigned int socket_id,
++			      unsigned int socket_id,
+ 			      __rte_unused const struct rte_eth_rxconf *rx_conf,
+ 			      struct rte_mempool *mp)
+ {
+@@ -1281,6 +1265,7 @@ static int ena_rx_queue_setup(struct rte_eth_dev *dev,
+ 	rxq->next_to_clean = 0;
+ 	rxq->next_to_use = 0;
+ 	rxq->ring_size = nb_desc;
++	rxq->numa_socket_id = socket_id;
+ 	rxq->mb_pool = mp;
+ 
+ 	rxq->rx_buffer_info = rte_zmalloc("rxq->buffer_info",
+diff --git a/drivers/net/ena/ena_ethdev.h b/drivers/net/ena/ena_ethdev.h
+index 982ad7854..2ce0eb79e 100644
+--- a/drivers/net/ena/ena_ethdev.h
++++ b/drivers/net/ena/ena_ethdev.h
+@@ -105,6 +105,8 @@ struct ena_ring {
+ 	struct ena_adapter *adapter;
+ 	uint64_t offloads;
+ 	u16 sgl_size;
++
++	unsigned int numa_socket_id;
+ } __rte_cache_aligned;
+ 
+ enum ena_adapter_state {
+-- 
+2.20.1
+

--- a/userspace/dpdk/18.11/0016-net-ena-fix-L4-checksum-Tx-offload.patch
+++ b/userspace/dpdk/18.11/0016-net-ena-fix-L4-checksum-Tx-offload.patch
@@ -1,0 +1,52 @@
+From 15e4484f9199f48b0594ca534e503ab5ebfeebbd Mon Sep 17 00:00:00 2001
+From: Maciej Bielski <mba@semihalf.com>
+Date: Thu, 1 Aug 2019 13:45:36 +0200
+Subject: [PATCH 16/16] net/ena: fix L4 checksum Tx offload
+
+[ upstream commit 40e7c02155625f18a87faf5e6a8cec2e986146e8 ]
+
+During an if-condition evaluation, a 2-bit flag evaluates to 'true' for
+'0x1', '0x2' and '0x3'. Thus, from this perspective these flags are
+indistinguishable. To make them distinct, respective bits must be
+extracted with a mask and then checked for strict equality.
+
+Specifically here, even if `PKT_TX_UDP_CKSUM` (value '0x3') was set, the
+expression `mbuf->ol_flags & PKT_TX_TCP` (the second flag of value
+'0x1') is evaluated first and the result is 'true'. In consequence, for
+UDP packets the execution flow enters an incorrect branch.
+
+Fixes: 56b8b9b7e5d2 ("net/ena: convert to new Tx offloads API")
+Cc: stable@dpdk.org
+
+Change-Id: I7917b209856f24e5d0b6481a94b322d09266bc5b
+Reported-by: Eduard Serra <eserra@vmware.com>
+Signed-off-by: Maciej Bielski <mba@semihalf.com>
+Acked-by: Michal Krawczyk <mk@semihalf.com>
+---
+ drivers/net/ena/ena_ethdev.c | 7 ++++---
+ 1 file changed, 4 insertions(+), 3 deletions(-)
+
+diff --git a/drivers/net/ena/ena_ethdev.c b/drivers/net/ena/ena_ethdev.c
+index 0cb183ea0..9137e3047 100644
+--- a/drivers/net/ena/ena_ethdev.c
++++ b/drivers/net/ena/ena_ethdev.c
+@@ -337,12 +337,13 @@ static inline void ena_tx_mbuf_prepare(struct rte_mbuf *mbuf,
+ 		}
+ 
+ 		/* check if L4 checksum is needed */
+-		if ((mbuf->ol_flags & PKT_TX_TCP_CKSUM) &&
++		if (((mbuf->ol_flags & PKT_TX_L4_MASK) == PKT_TX_TCP_CKSUM) &&
+ 		    (queue_offloads & DEV_TX_OFFLOAD_TCP_CKSUM)) {
+ 			ena_tx_ctx->l4_proto = ENA_ETH_IO_L4_PROTO_TCP;
+ 			ena_tx_ctx->l4_csum_enable = true;
+-		} else if ((mbuf->ol_flags & PKT_TX_UDP_CKSUM) &&
+-			   (queue_offloads & DEV_TX_OFFLOAD_UDP_CKSUM)) {
++		} else if (((mbuf->ol_flags & PKT_TX_L4_MASK) ==
++				PKT_TX_UDP_CKSUM) &&
++				(queue_offloads & DEV_TX_OFFLOAD_UDP_CKSUM)) {
+ 			ena_tx_ctx->l4_proto = ENA_ETH_IO_L4_PROTO_UDP;
+ 			ena_tx_ctx->l4_csum_enable = true;
+ 		} else {
+-- 
+2.20.1
+

--- a/userspace/dpdk/19.02/0001-net-ena-get-device-info-statically.patch
+++ b/userspace/dpdk/19.02/0001-net-ena-get-device-info-statically.patch
@@ -1,0 +1,123 @@
+From 5433ba938e996f8309cdbc45284e1f54f16c081e Mon Sep 17 00:00:00 2001
+From: Michal Krawczyk <mk@semihalf.com>
+Date: Fri, 15 Feb 2019 09:36:39 +0100
+Subject: [PATCH 1/6] net/ena: get device info statically
+
+[ upstream commit 117ba4a60488a0f96a5737f38ddba6d0f9a728b6 ]
+
+Whenever the app is calling rte_eth_dev_info_get(), it shouldn't use the
+admin command. It was causing problems, if it was called from the
+secondary process - the main process was crashing, and the secondary app
+wasn't getting any result, as the admin request couldn't be processed by
+the process which was requesting the data.
+
+To fix that, the data is being written to the adapter structure during
+device initialization routine.
+
+Change-Id: I94f61f51223725602f70ac9795acf02b7b014984
+Signed-off-by: Michal Krawczyk <mk@semihalf.com>
+---
+ drivers/net/ena/ena_ethdev.c | 31 ++++++++++++-------------------
+ drivers/net/ena/ena_ethdev.h |  8 +++++++-
+ 2 files changed, 19 insertions(+), 20 deletions(-)
+
+diff --git a/drivers/net/ena/ena_ethdev.c b/drivers/net/ena/ena_ethdev.c
+index 8bb05caa2..08b1ab195 100644
+--- a/drivers/net/ena/ena_ethdev.c
++++ b/drivers/net/ena/ena_ethdev.c
+@@ -1804,9 +1804,14 @@ static int eth_ena_dev_init(struct rte_eth_dev *eth_dev)
+ 	/* Set max MTU for this device */
+ 	adapter->max_mtu = get_feat_ctx.dev_attr.max_mtu;
+ 
+-	/* set device support for TSO */
+-	adapter->tso4_supported = get_feat_ctx.offload.tx &
+-				  ENA_ADMIN_FEATURE_OFFLOAD_DESC_TSO_IPV4_MASK;
++	/* set device support for offloads */
++	adapter->offloads.tso4_supported = (get_feat_ctx.offload.tx &
++		ENA_ADMIN_FEATURE_OFFLOAD_DESC_TSO_IPV4_MASK) != 0;
++	adapter->offloads.tx_csum_supported = (get_feat_ctx.offload.tx &
++		ENA_ADMIN_FEATURE_OFFLOAD_DESC_TX_L4_IPV4_CSUM_PART_MASK) != 0;
++	adapter->offloads.tx_csum_supported =
++		(get_feat_ctx.offload.rx_supported &
++		ENA_ADMIN_FEATURE_OFFLOAD_DESC_RX_L4_IPV4_CSUM_MASK) != 0;
+ 
+ 	/* Copy MAC address and point DPDK to it */
+ 	eth_dev->data->mac_addrs = (struct ether_addr *)adapter->mac_addr;
+@@ -1939,9 +1944,7 @@ static void ena_infos_get(struct rte_eth_dev *dev,
+ {
+ 	struct ena_adapter *adapter;
+ 	struct ena_com_dev *ena_dev;
+-	struct ena_com_dev_get_features_ctx feat;
+ 	uint64_t rx_feat = 0, tx_feat = 0;
+-	int rc = 0;
+ 
+ 	ena_assert_msg(dev->data != NULL, "Uninitialized device\n");
+ 	ena_assert_msg(dev->data->dev_private != NULL, "Uninitialized device\n");
+@@ -1960,26 +1963,16 @@ static void ena_infos_get(struct rte_eth_dev *dev,
+ 			ETH_LINK_SPEED_50G  |
+ 			ETH_LINK_SPEED_100G;
+ 
+-	/* Get supported features from HW */
+-	rc = ena_com_get_dev_attr_feat(ena_dev, &feat);
+-	if (unlikely(rc)) {
+-		RTE_LOG(ERR, PMD,
+-			"Cannot get attribute for ena device rc= %d\n", rc);
+-		return;
+-	}
+-
+ 	/* Set Tx & Rx features available for device */
+-	if (feat.offload.tx & ENA_ADMIN_FEATURE_OFFLOAD_DESC_TSO_IPV4_MASK)
++	if (adapter->offloads.tso4_supported)
+ 		tx_feat	|= DEV_TX_OFFLOAD_TCP_TSO;
+ 
+-	if (feat.offload.tx &
+-	    ENA_ADMIN_FEATURE_OFFLOAD_DESC_TX_L4_IPV4_CSUM_PART_MASK)
++	if (adapter->offloads.tx_csum_supported)
+ 		tx_feat |= DEV_TX_OFFLOAD_IPV4_CKSUM |
+ 			DEV_TX_OFFLOAD_UDP_CKSUM |
+ 			DEV_TX_OFFLOAD_TCP_CKSUM;
+ 
+-	if (feat.offload.rx_supported &
+-	    ENA_ADMIN_FEATURE_OFFLOAD_DESC_RX_L4_IPV4_CSUM_MASK)
++	if (adapter->offloads.rx_csum_supported)
+ 		rx_feat |= DEV_RX_OFFLOAD_IPV4_CKSUM |
+ 			DEV_RX_OFFLOAD_UDP_CKSUM  |
+ 			DEV_RX_OFFLOAD_TCP_CKSUM;
+@@ -2171,7 +2164,7 @@ eth_ena_prep_pkts(void *tx_queue, struct rte_mbuf **tx_pkts,
+ 			/* If IPv4 header has DF flag enabled and TSO support is
+ 			 * disabled, partial chcecksum should not be calculated.
+ 			 */
+-			if (!tx_ring->adapter->tso4_supported)
++			if (!tx_ring->adapter->offloads.tso4_supported)
+ 				continue;
+ 		}
+ 
+diff --git a/drivers/net/ena/ena_ethdev.h b/drivers/net/ena/ena_ethdev.h
+index 309b92f65..221760c62 100644
+--- a/drivers/net/ena/ena_ethdev.h
++++ b/drivers/net/ena/ena_ethdev.h
+@@ -167,6 +167,12 @@ struct ena_stats_dev {
+ 	u64 dev_stop;
+ };
+ 
++struct ena_offloads {
++	bool tso4_supported;
++	bool tx_csum_supported;
++	bool rx_csum_supported;
++};
++
+ /* board specific private data structure */
+ struct ena_adapter {
+ 	/* OS defined structs */
+@@ -188,7 +194,7 @@ struct ena_adapter {
+ 
+ 	u16 num_queues;
+ 	u16 max_mtu;
+-	u8 tso4_supported;
++	struct ena_offloads offloads;
+ 
+ 	int id_number;
+ 	char name[ENA_NAME_MAX_LEN];
+-- 
+2.20.1
+

--- a/userspace/dpdk/19.02/0002-net-ena-fix-checksum-feature-flag.patch
+++ b/userspace/dpdk/19.02/0002-net-ena-fix-checksum-feature-flag.patch
@@ -1,0 +1,35 @@
+From 0d73961d8e76dd5d64eb6e785f55bdef0a17b4f1 Mon Sep 17 00:00:00 2001
+From: Michal Krawczyk <mk@semihalf.com>
+Date: Mon, 8 Apr 2019 12:27:44 +0200
+Subject: [PATCH 2/6] net/ena: fix checksum feature flag
+
+[ upstream commit ef538c1a7f565c9b58518375a500aa864445fd11 ]
+
+The boolean value was assigned to Tx flag twice, so it could cause bug
+whenever Rx checksum will not be supported and Tx will be.
+
+Coverity issue: 336831
+Fixes: 117ba4a60488 ("net/ena: get device info statically")
+
+Change-Id: Id1ca7bb11b566c35ab7c9691593dcab40263c0f7
+Signed-off-by: Michal Krawczyk <mk@semihalf.com>
+---
+ drivers/net/ena/ena_ethdev.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/drivers/net/ena/ena_ethdev.c b/drivers/net/ena/ena_ethdev.c
+index 08b1ab195..ca391ec4a 100644
+--- a/drivers/net/ena/ena_ethdev.c
++++ b/drivers/net/ena/ena_ethdev.c
+@@ -1809,7 +1809,7 @@ static int eth_ena_dev_init(struct rte_eth_dev *eth_dev)
+ 		ENA_ADMIN_FEATURE_OFFLOAD_DESC_TSO_IPV4_MASK) != 0;
+ 	adapter->offloads.tx_csum_supported = (get_feat_ctx.offload.tx &
+ 		ENA_ADMIN_FEATURE_OFFLOAD_DESC_TX_L4_IPV4_CSUM_PART_MASK) != 0;
+-	adapter->offloads.tx_csum_supported =
++	adapter->offloads.rx_csum_supported =
+ 		(get_feat_ctx.offload.rx_supported &
+ 		ENA_ADMIN_FEATURE_OFFLOAD_DESC_RX_L4_IPV4_CSUM_MASK) != 0;
+ 
+-- 
+2.20.1
+

--- a/userspace/dpdk/19.02/0003-net-ena-fix-Tx-statistics.patch
+++ b/userspace/dpdk/19.02/0003-net-ena-fix-Tx-statistics.patch
@@ -1,0 +1,36 @@
+From b3bfc9ce1a047aa1690daf0d9c8c0ad0bda5bbf8 Mon Sep 17 00:00:00 2001
+From: Rafal Kozik <rk@semihalf.com>
+Date: Tue, 14 May 2019 13:11:26 +0200
+Subject: [PATCH 3/6] net/ena: fix Tx statistics
+
+[ upstream commit 5673e285a63347068e51dbd191915348f6a580b0 ]
+
+Instead of counting number of used NIC Tx bufs just count number
+of Tx packets.
+
+Fixes: 45b6d86184fc ("net/ena: add per-queue software counters stats")
+Cc: stable@dpdk.org
+
+Change-Id: I8e3260f11ed4b98a5917634d6dfbe92b986c788a
+Signed-off-by: Rafal Kozik <rk@semihalf.com>
+Acked-by: Michal Krawczyk <mk@semihalf.com>
+---
+ drivers/net/ena/ena_ethdev.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/drivers/net/ena/ena_ethdev.c b/drivers/net/ena/ena_ethdev.c
+index ca391ec4a..b948517d2 100644
+--- a/drivers/net/ena/ena_ethdev.c
++++ b/drivers/net/ena/ena_ethdev.c
+@@ -2392,7 +2392,7 @@ static uint16_t eth_ena_xmit_pkts(void *tx_queue, struct rte_mbuf **tx_pkts,
+ 		tx_info->tx_descs = nb_hw_desc;
+ 
+ 		next_to_use++;
+-		tx_ring->tx_stats.cnt += tx_info->num_of_bufs;
++		tx_ring->tx_stats.cnt++;
+ 		tx_ring->tx_stats.bytes += total_length;
+ 	}
+ 	tx_ring->tx_stats.available_desc =
+-- 
+2.20.1
+

--- a/userspace/dpdk/19.02/0004-net-ena-fix-Rx-checksum-errors-statistics.patch
+++ b/userspace/dpdk/19.02/0004-net-ena-fix-Rx-checksum-errors-statistics.patch
@@ -1,0 +1,52 @@
+From 4d807ac597171d80ce0d4131cecef2950be2b20a Mon Sep 17 00:00:00 2001
+From: Michal Krawczyk <mk@semihalf.com>
+Date: Tue, 28 May 2019 10:28:34 +0200
+Subject: [PATCH 4/6] net/ena: fix Rx checksum errors statistics
+
+[ upstream commit ef74b5f7b69b9502ddab81121611243efcfe1dde ]
+
+Rx checksum flags and input errors shouldn't be updated on Tx, as it
+would work only for packets forwarding.
+
+The ierrors statistic should be updated on Rx, right after checking
+Rx checksum flags if the Rx checksum offload is enabled.
+
+Fixes: 1173fca25af9 ("ena: add polling-mode driver")
+Cc: stable@dpdk.org
+
+Change-Id: I4ccf68bcb1ef6b50d01c811fc7f050a3d7ec9966
+Signed-off-by: Michal Krawczyk <mk@semihalf.com>
+---
+ drivers/net/ena/ena_ethdev.c | 8 +++-----
+ 1 file changed, 3 insertions(+), 5 deletions(-)
+
+diff --git a/drivers/net/ena/ena_ethdev.c b/drivers/net/ena/ena_ethdev.c
+index b948517d2..94c2bad14 100644
+--- a/drivers/net/ena/ena_ethdev.c
++++ b/drivers/net/ena/ena_ethdev.c
+@@ -2105,8 +2105,10 @@ static uint16_t eth_ena_recv_pkts(void *rx_queue, struct rte_mbuf **rx_pkts,
+ 		ena_rx_mbuf_prepare(mbuf_head, &ena_rx_ctx);
+ 
+ 		if (unlikely(mbuf_head->ol_flags &
+-			(PKT_RX_IP_CKSUM_BAD | PKT_RX_L4_CKSUM_BAD)))
++				(PKT_RX_IP_CKSUM_BAD | PKT_RX_L4_CKSUM_BAD))) {
++			rte_atomic64_inc(&rx_ring->adapter->drv_stats->ierrors);
+ 			++rx_ring->rx_stats.bad_csum;
++		}
+ 
+ 		mbuf_head->hash.rss = ena_rx_ctx.hash;
+ 
+@@ -2334,10 +2336,6 @@ static uint16_t eth_ena_xmit_pkts(void *tx_queue, struct rte_mbuf **tx_pkts,
+ 		/* Set TX offloads flags, if applicable */
+ 		ena_tx_mbuf_prepare(mbuf, &ena_tx_ctx, tx_ring->offloads);
+ 
+-		if (unlikely(mbuf->ol_flags &
+-			     (PKT_RX_L4_CKSUM_BAD | PKT_RX_IP_CKSUM_BAD)))
+-			rte_atomic64_inc(&tx_ring->adapter->drv_stats->ierrors);
+-
+ 		rte_prefetch0(tx_pkts[(sent_idx + 4) & ring_mask]);
+ 
+ 		/* Process first segment taking into
+-- 
+2.20.1
+

--- a/userspace/dpdk/19.02/0005-net-ena-fix-assigning-NUMA-node-to-IO-queue.patch
+++ b/userspace/dpdk/19.02/0005-net-ena-fix-assigning-NUMA-node-to-IO-queue.patch
@@ -1,0 +1,118 @@
+From 3adc0484592c907640663ba836924bcd77b59002 Mon Sep 17 00:00:00 2001
+From: Michal Krawczyk <mk@semihalf.com>
+Date: Tue, 4 Jun 2019 12:59:36 +0200
+Subject: [PATCH 5/6] net/ena: fix assigning NUMA node to IO queue
+
+[ upstream commit 4217cb0b7d2c5385f06f531af7f14b860927aba7 ]
+
+Previous solution was using memzones in invalid way in hope to assign
+IO queue to the appropriate NUMA zone.
+
+The right way is to use socket_id from the rx/tx queue setup function
+and then pass it to the IO queue.
+
+Fixes: 3d3edc265fc8 ("net/ena: make coherent memory allocation NUMA-aware")
+Cc: stable@dpdk.org
+
+Change-Id: I252df018ca6aae9d566618b6967bec0c5b3d939a
+Signed-off-by: Michal Krawczyk <mk@semihalf.com>
+Reviewed-by: David Marchand <david.marchand@redhat.com>
+---
+ drivers/net/ena/ena_ethdev.c | 25 +++++--------------------
+ drivers/net/ena/ena_ethdev.h |  2 ++
+ 2 files changed, 7 insertions(+), 20 deletions(-)
+
+diff --git a/drivers/net/ena/ena_ethdev.c b/drivers/net/ena/ena_ethdev.c
+index 94c2bad14..ad7d8fed4 100644
+--- a/drivers/net/ena/ena_ethdev.c
++++ b/drivers/net/ena/ena_ethdev.c
+@@ -39,7 +39,6 @@
+ #include <rte_dev.h>
+ #include <rte_errno.h>
+ #include <rte_version.h>
+-#include <rte_eal_memconfig.h>
+ #include <rte_net.h>
+ 
+ #include "ena_ethdev.h"
+@@ -271,22 +270,6 @@ static const struct eth_dev_ops ena_dev_ops = {
+ 	.reta_query           = ena_rss_reta_query,
+ };
+ 
+-#define NUMA_NO_NODE	SOCKET_ID_ANY
+-
+-static inline int ena_cpu_to_node(int cpu)
+-{
+-	struct rte_config *config = rte_eal_get_configuration();
+-	struct rte_fbarray *arr = &config->mem_config->memzones;
+-	const struct rte_memzone *mz;
+-
+-	if (unlikely(cpu >= RTE_MAX_MEMZONE))
+-		return NUMA_NO_NODE;
+-
+-	mz = rte_fbarray_get(arr, cpu);
+-
+-	return mz->socket_id;
+-}
+-
+ static inline void ena_rx_mbuf_prepare(struct rte_mbuf *mbuf,
+ 				       struct ena_com_rx_ctx *ena_rx_ctx)
+ {
+@@ -1127,7 +1110,7 @@ static int ena_create_io_queue(struct ena_ring *ring)
+ 	}
+ 	ctx.qid = ena_qid;
+ 	ctx.msix_vector = -1; /* interrupts not used */
+-	ctx.numa_node = ena_cpu_to_node(ring->id);
++	ctx.numa_node = ring->numa_socket_id;
+ 
+ 	rc = ena_com_create_io_queue(ena_dev, &ctx);
+ 	if (rc) {
+@@ -1225,7 +1208,7 @@ static int ena_queue_start(struct ena_ring *ring)
+ static int ena_tx_queue_setup(struct rte_eth_dev *dev,
+ 			      uint16_t queue_idx,
+ 			      uint16_t nb_desc,
+-			      __rte_unused unsigned int socket_id,
++			      unsigned int socket_id,
+ 			      const struct rte_eth_txconf *tx_conf)
+ {
+ 	struct ena_ring *txq = NULL;
+@@ -1263,6 +1246,7 @@ static int ena_tx_queue_setup(struct rte_eth_dev *dev,
+ 	txq->next_to_clean = 0;
+ 	txq->next_to_use = 0;
+ 	txq->ring_size = nb_desc;
++	txq->numa_socket_id = socket_id;
+ 
+ 	txq->tx_buffer_info = rte_zmalloc("txq->tx_buffer_info",
+ 					  sizeof(struct ena_tx_buffer) *
+@@ -1310,7 +1294,7 @@ static int ena_tx_queue_setup(struct rte_eth_dev *dev,
+ static int ena_rx_queue_setup(struct rte_eth_dev *dev,
+ 			      uint16_t queue_idx,
+ 			      uint16_t nb_desc,
+-			      __rte_unused unsigned int socket_id,
++			      unsigned int socket_id,
+ 			      __rte_unused const struct rte_eth_rxconf *rx_conf,
+ 			      struct rte_mempool *mp)
+ {
+@@ -1348,6 +1332,7 @@ static int ena_rx_queue_setup(struct rte_eth_dev *dev,
+ 	rxq->next_to_clean = 0;
+ 	rxq->next_to_use = 0;
+ 	rxq->ring_size = nb_desc;
++	rxq->numa_socket_id = socket_id;
+ 	rxq->mb_pool = mp;
+ 
+ 	rxq->rx_buffer_info = rte_zmalloc("rxq->buffer_info",
+diff --git a/drivers/net/ena/ena_ethdev.h b/drivers/net/ena/ena_ethdev.h
+index 221760c62..fafaed428 100644
+--- a/drivers/net/ena/ena_ethdev.h
++++ b/drivers/net/ena/ena_ethdev.h
+@@ -143,6 +143,8 @@ struct ena_ring {
+ 		struct ena_stats_rx rx_stats;
+ 		struct ena_stats_tx tx_stats;
+ 	};
++
++	unsigned int numa_socket_id;
+ } __rte_cache_aligned;
+ 
+ enum ena_adapter_state {
+-- 
+2.20.1
+

--- a/userspace/dpdk/19.02/0006-net-ena-fix-L4-checksum-Tx-offload.patch
+++ b/userspace/dpdk/19.02/0006-net-ena-fix-L4-checksum-Tx-offload.patch
@@ -1,0 +1,52 @@
+From 79d998f66a74834439e570454bdea79e3058bb2e Mon Sep 17 00:00:00 2001
+From: Maciej Bielski <mba@semihalf.com>
+Date: Thu, 1 Aug 2019 13:45:36 +0200
+Subject: [PATCH 6/6] net/ena: fix L4 checksum Tx offload
+
+[ upstream commit 40e7c02155625f18a87faf5e6a8cec2e986146e8 ]
+
+During an if-condition evaluation, a 2-bit flag evaluates to 'true' for
+'0x1', '0x2' and '0x3'. Thus, from this perspective these flags are
+indistinguishable. To make them distinct, respective bits must be
+extracted with a mask and then checked for strict equality.
+
+Specifically here, even if `PKT_TX_UDP_CKSUM` (value '0x3') was set, the
+expression `mbuf->ol_flags & PKT_TX_TCP` (the second flag of value
+'0x1') is evaluated first and the result is 'true'. In consequence, for
+UDP packets the execution flow enters an incorrect branch.
+
+Fixes: 56b8b9b7e5d2 ("net/ena: convert to new Tx offloads API")
+Cc: stable@dpdk.org
+
+Change-Id: I7917b209856f24e5d0b6481a94b322d09266bc5b
+Reported-by: Eduard Serra <eserra@vmware.com>
+Signed-off-by: Maciej Bielski <mba@semihalf.com>
+Acked-by: Michal Krawczyk <mk@semihalf.com>
+---
+ drivers/net/ena/ena_ethdev.c | 7 ++++---
+ 1 file changed, 4 insertions(+), 3 deletions(-)
+
+diff --git a/drivers/net/ena/ena_ethdev.c b/drivers/net/ena/ena_ethdev.c
+index ad7d8fed4..345b6c45e 100644
+--- a/drivers/net/ena/ena_ethdev.c
++++ b/drivers/net/ena/ena_ethdev.c
+@@ -329,12 +329,13 @@ static inline void ena_tx_mbuf_prepare(struct rte_mbuf *mbuf,
+ 		}
+ 
+ 		/* check if L4 checksum is needed */
+-		if ((mbuf->ol_flags & PKT_TX_TCP_CKSUM) &&
++		if (((mbuf->ol_flags & PKT_TX_L4_MASK) == PKT_TX_TCP_CKSUM) &&
+ 		    (queue_offloads & DEV_TX_OFFLOAD_TCP_CKSUM)) {
+ 			ena_tx_ctx->l4_proto = ENA_ETH_IO_L4_PROTO_TCP;
+ 			ena_tx_ctx->l4_csum_enable = true;
+-		} else if ((mbuf->ol_flags & PKT_TX_UDP_CKSUM) &&
+-			   (queue_offloads & DEV_TX_OFFLOAD_UDP_CKSUM)) {
++		} else if (((mbuf->ol_flags & PKT_TX_L4_MASK) ==
++				PKT_TX_UDP_CKSUM) &&
++				(queue_offloads & DEV_TX_OFFLOAD_UDP_CKSUM)) {
+ 			ena_tx_ctx->l4_proto = ENA_ETH_IO_L4_PROTO_UDP;
+ 			ena_tx_ctx->l4_csum_enable = true;
+ 		} else {
+-- 
+2.20.1
+

--- a/userspace/dpdk/19.05/0001-net-ena-fix-Tx-statistics.patch
+++ b/userspace/dpdk/19.05/0001-net-ena-fix-Tx-statistics.patch
@@ -1,0 +1,36 @@
+From 760b83027274fee51de1a948fd9aac44b863d86f Mon Sep 17 00:00:00 2001
+From: Rafal Kozik <rk@semihalf.com>
+Date: Tue, 14 May 2019 13:11:26 +0200
+Subject: [PATCH 1/4] net/ena: fix Tx statistics
+
+[ upstream commit 5673e285a63347068e51dbd191915348f6a580b0 ]
+
+Instead of counting number of used NIC Tx bufs just count number
+of Tx packets.
+
+Fixes: 45b6d86184fc ("net/ena: add per-queue software counters stats")
+Cc: stable@dpdk.org
+
+Change-Id: I8e3260f11ed4b98a5917634d6dfbe92b986c788a
+Signed-off-by: Rafal Kozik <rk@semihalf.com>
+Acked-by: Michal Krawczyk <mk@semihalf.com>
+---
+ drivers/net/ena/ena_ethdev.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/drivers/net/ena/ena_ethdev.c b/drivers/net/ena/ena_ethdev.c
+index 3eb38165c..178c23031 100644
+--- a/drivers/net/ena/ena_ethdev.c
++++ b/drivers/net/ena/ena_ethdev.c
+@@ -2391,7 +2391,7 @@ static uint16_t eth_ena_xmit_pkts(void *tx_queue, struct rte_mbuf **tx_pkts,
+ 		tx_info->tx_descs = nb_hw_desc;
+ 
+ 		next_to_use++;
+-		tx_ring->tx_stats.cnt += tx_info->num_of_bufs;
++		tx_ring->tx_stats.cnt++;
+ 		tx_ring->tx_stats.bytes += total_length;
+ 	}
+ 	tx_ring->tx_stats.available_desc =
+-- 
+2.20.1
+

--- a/userspace/dpdk/19.05/0002-net-ena-fix-Rx-checksum-errors-statistics.patch
+++ b/userspace/dpdk/19.05/0002-net-ena-fix-Rx-checksum-errors-statistics.patch
@@ -1,0 +1,52 @@
+From 160fbf354dee3ecaedb8c68f98d0cc5a08882d6b Mon Sep 17 00:00:00 2001
+From: Michal Krawczyk <mk@semihalf.com>
+Date: Tue, 28 May 2019 10:28:34 +0200
+Subject: [PATCH 2/4] net/ena: fix Rx checksum errors statistics
+
+[ upstream commit ef74b5f7b69b9502ddab81121611243efcfe1dde ]
+
+Rx checksum flags and input errors shouldn't be updated on Tx, as it
+would work only for packets forwarding.
+
+The ierrors statistic should be updated on Rx, right after checking
+Rx checksum flags if the Rx checksum offload is enabled.
+
+Fixes: 1173fca25af9 ("ena: add polling-mode driver")
+Cc: stable@dpdk.org
+
+Change-Id: I4ccf68bcb1ef6b50d01c811fc7f050a3d7ec9966
+Signed-off-by: Michal Krawczyk <mk@semihalf.com>
+---
+ drivers/net/ena/ena_ethdev.c | 8 +++-----
+ 1 file changed, 3 insertions(+), 5 deletions(-)
+
+diff --git a/drivers/net/ena/ena_ethdev.c b/drivers/net/ena/ena_ethdev.c
+index 178c23031..69740baf1 100644
+--- a/drivers/net/ena/ena_ethdev.c
++++ b/drivers/net/ena/ena_ethdev.c
+@@ -2104,8 +2104,10 @@ static uint16_t eth_ena_recv_pkts(void *rx_queue, struct rte_mbuf **rx_pkts,
+ 		ena_rx_mbuf_prepare(mbuf_head, &ena_rx_ctx);
+ 
+ 		if (unlikely(mbuf_head->ol_flags &
+-			(PKT_RX_IP_CKSUM_BAD | PKT_RX_L4_CKSUM_BAD)))
++				(PKT_RX_IP_CKSUM_BAD | PKT_RX_L4_CKSUM_BAD))) {
++			rte_atomic64_inc(&rx_ring->adapter->drv_stats->ierrors);
+ 			++rx_ring->rx_stats.bad_csum;
++		}
+ 
+ 		mbuf_head->hash.rss = ena_rx_ctx.hash;
+ 
+@@ -2333,10 +2335,6 @@ static uint16_t eth_ena_xmit_pkts(void *tx_queue, struct rte_mbuf **tx_pkts,
+ 		/* Set TX offloads flags, if applicable */
+ 		ena_tx_mbuf_prepare(mbuf, &ena_tx_ctx, tx_ring->offloads);
+ 
+-		if (unlikely(mbuf->ol_flags &
+-			     (PKT_RX_L4_CKSUM_BAD | PKT_RX_IP_CKSUM_BAD)))
+-			rte_atomic64_inc(&tx_ring->adapter->drv_stats->ierrors);
+-
+ 		rte_prefetch0(tx_pkts[(sent_idx + 4) & ring_mask]);
+ 
+ 		/* Process first segment taking into
+-- 
+2.20.1
+

--- a/userspace/dpdk/19.05/0003-net-ena-fix-assigning-NUMA-node-to-IO-queue.patch
+++ b/userspace/dpdk/19.05/0003-net-ena-fix-assigning-NUMA-node-to-IO-queue.patch
@@ -1,0 +1,118 @@
+From 944243bb6ded8a169bb91dbd25968ddd49e5109b Mon Sep 17 00:00:00 2001
+From: Michal Krawczyk <mk@semihalf.com>
+Date: Tue, 4 Jun 2019 12:59:36 +0200
+Subject: [PATCH 3/4] net/ena: fix assigning NUMA node to IO queue
+
+[ upstream commit 4217cb0b7d2c5385f06f531af7f14b860927aba7 ]
+
+Previous solution was using memzones in invalid way in hope to assign
+IO queue to the appropriate NUMA zone.
+
+The right way is to use socket_id from the rx/tx queue setup function
+and then pass it to the IO queue.
+
+Fixes: 3d3edc265fc8 ("net/ena: make coherent memory allocation NUMA-aware")
+Cc: stable@dpdk.org
+
+Change-Id: I252df018ca6aae9d566618b6967bec0c5b3d939a
+Signed-off-by: Michal Krawczyk <mk@semihalf.com>
+Reviewed-by: David Marchand <david.marchand@redhat.com>
+---
+ drivers/net/ena/ena_ethdev.c | 25 +++++--------------------
+ drivers/net/ena/ena_ethdev.h |  2 ++
+ 2 files changed, 7 insertions(+), 20 deletions(-)
+
+diff --git a/drivers/net/ena/ena_ethdev.c b/drivers/net/ena/ena_ethdev.c
+index 69740baf1..4def70c4b 100644
+--- a/drivers/net/ena/ena_ethdev.c
++++ b/drivers/net/ena/ena_ethdev.c
+@@ -40,7 +40,6 @@
+ #include <rte_dev.h>
+ #include <rte_errno.h>
+ #include <rte_version.h>
+-#include <rte_eal_memconfig.h>
+ #include <rte_net.h>
+ 
+ #include "ena_ethdev.h"
+@@ -272,22 +271,6 @@ static const struct eth_dev_ops ena_dev_ops = {
+ 	.reta_query           = ena_rss_reta_query,
+ };
+ 
+-#define NUMA_NO_NODE	SOCKET_ID_ANY
+-
+-static inline int ena_cpu_to_node(int cpu)
+-{
+-	struct rte_config *config = rte_eal_get_configuration();
+-	struct rte_fbarray *arr = &config->mem_config->memzones;
+-	const struct rte_memzone *mz;
+-
+-	if (unlikely(cpu >= RTE_MAX_MEMZONE))
+-		return NUMA_NO_NODE;
+-
+-	mz = rte_fbarray_get(arr, cpu);
+-
+-	return mz->socket_id;
+-}
+-
+ static inline void ena_rx_mbuf_prepare(struct rte_mbuf *mbuf,
+ 				       struct ena_com_rx_ctx *ena_rx_ctx)
+ {
+@@ -1126,7 +1109,7 @@ static int ena_create_io_queue(struct ena_ring *ring)
+ 	}
+ 	ctx.qid = ena_qid;
+ 	ctx.msix_vector = -1; /* interrupts not used */
+-	ctx.numa_node = ena_cpu_to_node(ring->id);
++	ctx.numa_node = ring->numa_socket_id;
+ 
+ 	rc = ena_com_create_io_queue(ena_dev, &ctx);
+ 	if (rc) {
+@@ -1224,7 +1207,7 @@ static int ena_queue_start(struct ena_ring *ring)
+ static int ena_tx_queue_setup(struct rte_eth_dev *dev,
+ 			      uint16_t queue_idx,
+ 			      uint16_t nb_desc,
+-			      __rte_unused unsigned int socket_id,
++			      unsigned int socket_id,
+ 			      const struct rte_eth_txconf *tx_conf)
+ {
+ 	struct ena_ring *txq = NULL;
+@@ -1262,6 +1245,7 @@ static int ena_tx_queue_setup(struct rte_eth_dev *dev,
+ 	txq->next_to_clean = 0;
+ 	txq->next_to_use = 0;
+ 	txq->ring_size = nb_desc;
++	txq->numa_socket_id = socket_id;
+ 
+ 	txq->tx_buffer_info = rte_zmalloc("txq->tx_buffer_info",
+ 					  sizeof(struct ena_tx_buffer) *
+@@ -1309,7 +1293,7 @@ static int ena_tx_queue_setup(struct rte_eth_dev *dev,
+ static int ena_rx_queue_setup(struct rte_eth_dev *dev,
+ 			      uint16_t queue_idx,
+ 			      uint16_t nb_desc,
+-			      __rte_unused unsigned int socket_id,
++			      unsigned int socket_id,
+ 			      __rte_unused const struct rte_eth_rxconf *rx_conf,
+ 			      struct rte_mempool *mp)
+ {
+@@ -1347,6 +1331,7 @@ static int ena_rx_queue_setup(struct rte_eth_dev *dev,
+ 	rxq->next_to_clean = 0;
+ 	rxq->next_to_use = 0;
+ 	rxq->ring_size = nb_desc;
++	rxq->numa_socket_id = socket_id;
+ 	rxq->mb_pool = mp;
+ 
+ 	rxq->rx_buffer_info = rte_zmalloc("rxq->buffer_info",
+diff --git a/drivers/net/ena/ena_ethdev.h b/drivers/net/ena/ena_ethdev.h
+index 221760c62..fafaed428 100644
+--- a/drivers/net/ena/ena_ethdev.h
++++ b/drivers/net/ena/ena_ethdev.h
+@@ -143,6 +143,8 @@ struct ena_ring {
+ 		struct ena_stats_rx rx_stats;
+ 		struct ena_stats_tx tx_stats;
+ 	};
++
++	unsigned int numa_socket_id;
+ } __rte_cache_aligned;
+ 
+ enum ena_adapter_state {
+-- 
+2.20.1
+

--- a/userspace/dpdk/19.05/0004-net-ena-fix-L4-checksum-Tx-offload.patch
+++ b/userspace/dpdk/19.05/0004-net-ena-fix-L4-checksum-Tx-offload.patch
@@ -1,0 +1,52 @@
+From 6dd476778b15dc6fb702df5c2783d7b93f25e2e9 Mon Sep 17 00:00:00 2001
+From: Maciej Bielski <mba@semihalf.com>
+Date: Thu, 1 Aug 2019 13:45:36 +0200
+Subject: [PATCH 4/4] net/ena: fix L4 checksum Tx offload
+
+[ upstream commit 40e7c02155625f18a87faf5e6a8cec2e986146e8 ]
+
+During an if-condition evaluation, a 2-bit flag evaluates to 'true' for
+'0x1', '0x2' and '0x3'. Thus, from this perspective these flags are
+indistinguishable. To make them distinct, respective bits must be
+extracted with a mask and then checked for strict equality.
+
+Specifically here, even if `PKT_TX_UDP_CKSUM` (value '0x3') was set, the
+expression `mbuf->ol_flags & PKT_TX_TCP` (the second flag of value
+'0x1') is evaluated first and the result is 'true'. In consequence, for
+UDP packets the execution flow enters an incorrect branch.
+
+Fixes: 56b8b9b7e5d2 ("net/ena: convert to new Tx offloads API")
+Cc: stable@dpdk.org
+
+Change-Id: I7917b209856f24e5d0b6481a94b322d09266bc5b
+Reported-by: Eduard Serra <eserra@vmware.com>
+Signed-off-by: Maciej Bielski <mba@semihalf.com>
+Acked-by: Michal Krawczyk <mk@semihalf.com>
+---
+ drivers/net/ena/ena_ethdev.c | 7 ++++---
+ 1 file changed, 4 insertions(+), 3 deletions(-)
+
+diff --git a/drivers/net/ena/ena_ethdev.c b/drivers/net/ena/ena_ethdev.c
+index 4def70c4b..e49edfa79 100644
+--- a/drivers/net/ena/ena_ethdev.c
++++ b/drivers/net/ena/ena_ethdev.c
+@@ -330,12 +330,13 @@ static inline void ena_tx_mbuf_prepare(struct rte_mbuf *mbuf,
+ 		}
+ 
+ 		/* check if L4 checksum is needed */
+-		if ((mbuf->ol_flags & PKT_TX_TCP_CKSUM) &&
++		if (((mbuf->ol_flags & PKT_TX_L4_MASK) == PKT_TX_TCP_CKSUM) &&
+ 		    (queue_offloads & DEV_TX_OFFLOAD_TCP_CKSUM)) {
+ 			ena_tx_ctx->l4_proto = ENA_ETH_IO_L4_PROTO_TCP;
+ 			ena_tx_ctx->l4_csum_enable = true;
+-		} else if ((mbuf->ol_flags & PKT_TX_UDP_CKSUM) &&
+-			   (queue_offloads & DEV_TX_OFFLOAD_UDP_CKSUM)) {
++		} else if (((mbuf->ol_flags & PKT_TX_L4_MASK) ==
++				PKT_TX_UDP_CKSUM) &&
++				(queue_offloads & DEV_TX_OFFLOAD_UDP_CKSUM)) {
+ 			ena_tx_ctx->l4_proto = ENA_ETH_IO_L4_PROTO_UDP;
+ 			ena_tx_ctx->l4_csum_enable = true;
+ 		} else {
+-- 
+2.20.1
+

--- a/userspace/dpdk/RELEASENOTES.md
+++ b/userspace/dpdk/RELEASENOTES.md
@@ -4,8 +4,31 @@ ___
 
 ### Normal releases
 
+#### v19.08
+_Release of the new version of the driver - r2.0.1._
+
+Bug Fixes:
+* Don't count Tx packets by summing up the number of buffers. It could cause
+  Tx packets to be too big for mbuf chains.
+* Fix Rx checksum error statistic counting. It was checked on Tx path instead of
+  Rx.
+* Fix assigning NUMA node to IO queues. DPDK has special API to do that from the
+  application perspective, PMD shouldn't be trying to resolve appropriate NUMA
+  node on it's own.
+* Fix admin CQ polling mode for 32-bit applications.
+* Mask mbuf flags and compare them with appropriate flags when Tx checksum
+  offload is used as '&' operator may give false positives.
+
+#### v19.05
+Bug Fixes:
+* Fix assignment of the Rx checksum capabilities - they were assigned to the Tx
+  variable.
+* Get device info statically, to make call to the get_eth_dev_info_get() safe
+  for the multithread applications.
+
 #### v19.02
 _Release of the new version of the driver - r2.0.0._
+
 New Features:
 * Add Low Latency Queue v2 (LLQv2). This feature reduces the latency
   of the packets by pushing the header directly through the PCI to the
@@ -21,7 +44,6 @@ New Features:
 Bug Fixes:
 * The reset routine was aligned with the DPDK API, so now it can be
   handled as in other PMDs.
-* Fix out of order (OOO) completion.
 * Fix memory leaks due to port stops and starts in the middle of
   traffic.
 * Assign to rte_errno only posivite values.
@@ -43,6 +65,7 @@ Minor Changes:
 _Release of the new version of the driver - r1.1.1._
 
 Bug fixes:
+* Fix out of order (OOO) completion.
 * Add information about VFIO support and instructions (Note - it should also
   apply to older DPDK releases, but it cannot be upstreamed for no longer
   supported versions).
@@ -137,6 +160,8 @@ Bug Fixes:
 * Improve safety of string handling.
 
 #### v16.07
+_Release of the new version of the driver - r1.0.0._
+
 New Features:
 * Configure debug memory area in the ENA which can be used for storing
   additional information.
@@ -153,7 +178,7 @@ Minor changes:
 * Doorbells optimization.
 
 #### v16.04
-_Release of the driver (r1.0.0)_
+_Release of the driver (unversioned)_
 
 Bug Fixes:
 * Use correct field for checking Rx offloads (the Tx field was used before).
@@ -171,7 +196,34 @@ Bug Fixes:
 
 There comes only backported patches.
 
+#### v18.11.3
+Bug fixes:
+* Fix Rx checksum error statistic counting. It was checked on Tx path instead of
+  Rx. (v19.08)
+* Fix assigning NUMA node to IO queues. DPDK has special API to do that from the
+  application perspective, PMD shouldn't be trying to resolve appropriate NUMA
+  node on it's own. (v19.08)
+* Fix admin CQ polling mode for 32-bit applications. (v19.08)
+* Mask mbuf flags and compare them with appropriate flags when Tx checksum
+  offload is used as '&' operator may give false positives. (v19.08)
+
+#### v18.11.1
+Bug fixes:
+* Assign to rte_errno only posivite values. (v19.02)
+* Fix device init with multi-process. (v19.02)
+
+#### v18.08.1
+Bug fixes:
+* Fix setting hash in the received mbuf. Instead of queue ID, value received
+  from the descriptor should be passed there. (v18.11)
+* Fix out of order (OOO) completion. (v18.11)
+* Recreate HW IO rings on start and stop to prevent descriptors memory leak
+  (v18.11)
+* Fix Rx out of order completion - the refill was not assigning mbufs to Rx
+  buffers properly (v18.11)
+
 #### v18.05.1
+Bug fixes:
 * Add checks for pointers acquired from rte_memzone_reserve in coherent memory
   allocation, to prevent device from accessing NULL pointers. (v18.08)
 * Do not allocate physically contiguous memory in the ENA_MEM_ALLOC_NODE, as it
@@ -184,7 +236,20 @@ There comes only backported patches.
   virtualized environment when link speed cannot be specified accurately.
   (v18.08)
 
+#### v17.11.6
+Bug fixes:
+* Assign to rte_errno only posivite values. (v19.02)
+* Fix device init with multi-process. (v19.02)
+* Update completion queue after Tx and Rx cleanups. (v19.02)
+* Add supported RSS offloads types. (v19.02)
+
+#### v17.11.5
+Bug fixes:
+* Fix setting hash in the received mbuf. Instead of queue ID, value received
+  from the descriptor should be passed there. (v18.11)
+
 #### v17.11.4
+Bug fixes:
 * Add checks for pointers acquired from rte_memzone_reserve in coherent memory
   allocation, to prevent device from accessing NULL pointers. (v18.08)
 * Do not allocate physically contiguous memory in the ENA_MEM_ALLOC_NODE, as it
@@ -219,8 +284,8 @@ Bug fixes:
 * Add information about VFIO support and instructions (Note - it should also
   apply to older DPDK releases, but it cannot be upstreamed for no longer
   supported version).
-* Fix Rx out of order completion - the refill was not assigning mbufs to Rx
-  buffers properly
+* Fix setting hash in the received mbuf. Instead of queue ID, value received
+  from the descriptor should be passed there. (v18.11)
 
 #### v16.11.8
 Bug fixes:


### PR DESCRIPTION
*Description of changes:*
Contains update of the release notes and backport of all important fixes released in 19.08 and 19.05 for ENA

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
