### PR TITLE
fbsd/ena: update ENA FreeBSD driver to v2.1.1

### DIFF
--- a/kernel/fbsd/ena/README
+++ b/kernel/fbsd/ena/README
@@ -3,7 +3,7 @@ FreeBSD kernel driver for Elastic Network Adapter (ENA) family:
 
 Version:
 ========
-v2.1.0
+v2.1.1
 
 Supported FreeBSD Versions:
 ===========================

--- a/kernel/fbsd/ena/RELEASENOTES.md
+++ b/kernel/fbsd/ena/RELEASENOTES.md
@@ -8,12 +8,23 @@ The driver was verified on the following distributions:
 
 **Releases:**
 * FreeBSD 11.3
-* FreeBSD 12.0
+* FreeBSD 12.1
 
 **Development:**
-* stable/11 - r352773
-* stable/12 - r352266
-* HEAD - r352778
+* stable/11 - r358167
+* stable/12 - r358167
+* HEAD - r358167
+
+## r2.1.1 release notes
+**New Features**
+* Initialize cleanup task as NET_TASK - it is required by the latest
+  stack updates as NET_TASK is entering epoch mode upon execution.
+
+**Bug Fixes**
+* Fix race on multiple queues when LLQ is being enabled with Tx checksum
+  offload. It could lead to data corruption.
+* Fix compilation for gcc by defining validate_rx_req_id() as
+  'static inline'.
 
 ## r2.1.0 release notes
 **New Features**

--- a/kernel/fbsd/ena/ena.c
+++ b/kernel/fbsd/ena/ena.c
@@ -558,14 +558,9 @@ ena_release_all_tx_dmamap(struct ena_ring *tx_ring)
 			}
 		}
 #endif /* DEV_NETMAP */
-		if (tx_info->map_head != NULL) {
-			bus_dmamap_destroy(tx_tag, tx_info->map_head);
-			tx_info->map_head = NULL;
-		}
-
-		if (tx_info->map_seg != NULL) {
-			bus_dmamap_destroy(tx_tag, tx_info->map_seg);
-			tx_info->map_seg = NULL;
+		if (tx_info->dmamap != NULL) {
+			bus_dmamap_destroy(tx_tag, tx_info->dmamap);
+			tx_info->dmamap = NULL;
 		}
 	}
 }
@@ -627,24 +622,13 @@ ena_setup_tx_resources(struct ena_adapter *adapter, int qid)
 	/* ... and create the buffer DMA maps */
 	for (i = 0; i < tx_ring->ring_size; i++) {
 		err = bus_dmamap_create(adapter->tx_buf_tag, 0,
-		    &tx_ring->tx_buffer_info[i].map_head);
+		    &tx_ring->tx_buffer_info[i].dmamap);
 		if (unlikely(err != 0)) {
 			ena_trace(ENA_ALERT,
-			    "Unable to create Tx DMA map_head for buffer %d\n",
+			    "Unable to create Tx DMA map for buffer %d\n",
 			    i);
 			goto err_map_release;
 		}
-		tx_ring->tx_buffer_info[i].seg_mapped = false;
-
-		err = bus_dmamap_create(adapter->tx_buf_tag, 0,
-		    &tx_ring->tx_buffer_info[i].map_seg);
-		if (unlikely(err != 0)) {
-			ena_trace(ENA_ALERT,
-			    "Unable to create Tx DMA map_seg for buffer %d\n",
-			    i);
-			goto err_map_release;
-		}
-		tx_ring->tx_buffer_info[i].head_mapped = false;
 
 #ifdef DEV_NETMAP
 		if (adapter->ifp->if_capenable & IFCAP_NETMAP) {
@@ -720,27 +704,12 @@ ena_free_tx_resources(struct ena_adapter *adapter, int qid)
 
 	/* Free buffer DMA maps, */
 	for (int i = 0; i < tx_ring->ring_size; i++) {
-		if (tx_ring->tx_buffer_info[i].head_mapped == true) {
-			bus_dmamap_sync(adapter->tx_buf_tag,
-			    tx_ring->tx_buffer_info[i].map_head,
-			    BUS_DMASYNC_POSTWRITE);
-			bus_dmamap_unload(adapter->tx_buf_tag,
-			    tx_ring->tx_buffer_info[i].map_head);
-			tx_ring->tx_buffer_info[i].head_mapped = false;
-		}
+		bus_dmamap_sync(adapter->tx_buf_tag,
+		    tx_ring->tx_buffer_info[i].dmamap, BUS_DMASYNC_POSTWRITE);
+		bus_dmamap_unload(adapter->tx_buf_tag,
+		    tx_ring->tx_buffer_info[i].dmamap);
 		bus_dmamap_destroy(adapter->tx_buf_tag,
-		    tx_ring->tx_buffer_info[i].map_head);
-
-		if (tx_ring->tx_buffer_info[i].seg_mapped == true) {
-			bus_dmamap_sync(adapter->tx_buf_tag,
-			    tx_ring->tx_buffer_info[i].map_seg,
-			    BUS_DMASYNC_POSTWRITE);
-			bus_dmamap_unload(adapter->tx_buf_tag,
-			    tx_ring->tx_buffer_info[i].map_seg);
-			tx_ring->tx_buffer_info[i].seg_mapped = false;
-		}
-		bus_dmamap_destroy(adapter->tx_buf_tag,
-		    tx_ring->tx_buffer_info[i].map_seg);
+		    tx_ring->tx_buffer_info[i].dmamap);
 
 #ifdef DEV_NETMAP
 		if (adapter->ifp->if_capenable & IFCAP_NETMAP) {
@@ -1209,21 +1178,9 @@ ena_free_tx_bufs(struct ena_adapter *adapter, unsigned int qid)
 			     qid, i);
 		}
 
-		if (tx_info->head_mapped == true) {
-			bus_dmamap_sync(adapter->tx_buf_tag, tx_info->map_head,
-			    BUS_DMASYNC_POSTWRITE);
-			bus_dmamap_unload(adapter->tx_buf_tag,
-			    tx_info->map_head);
-			tx_info->head_mapped = false;
-		}
-
-		if (tx_info->seg_mapped == true) {
-			bus_dmamap_sync(adapter->tx_buf_tag, tx_info->map_seg,
-			    BUS_DMASYNC_POSTWRITE);
-			bus_dmamap_unload(adapter->tx_buf_tag,
-			    tx_info->map_seg);
-			tx_info->seg_mapped = false;
-		}
+		bus_dmamap_sync(adapter->tx_buf_tag, tx_info->dmamap,
+		    BUS_DMASYNC_POSTWRITE);
+		bus_dmamap_unload(adapter->tx_buf_tag, tx_info->dmamap);
 
 		m_free(tx_info->mbuf);
 		tx_info->mbuf = NULL;
@@ -1353,7 +1310,11 @@ ena_create_io_queues(struct ena_adapter *adapter)
 	for (i = 0; i < adapter->num_queues; i++) {
 		queue = &adapter->que[i];
 
+#if __FreeBSD_version > 1300077
+		NET_TASK_INIT(&queue->cleanup_task, 0, ena_cleanup, queue);
+#else
 		TASK_INIT(&queue->cleanup_task, 0, ena_cleanup, queue);
+#endif
 		queue->cleanup_tq = taskqueue_create_fast("ena cleanup",
 		    M_WAITOK, taskqueue_thread_enqueue, &queue->cleanup_tq);
 

--- a/kernel/fbsd/ena/ena.h
+++ b/kernel/fbsd/ena/ena.h
@@ -41,7 +41,7 @@
 
 #define DRV_MODULE_VER_MAJOR	2
 #define DRV_MODULE_VER_MINOR	1
-#define DRV_MODULE_VER_SUBMINOR 0
+#define DRV_MODULE_VER_SUBMINOR 1
 
 #define DRV_MODULE_NAME		"ena"
 
@@ -241,13 +241,8 @@ struct ena_tx_buffer {
 	unsigned int tx_descs;
 	/* # of buffers used by this mbuf */
 	unsigned int num_of_bufs;
-	bus_dmamap_t map_head;
-	bus_dmamap_t map_seg;
 
-	/* Indicate if segments of the mbuf were mapped */
-	bool seg_mapped;
-	/* Indicate if bufs[0] maps the linear data of the mbuf */
-	bool head_mapped;
+	bus_dmamap_t dmamap;
 
 	/* Used to detect missing tx packets */
 	struct bintime timestamp;
@@ -489,9 +484,8 @@ void	ena_down(struct ena_adapter *);
 int	ena_restore_device(struct ena_adapter *);
 void	ena_destroy_device(struct ena_adapter *, bool);
 int	ena_refill_rx_bufs(struct ena_ring *, uint32_t);
-inline int validate_rx_req_id(struct ena_ring *, uint16_t);
 
-inline int
+static inline int
 validate_rx_req_id(struct ena_ring *rx_ring, uint16_t req_id)
 {
 	if (likely(req_id < rx_ring->ring_size))


### PR DESCRIPTION
Changes since last release (v2.1.0)

**New Features**
* Initialize cleanup task as NET_TASK - it is required by the latest
  stack updates as NET_TASK is entering epoch mode upon execution.

**Bug Fixes**
* Fix race on multiple queues when LLQ is being enabled with Tx checksum
  offload. It could lead to data corruption.
* Fix compilation for gcc by defining validate_rx_req_id() as
  'static inline'.

Signed-off-by: Michal Krawczyk <mk@semihalf.com>

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
