### PR TITLE
fbsd/ena: update ENA FreeBSD driver to v2.2.0

### DIFF
--- a/kernel/fbsd/ena/Makefile
+++ b/kernel/fbsd/ena/Makefile
@@ -1,7 +1,7 @@
 #
 # BSD LICENSE
 #
-# Copyright (c) 2015-2019 Amazon.com, Inc. or its affiliates.
+# Copyright (c) 2015-2020 Amazon.com, Inc. or its affiliates.
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
@@ -44,6 +44,7 @@ SRCS	+= ena_com.c ena_eth_com.c
 SRCS	+= ena.c ena_sysctl.c ena_datapath.c ena_netmap.c
 
 CFLAGS  += -DSMP -O2
+CFLAGS  += -I${.CURDIR}/ena_com
 
 # Enable debug messages and sysctls
 # CFLAGS  += -DENA_DEBUG
@@ -53,7 +54,7 @@ CFLAGS  += -DSMP -O2
 # CFLAGS += -DDEV_NETMAP
 
 clean:
-	rm -f opt_bdg.h device_if.h bus_if.h pci_if.h setdef* *_StripErr
+	rm -f opt_global.h opt_bdg.h device_if.h bus_if.h pci_if.h setdef* *_StripErr
 	rm -f *.o *.kld *.ko .*.o
 	rm -f @ export_syms machine x86
 

--- a/kernel/fbsd/ena/README
+++ b/kernel/fbsd/ena/README
@@ -3,7 +3,7 @@ FreeBSD kernel driver for Elastic Network Adapter (ENA) family:
 
 Version:
 ========
-v2.1.1
+v2.2.0
 
 Supported FreeBSD Versions:
 ===========================
@@ -124,9 +124,10 @@ Supported PCI vendor ID/device IDs:
 
 ENA Source Code Directory Structure:
 ====================================
-/*
 ena.[ch]   	  - Main FreeBSD kernel driver.
 ena_sysctl.[ch]   - ENA sysctl nodes for ENA configuration and statistics.
+ena_datapath.[ch] - Implementation of the main I/O path of the driver.
+ena_netmap.[ch]   - Main code supporting the netmap mode in the ENA.
 
 ena_com/*
 ena_com.[ch]      - Management communication layer. This layer is

--- a/kernel/fbsd/ena/RELEASENOTES.md
+++ b/kernel/fbsd/ena/RELEASENOTES.md
@@ -8,12 +8,57 @@ The driver was verified on the following distributions:
 
 **Releases:**
 * FreeBSD 11.3
+* FreeBSD 11.4-RC1
 * FreeBSD 12.1
 
 **Development:**
-* stable/11 - r358167
-* stable/12 - r358167
-* HEAD - r358167
+* stable/11 - r361551
+* stable/12 - r361551
+* HEAD - r361551
+
+## r2.2.0 release notes
+**New Features**
+* Add 'Tx drops' statistic which can be acquired by probing sysctl:
+  dev.ena.#.hw_stats.tx_drops
+  Where # stands for the interface number (0, 1, 2, ...).
+* Mark the driver as epoch ready, to properly support latest FreeBSD 13
+  stack changes.
+* Allow changing the number of IO queues during runtime by using sysctl:
+  dev.ena.#.io_queues_nb
+  Where # stands for the interface number (0, 1, 2, ...).
+* Generate default RSS key using RNG in order to improve security.
+
+**Bug Fixes**
+* Fix ENA IO memory read/write macros - add appropriate barriers where
+  needed and remove them where they are no longer needed.
+* Tx DMA mapping in case of the LLQ is being used was totally reworked
+  to improve stability and simplicity.
+* Rx refill optimization for low memory conditions - by default page
+  size clusters are now being used. It can be reverted, as it may affect
+  performance a bit, by setting sysctl "hw.ena.enable_9k_mbufs" to "1"
+  in "/boot/loader.conf" file.
+* Prevent driver from limiting IO queue number in case number of
+  MSIx vectors changed between device resets.
+* Update 'make clean' to remove 'opt_global.h' which started to appear on
+  FreeBSD 13.
+* Fix build for arm64 FreeBSD 12 as pmap_change_attr() isn't public
+  there, yet
+
+**Minor Changes**
+* Update HAL to the newer version.
+* Driver version can now be acquired probing sysctl:
+  hw.ena.driver_version
+* Improve locking on the configuration path - the driver was using two
+  different locks and now it is unified.
+* Rework Rx queue size configuration to do not use hardcoded values and
+  to avoid device reset upon doing so.
+* Tx buffer ring size reconfiguration was also reworked for the same
+  purpose.
+* Create queues with optional backoff in case the OS cannot provide
+  enough resources while setting up the queues.
+* Allow to disable meta caching for Tx path - it may be requested by the
+  device.
+* Set all sysctl nodes and procedures as MP safe.
 
 ## r2.1.1 release notes
 **New Features**

--- a/kernel/fbsd/ena/ena.c
+++ b/kernel/fbsd/ena/ena.c
@@ -1,7 +1,7 @@
 /*-
  * BSD LICENSE
  *
- * Copyright (c) 2015-2019 Amazon.com, Inc. or its affiliates.
+ * Copyright (c) 2015-2020 Amazon.com, Inc. or its affiliates.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -96,6 +96,8 @@ static inline void ena_free_counters(counter_u64_t *, int);
 static inline void ena_reset_counters(counter_u64_t *, int);
 static void	ena_init_io_rings_common(struct ena_adapter *,
     struct ena_ring *, uint16_t);
+static void	ena_init_io_rings_basic(struct ena_adapter *);
+static void	ena_init_io_rings_advanced(struct ena_adapter *);
 static void	ena_init_io_rings(struct ena_adapter *);
 static void	ena_free_io_ring_resources(struct ena_adapter *, unsigned int);
 static void	ena_free_all_io_rings_resources(struct ena_adapter *);
@@ -151,12 +153,9 @@ static int	ena_setup_ifnet(device_t, struct ena_adapter *,
 static int	ena_enable_wc(struct resource *);
 static int	ena_set_queues_placement_policy(device_t, struct ena_com_dev *,
     struct ena_admin_feature_llq_desc *, struct ena_llq_configurations *);
-static int	ena_calc_io_queue_num(struct ena_adapter *,
+static uint32_t	ena_calc_max_io_queue_num(device_t, struct ena_com_dev *,
     struct ena_com_dev_get_features_ctx *);
-static int	ena_calc_queue_size(struct ena_adapter *,
-    struct ena_calc_queue_size_ctx *);
-static int	ena_handle_updated_queues(struct ena_adapter *,
-    struct ena_com_dev_get_features_ctx *);
+static int	ena_calc_io_queue_size(struct ena_calc_queue_size_ctx *);
 static int	ena_rss_init_default(struct ena_adapter *);
 static void	ena_rss_init_default_deferred(void *);
 static void	ena_config_host_info(struct ena_com_dev *, device_t);
@@ -164,8 +163,7 @@ static int	ena_attach(device_t);
 static int	ena_detach(device_t);
 static int	ena_device_init(struct ena_adapter *, device_t,
     struct ena_com_dev_get_features_ctx *, int *);
-static int	ena_enable_msix_and_set_admin_interrupts(struct ena_adapter *,
-    int);
+static int	ena_enable_msix_and_set_admin_interrupts(struct ena_adapter *);
 static void ena_update_on_link_change(void *, struct ena_admin_aenq_entry *);
 static void	unimplemented_aenq_handler(void *,
     struct ena_admin_aenq_entry *);
@@ -258,6 +256,31 @@ fail_tag:
 	dma->paddr = 0;
 
 	return (error);
+}
+
+/*
+ * This function should generate unique key for the whole driver.
+ * If the key was already genereated in the previous call (for example
+ * for another adapter), then it should be returned instead.
+ */
+void
+ena_rss_key_fill(void *key, size_t size)
+{
+	static bool key_generated;
+	static uint8_t default_key[ENA_HASH_KEY_SIZE];
+
+	KASSERT(size <= ENA_HASH_KEY_SIZE, ("Requested more bytes than ENA RSS key can hold"));
+
+	if (!key_generated) {
+#if __FreeBSD_version > 1200028
+		arc4random_buf(default_key, ENA_HASH_KEY_SIZE);
+#else
+		arc4rand(default_key, ENA_HASH_KEY_SIZE, 0);
+#endif
+		key_generated = true;
+	}
+
+	memcpy(key, default_key, size);
 }
 
 static void
@@ -371,7 +394,7 @@ ena_init_io_rings_common(struct ena_adapter *adapter, struct ena_ring *ring,
 }
 
 static void
-ena_init_io_rings(struct ena_adapter *adapter)
+ena_init_io_rings_basic(struct ena_adapter *adapter)
 {
 	struct ena_com_dev *ena_dev;
 	struct ena_ring *txr, *rxr;
@@ -380,7 +403,7 @@ ena_init_io_rings(struct ena_adapter *adapter)
 
 	ena_dev = adapter->ena_dev;
 
-	for (i = 0; i < adapter->num_queues; i++) {
+	for (i = 0; i < adapter->num_io_queues; i++) {
 		txr = &adapter->tx_ring[i];
 		rxr = &adapter->rx_ring[i];
 
@@ -389,37 +412,8 @@ ena_init_io_rings(struct ena_adapter *adapter)
 		ena_init_io_rings_common(adapter, rxr, i);
 
 		/* TX specific ring state */
-		txr->ring_size = adapter->tx_ring_size;
 		txr->tx_max_header_size = ena_dev->tx_max_header_size;
 		txr->tx_mem_queue_type = ena_dev->tx_mem_queue_type;
-		txr->smoothed_interval =
-		    ena_com_get_nonadaptive_moderation_interval_tx(ena_dev);
-
-		/* Allocate a buf ring */
-		txr->buf_ring_size = adapter->buf_ring_size;
-		txr->br = buf_ring_alloc(txr->buf_ring_size, M_DEVBUF,
-		    M_WAITOK, &txr->ring_mtx);
-
-		/* Alloc TX statistics. */
-		ena_alloc_counters((counter_u64_t *)&txr->tx_stats,
-		    sizeof(txr->tx_stats));
-
-		/* RX specific ring state */
-		rxr->ring_size = adapter->rx_ring_size;
-		rxr->smoothed_interval =
-		    ena_com_get_nonadaptive_moderation_interval_rx(ena_dev);
-
-		/* Alloc RX statistics. */
-		ena_alloc_counters((counter_u64_t *)&rxr->rx_stats,
-		    sizeof(rxr->rx_stats));
-
-		/* Initialize locks */
-		snprintf(txr->mtx_name, nitems(txr->mtx_name), "%s:tx(%d)",
-		    device_get_nameunit(adapter->pdev), i);
-		snprintf(rxr->mtx_name, nitems(rxr->mtx_name), "%s:rx(%d)",
-		    device_get_nameunit(adapter->pdev), i);
-
-		mtx_init(&txr->ring_mtx, txr->mtx_name, NULL, MTX_DEF);
 
 		que = &adapter->que[i];
 		que->adapter = adapter;
@@ -431,7 +425,54 @@ ena_init_io_rings(struct ena_adapter *adapter)
 		rxr->que = que;
 
 		rxr->empty_rx_queue = 0;
+		rxr->rx_mbuf_sz = ena_mbuf_sz;
 	}
+}
+
+static void
+ena_init_io_rings_advanced(struct ena_adapter *adapter)
+{
+	struct ena_ring *txr, *rxr;
+	int i;
+
+	for (i = 0; i < adapter->num_io_queues; i++) {
+		txr = &adapter->tx_ring[i];
+		rxr = &adapter->rx_ring[i];
+
+		/* Allocate a buf ring */
+		txr->buf_ring_size = adapter->buf_ring_size;
+		txr->br = buf_ring_alloc(txr->buf_ring_size, M_DEVBUF,
+		    M_WAITOK, &txr->ring_mtx);
+
+		/* Allocate Tx statistics. */
+		ena_alloc_counters((counter_u64_t *)&txr->tx_stats,
+		    sizeof(txr->tx_stats));
+
+		/* Allocate Rx statistics. */
+		ena_alloc_counters((counter_u64_t *)&rxr->rx_stats,
+		    sizeof(rxr->rx_stats));
+
+		/* Initialize locks */
+		snprintf(txr->mtx_name, nitems(txr->mtx_name), "%s:tx(%d)",
+		    device_get_nameunit(adapter->pdev), i);
+		snprintf(rxr->mtx_name, nitems(rxr->mtx_name), "%s:rx(%d)",
+		    device_get_nameunit(adapter->pdev), i);
+
+		mtx_init(&txr->ring_mtx, txr->mtx_name, NULL, MTX_DEF);
+	}
+}
+
+static void
+ena_init_io_rings(struct ena_adapter *adapter)
+{
+	/*
+	 * IO rings initialization can be divided into the 2 steps:
+	 *   1. Initialize variables and fields with initial values and copy
+	 *      them from adapter/ena_dev (basic)
+	 *   2. Allocate mutex, counters and buf_ring (advanced)
+	 */
+	ena_init_io_rings_basic(adapter);
+	ena_init_io_rings_advanced(adapter);
 }
 
 static void
@@ -457,7 +498,7 @@ ena_free_all_io_rings_resources(struct ena_adapter *adapter)
 {
 	int i;
 
-	for (i = 0; i < adapter->num_queues; i++)
+	for (i = 0; i < adapter->num_io_queues; i++)
 		ena_free_io_ring_resources(adapter, i);
 
 }
@@ -508,9 +549,9 @@ ena_setup_rx_dma_tag(struct ena_adapter *adapter)
 	    ENA_DMA_BIT_MASK(adapter->dma_width), /* lowaddr of excl window  */
 	    BUS_SPACE_MAXADDR, 			  /* highaddr of excl window */
 	    NULL, NULL,				  /* filter, filterarg 	     */
-	    MJUM16BYTES,			  /* maxsize 		     */
+	    ena_mbuf_sz,			  /* maxsize 		     */
 	    adapter->max_rx_sgl_size,		  /* nsegments 		     */
-	    MJUM16BYTES,			  /* maxsegsize 	     */
+	    ena_mbuf_sz,			  /* maxsegsize 	     */
 	    0,					  /* flags 		     */
 	    NULL,				  /* lockfunc 		     */
 	    NULL,				  /* lockarg 		     */
@@ -741,8 +782,7 @@ ena_free_tx_resources(struct ena_adapter *adapter, int qid)
 	free(tx_ring->free_tx_ids, M_DEVBUF);
 	tx_ring->free_tx_ids = NULL;
 
-	ENA_MEM_FREE(adapter->ena_dev->dmadev,
-	    tx_ring->push_buf_intermediate_buf);
+	free(tx_ring->push_buf_intermediate_buf, M_DEVBUF);
 	tx_ring->push_buf_intermediate_buf = NULL;
 }
 
@@ -757,7 +797,7 @@ ena_setup_all_tx_resources(struct ena_adapter *adapter)
 {
 	int i, rc;
 
-	for (i = 0; i < adapter->num_queues; i++) {
+	for (i = 0; i < adapter->num_io_queues; i++) {
 		rc = ena_setup_tx_resources(adapter, i);
 		if (rc != 0) {
 			device_printf(adapter->pdev,
@@ -786,7 +826,7 @@ ena_free_all_tx_resources(struct ena_adapter *adapter)
 {
 	int i;
 
-	for (i = 0; i < adapter->num_queues; i++)
+	for (i = 0; i < adapter->num_io_queues; i++)
 		ena_free_tx_resources(adapter, i);
 }
 
@@ -917,7 +957,7 @@ ena_setup_all_rx_resources(struct ena_adapter *adapter)
 {
 	int i, rc = 0;
 
-	for (i = 0; i < adapter->num_queues; i++) {
+	for (i = 0; i < adapter->num_io_queues; i++) {
 		rc = ena_setup_rx_resources(adapter, i);
 		if (rc != 0) {
 			device_printf(adapter->pdev,
@@ -945,7 +985,7 @@ ena_free_all_rx_resources(struct ena_adapter *adapter)
 {
 	int i;
 
-	for (i = 0; i < adapter->num_queues; i++)
+	for (i = 0; i < adapter->num_io_queues; i++)
 		ena_free_rx_resources(adapter, i);
 }
 
@@ -963,7 +1003,8 @@ ena_alloc_rx_mbuf(struct ena_adapter *adapter,
 		return (0);
 
 	/* Get mbuf using UMA allocator */
-	rx_info->mbuf = m_getjcl(M_NOWAIT, MT_DATA, M_PKTHDR, MJUM16BYTES);
+	rx_info->mbuf = m_getjcl(M_NOWAIT, MT_DATA, M_PKTHDR,
+	    rx_ring->rx_mbuf_sz);
 
 	if (unlikely(rx_info->mbuf == NULL)) {
 		counter_u64_add(rx_ring->rx_stats.mjum_alloc_fail, 1);
@@ -974,7 +1015,7 @@ ena_alloc_rx_mbuf(struct ena_adapter *adapter,
 		}
 		mlen = MCLBYTES;
 	} else {
-		mlen = MJUM16BYTES;
+		mlen = rx_ring->rx_mbuf_sz;
 	}
 	/* Set mbuf length*/
 	rx_info->mbuf->m_pkthdr.len = rx_info->mbuf->m_len = mlen;
@@ -1086,12 +1127,170 @@ ena_refill_rx_bufs(struct ena_ring *rx_ring, uint32_t num)
 		     rx_ring->qid, i, num);
 	}
 
-	if (likely(i != 0)) {
-		wmb();
+	if (likely(i != 0))
 		ena_com_write_sq_doorbell(rx_ring->ena_com_io_sq);
-	}
+
 	rx_ring->next_to_use = next_to_use;
 	return (i);
+}
+
+int
+ena_update_buf_ring_size(struct ena_adapter *adapter,
+    uint32_t new_buf_ring_size)
+{
+	uint32_t old_buf_ring_size;
+	int rc = 0;
+	bool dev_was_up;
+
+	ENA_LOCK_LOCK(adapter);
+
+	old_buf_ring_size = adapter->buf_ring_size;
+	adapter->buf_ring_size = new_buf_ring_size;
+
+	dev_was_up = ENA_FLAG_ISSET(ENA_FLAG_DEV_UP, adapter);
+	ena_down(adapter);
+
+	/* Reconfigure buf ring for all Tx rings. */
+	ena_free_all_io_rings_resources(adapter);
+	ena_init_io_rings_advanced(adapter);
+	if (dev_was_up) {
+		/*
+		 * If ena_up() fails, it's not because of recent buf_ring size
+		 * changes. Because of that, we just want to revert old drbr
+		 * value and trigger the reset because something else had to
+		 * go wrong.
+		 */
+		rc = ena_up(adapter);
+		if (unlikely(rc != 0)) {
+			device_printf(adapter->pdev,
+			    "Failed to configure device after setting new drbr size: %u. Reverting old value: %u and triggering the reset\n",
+			    new_buf_ring_size, old_buf_ring_size);
+
+			/* Revert old size and trigger the reset */
+			adapter->buf_ring_size = old_buf_ring_size;
+			ena_free_all_io_rings_resources(adapter);
+			ena_init_io_rings_advanced(adapter);
+
+			ENA_FLAG_SET_ATOMIC(ENA_FLAG_DEV_UP_BEFORE_RESET,
+			    adapter);
+			ena_trigger_reset(adapter, ENA_REGS_RESET_OS_TRIGGER);
+
+		}
+	}
+
+	ENA_LOCK_UNLOCK(adapter);
+
+	return (rc);
+}
+
+int
+ena_update_queue_size(struct ena_adapter *adapter, uint32_t new_tx_size,
+    uint32_t new_rx_size)
+{
+	uint32_t old_tx_size, old_rx_size;
+	int rc = 0;
+	bool dev_was_up;
+
+	ENA_LOCK_LOCK(adapter);
+
+	old_tx_size = adapter->requested_tx_ring_size;
+	old_rx_size = adapter->requested_rx_ring_size;
+	adapter->requested_tx_ring_size = new_tx_size;
+	adapter->requested_rx_ring_size = new_rx_size;
+
+	dev_was_up = ENA_FLAG_ISSET(ENA_FLAG_DEV_UP, adapter);
+	ena_down(adapter);
+
+	/* Configure queues with new size. */
+	ena_init_io_rings_basic(adapter);
+	if (dev_was_up) {
+		rc = ena_up(adapter);
+		if (unlikely(rc != 0)) {
+			device_printf(adapter->pdev,
+			    "Failed to configure device with the new sizes - Tx: %u Rx: %u. Reverting old values - Tx: %u Rx: %u\n",
+			    new_tx_size, new_rx_size, old_tx_size, old_rx_size);
+
+			/* Revert old size. */
+			adapter->requested_tx_ring_size = old_tx_size;
+			adapter->requested_rx_ring_size = old_rx_size;
+			ena_init_io_rings_basic(adapter);
+
+			/* And try again. */
+			rc = ena_up(adapter);
+			if (unlikely(rc != 0)) {
+				device_printf(adapter->pdev,
+				    "Failed to revert old queue sizes. Triggering device reset.\n");
+				/*
+				 * If we've failed again, something had to go
+				 * wrong. After reset, the device should try to
+				 * go up
+				 */
+				ENA_FLAG_SET_ATOMIC(
+				    ENA_FLAG_DEV_UP_BEFORE_RESET, adapter);
+				ena_trigger_reset(adapter,
+				    ENA_REGS_RESET_OS_TRIGGER);
+			}
+		}
+	}
+
+	ENA_LOCK_UNLOCK(adapter);
+
+	return (rc);
+}
+
+static void
+ena_update_io_rings(struct ena_adapter *adapter, uint32_t num)
+{
+	ena_free_all_io_rings_resources(adapter);
+	/* Force indirection table to be reinitialized */
+	ena_com_rss_destroy(adapter->ena_dev);
+
+	adapter->num_io_queues = num;
+	ena_init_io_rings(adapter);
+}
+
+/* Caller should sanitize new_num */
+int
+ena_update_io_queue_nb(struct ena_adapter *adapter, uint32_t new_num)
+{
+	uint32_t old_num;
+	int rc = 0;
+	bool dev_was_up;
+
+	ENA_LOCK_LOCK(adapter);
+
+	dev_was_up = ENA_FLAG_ISSET(ENA_FLAG_DEV_UP, adapter);
+	old_num = adapter->num_io_queues;
+	ena_down(adapter);
+
+	ena_update_io_rings(adapter, new_num);
+
+	if (dev_was_up) {
+		rc = ena_up(adapter);
+		if (unlikely(rc != 0)) {
+			device_printf(adapter->pdev,
+			    "Failed to configure device with %u IO queues. "
+			    "Reverting to previous value: %u\n",
+			    new_num, old_num);
+
+			ena_update_io_rings(adapter, old_num);
+
+			rc = ena_up(adapter);
+			if (unlikely(rc != 0)) {
+				device_printf(adapter->pdev,
+				    "Failed to revert to previous setup IO "
+				    "queues. Triggering device reset.\n");
+				ENA_FLAG_SET_ATOMIC(
+				    ENA_FLAG_DEV_UP_BEFORE_RESET, adapter);
+				ena_trigger_reset(adapter,
+				    ENA_REGS_RESET_OS_TRIGGER);
+			}
+		}
+	}
+
+	ENA_LOCK_UNLOCK(adapter);
+
+	return (rc);
 }
 
 static void
@@ -1127,7 +1326,7 @@ ena_refill_all_rx_bufs(struct ena_adapter *adapter)
 	struct ena_ring *rx_ring;
 	int i, rc, bufs_num;
 
-	for (i = 0; i < adapter->num_queues; i++) {
+	for (i = 0; i < adapter->num_io_queues; i++) {
 		rx_ring = &adapter->rx_ring[i];
 		bufs_num = rx_ring->ring_size - 1;
 		rc = ena_refill_rx_bufs(rx_ring, bufs_num);
@@ -1145,7 +1344,7 @@ ena_free_all_rx_bufs(struct ena_adapter *adapter)
 {
 	int i;
 
-	for (i = 0; i < adapter->num_queues; i++)
+	for (i = 0; i < adapter->num_io_queues; i++)
 		ena_free_rx_bufs(adapter, i);
 }
 
@@ -1192,7 +1391,7 @@ static void
 ena_free_all_tx_bufs(struct ena_adapter *adapter)
 {
 
-	for (int i = 0; i < adapter->num_queues; i++)
+	for (int i = 0; i < adapter->num_io_queues; i++)
 		ena_free_tx_bufs(adapter, i);
 }
 
@@ -1202,7 +1401,7 @@ ena_destroy_all_tx_queues(struct ena_adapter *adapter)
 	uint16_t ena_qid;
 	int i;
 
-	for (i = 0; i < adapter->num_queues; i++) {
+	for (i = 0; i < adapter->num_io_queues; i++) {
 		ena_qid = ENA_IO_TXQ_IDX(i);
 		ena_com_destroy_io_queue(adapter->ena_dev, ena_qid);
 	}
@@ -1214,7 +1413,7 @@ ena_destroy_all_rx_queues(struct ena_adapter *adapter)
 	uint16_t ena_qid;
 	int i;
 
-	for (i = 0; i < adapter->num_queues; i++) {
+	for (i = 0; i < adapter->num_io_queues; i++) {
 		ena_qid = ENA_IO_RXQ_IDX(i);
 		ena_com_destroy_io_queue(adapter->ena_dev, ena_qid);
 	}
@@ -1226,7 +1425,7 @@ ena_destroy_all_io_queues(struct ena_adapter *adapter)
 	struct ena_que *queue;
 	int i;
 
-	for (i = 0; i < adapter->num_queues; i++) {
+	for (i = 0; i < adapter->num_io_queues; i++) {
 		queue = &adapter->que[i];
 		while (taskqueue_cancel(queue->cleanup_tq,
 		    &queue->cleanup_task, NULL))
@@ -1251,12 +1450,12 @@ ena_create_io_queues(struct ena_adapter *adapter)
 	int rc, i;
 
 	/* Create TX queues */
-	for (i = 0; i < adapter->num_queues; i++) {
+	for (i = 0; i < adapter->num_io_queues; i++) {
 		msix_vector = ENA_IO_IRQ_IDX(i);
 		ena_qid = ENA_IO_TXQ_IDX(i);
 		ctx.mem_queue_type = ena_dev->tx_mem_queue_type;
 		ctx.direction = ENA_COM_IO_QUEUE_DIRECTION_TX;
-		ctx.queue_size = adapter->tx_ring_size;
+		ctx.queue_size = adapter->requested_tx_ring_size;
 		ctx.msix_vector = msix_vector;
 		ctx.qid = ena_qid;
 		rc = ena_com_create_io_queue(ena_dev, &ctx);
@@ -1279,12 +1478,12 @@ ena_create_io_queues(struct ena_adapter *adapter)
 	}
 
 	/* Create RX queues */
-	for (i = 0; i < adapter->num_queues; i++) {
+	for (i = 0; i < adapter->num_io_queues; i++) {
 		msix_vector = ENA_IO_IRQ_IDX(i);
 		ena_qid = ENA_IO_RXQ_IDX(i);
 		ctx.mem_queue_type = ENA_ADMIN_PLACEMENT_POLICY_HOST;
 		ctx.direction = ENA_COM_IO_QUEUE_DIRECTION_RX;
-		ctx.queue_size = adapter->rx_ring_size;
+		ctx.queue_size = adapter->requested_rx_ring_size;
 		ctx.msix_vector = msix_vector;
 		ctx.qid = ena_qid;
 		rc = ena_com_create_io_queue(ena_dev, &ctx);
@@ -1307,7 +1506,7 @@ ena_create_io_queues(struct ena_adapter *adapter)
 		}
 	}
 
-	for (i = 0; i < adapter->num_queues; i++) {
+	for (i = 0; i < adapter->num_io_queues; i++) {
 		queue = &adapter->que[i];
 
 #if __FreeBSD_version > 1300077
@@ -1328,7 +1527,7 @@ ena_create_io_queues(struct ena_adapter *adapter)
 err_rx:
 	while (i--)
 		ena_com_destroy_io_queue(ena_dev, ENA_IO_RXQ_IDX(i));
-	i = adapter->num_queues;
+	i = adapter->num_io_queues;
 err_tx:
 	while (i--)
 		ena_com_destroy_io_queue(ena_dev, ENA_IO_TXQ_IDX(i));
@@ -1388,7 +1587,7 @@ ena_enable_msix(struct ena_adapter *adapter)
 	}
 
 	/* Reserved the max msix vectors we might need */
-	msix_vecs = ENA_MAX_MSIX_VEC(adapter->num_queues);
+	msix_vecs = ENA_MAX_MSIX_VEC(adapter->max_num_io_queues);
 
 	adapter->msix_entries = malloc(msix_vecs * sizeof(struct msix_entry),
 	    M_DEVBUF, M_WAITOK | M_ZERO);
@@ -1422,7 +1621,6 @@ ena_enable_msix(struct ena_adapter *adapter)
 		}
 		device_printf(dev, "Enable only %d MSI-x (out of %d), reduce "
 		    "the number of queues\n", msix_vecs, msix_req);
-		adapter->num_queues = msix_vecs - ENA_ADMIN_MSIX_VEC;
 	}
 
 	adapter->msix_vecs = msix_vecs;
@@ -1463,7 +1661,7 @@ ena_setup_io_intr(struct ena_adapter *adapter)
 	if (adapter->msix_entries == NULL)
 		return (EINVAL);
 
-	for (int i = 0; i < adapter->num_queues; i++) {
+	for (int i = 0; i < adapter->num_io_queues; i++) {
 		irq_idx = ENA_IO_IRQ_IDX(i);
 
 		snprintf(adapter->irq_tbl[irq_idx].name, ENA_IRQNAME_SIZE,
@@ -1711,7 +1909,7 @@ ena_unmask_all_io_irqs(struct ena_adapter *adapter)
 	int i;
 
 	/* Unmask interrupts for all queues */
-	for (i = 0; i < adapter->num_queues; i++) {
+	for (i = 0; i < adapter->num_io_queues; i++) {
 		ena_qid = ENA_IO_TXQ_IDX(i);
 		io_cq = &adapter->ena_dev->io_cq_queues[ena_qid];
 		ena_com_update_intr_reg(&intr_reg, 0, 0, true);
@@ -1725,6 +1923,18 @@ ena_rss_configure(struct ena_adapter *adapter)
 {
 	struct ena_com_dev *ena_dev = adapter->ena_dev;
 	int rc;
+
+	/* In case the RSS table was destroyed */
+	if (!ena_dev->rss.tbl_log_size) {
+		rc = ena_rss_init_default(adapter);
+		if (unlikely((rc != 0) && (rc != EOPNOTSUPP))) {
+			device_printf(adapter->pdev,
+			    "WARNING: RSS was not properly re-initialized,"
+			    " it will affect bandwidth\n");
+			ENA_FLAG_CLEAR_ATOMIC(ENA_FLAG_RSS_ACTIVE, adapter);
+			return (rc);
+		}
+	}
 
 	/* Set indirect table */
 	rc = ena_com_indirect_table_set(ena_dev);
@@ -1751,8 +1961,11 @@ ena_up_complete(struct ena_adapter *adapter)
 
 	if (likely(ENA_FLAG_ISSET(ENA_FLAG_RSS_ACTIVE, adapter))) {
 		rc = ena_rss_configure(adapter);
-		if (rc != 0)
+		if (rc != 0) {
+			device_printf(adapter->pdev,
+			    "Failed to configure RSS\n");
 			return (rc);
+		}
 	}
 
 	rc = ena_change_mtu(adapter->ifp, adapter->ifp->if_mtu);
@@ -1766,6 +1979,104 @@ ena_up_complete(struct ena_adapter *adapter)
 	return (0);
 }
 
+static void
+set_io_rings_size(struct ena_adapter *adapter, int new_tx_size,
+    int new_rx_size)
+{
+	int i;
+
+	for (i = 0; i < adapter->num_io_queues; i++) {
+		adapter->tx_ring[i].ring_size = new_tx_size;
+		adapter->rx_ring[i].ring_size = new_rx_size;
+	}
+}
+
+static int
+create_queues_with_size_backoff(struct ena_adapter *adapter)
+{
+	int rc;
+	uint32_t cur_rx_ring_size, cur_tx_ring_size;
+	uint32_t new_rx_ring_size, new_tx_ring_size;
+
+	/*
+	 * Current queue sizes might be set to smaller than the requested
+	 * ones due to past queue allocation failures.
+	 */
+	set_io_rings_size(adapter, adapter->requested_tx_ring_size,
+	    adapter->requested_rx_ring_size);
+
+	while (1) {
+		/* Allocate transmit descriptors */
+		rc = ena_setup_all_tx_resources(adapter);
+		if (unlikely(rc != 0)) {
+			ena_trace(ENA_ALERT, "err_setup_tx\n");
+			goto err_setup_tx;
+		}
+
+		/* Allocate receive descriptors */
+		rc = ena_setup_all_rx_resources(adapter);
+		if (unlikely(rc != 0)) {
+			ena_trace(ENA_ALERT, "err_setup_rx\n");
+			goto err_setup_rx;
+		}
+
+		/* Create IO queues for Rx & Tx */
+		rc = ena_create_io_queues(adapter);
+		if (unlikely(rc != 0)) {
+			ena_trace(ENA_ALERT,
+			    "create IO queues failed\n");
+			goto err_io_que;
+		}
+
+		return (0);
+
+err_io_que:
+		ena_free_all_rx_resources(adapter);
+err_setup_rx:
+		ena_free_all_tx_resources(adapter);
+err_setup_tx:
+		/*
+		 * Lower the ring size if ENOMEM. Otherwise, return the
+		 * error straightaway.
+		 */
+		if (unlikely(rc != ENOMEM)) {
+			ena_trace(ENA_ALERT,
+			    "Queue creation failed with error code: %d\n", rc);
+			return (rc);
+		}
+
+		cur_tx_ring_size = adapter->tx_ring[0].ring_size;
+		cur_rx_ring_size = adapter->rx_ring[0].ring_size;
+
+		device_printf(adapter->pdev,
+		    "Not enough memory to create queues with sizes TX=%d, RX=%d\n",
+		    cur_tx_ring_size, cur_rx_ring_size);
+
+		new_tx_ring_size = cur_tx_ring_size;
+		new_rx_ring_size = cur_rx_ring_size;
+
+		/*
+		 * Decrease the size of a larger queue, or decrease both if they are
+		 * the same size.
+		 */
+		if (cur_rx_ring_size <= cur_tx_ring_size)
+			new_tx_ring_size = cur_tx_ring_size / 2;
+		if (cur_rx_ring_size >= cur_tx_ring_size)
+			new_rx_ring_size = cur_rx_ring_size / 2;
+
+		if (new_tx_ring_size < ENA_MIN_RING_SIZE ||
+		    new_rx_ring_size < ENA_MIN_RING_SIZE) {
+			device_printf(adapter->pdev,
+			    "Queue creation failed with the smallest possible queue size"
+			    "of %d for both queues. Not retrying with smaller queues\n",
+			    ENA_MIN_RING_SIZE);
+			return (rc);
+		}
+
+		set_io_rings_size(adapter, new_tx_ring_size, new_rx_ring_size);
+	}
+}
+
 int
 ena_up(struct ena_adapter *adapter)
 {
@@ -1776,80 +2087,73 @@ ena_up(struct ena_adapter *adapter)
 		return (ENXIO);
 	}
 
-	if (!ENA_FLAG_ISSET(ENA_FLAG_DEV_UP, adapter)) {
-		device_printf(adapter->pdev, "device is going UP\n");
+	if (ENA_FLAG_ISSET(ENA_FLAG_DEV_UP, adapter))
+		return (0);
 
-		/* setup interrupts for IO queues */
-		rc = ena_setup_io_intr(adapter);
-		if (unlikely(rc != 0)) {
-			ena_trace(ENA_ALERT, "error setting up IO interrupt\n");
-			goto error;
-		}
-		rc = ena_request_io_irq(adapter);
-		if (unlikely(rc != 0)) {
-			ena_trace(ENA_ALERT, "err_req_irq\n");
-			goto error;
-		}
+	device_printf(adapter->pdev, "device is going UP\n");
 
-		/* allocate transmit descriptors */
-		rc = ena_setup_all_tx_resources(adapter);
-		if (unlikely(rc != 0)) {
-			ena_trace(ENA_ALERT, "err_setup_tx\n");
-			goto err_setup_tx;
-		}
-
-		/* allocate receive descriptors */
-		rc = ena_setup_all_rx_resources(adapter);
-		if (unlikely(rc != 0)) {
-			ena_trace(ENA_ALERT, "err_setup_rx\n");
-			goto err_setup_rx;
-		}
-
-		/* create IO queues for Rx & Tx */
-		rc = ena_create_io_queues(adapter);
-		if (unlikely(rc != 0)) {
-			ena_trace(ENA_ALERT,
-			    "create IO queues failed\n");
-			goto err_io_que;
-		}
-
-		if (ENA_FLAG_ISSET(ENA_FLAG_LINK_UP, adapter))
-			if_link_state_change(adapter->ifp, LINK_STATE_UP);
-
-		rc = ena_up_complete(adapter);
-		if (unlikely(rc != 0))
-			goto err_up_complete;
-
-		counter_u64_add(adapter->dev_stats.interface_up, 1);
-
-		ena_update_hwassist(adapter);
-
-		if_setdrvflagbits(adapter->ifp, IFF_DRV_RUNNING,
-		    IFF_DRV_OACTIVE);
-
-		/* Activate timer service only if the device is running.
-		 * If this flag is not set, it means that the driver is being
-		 * reset and timer service will be activated afterwards.
-		 */
-		if (ENA_FLAG_ISSET(ENA_FLAG_DEVICE_RUNNING, adapter)) {
-			callout_reset_sbt(&adapter->timer_service, SBT_1S,
-			    SBT_1S, ena_timer_service, (void *)adapter, 0);
-		}
-
-		ENA_FLAG_SET_ATOMIC(ENA_FLAG_DEV_UP, adapter);
-
-		ena_unmask_all_io_irqs(adapter);
+	/* setup interrupts for IO queues */
+	rc = ena_setup_io_intr(adapter);
+	if (unlikely(rc != 0)) {
+		ena_trace(ENA_ALERT, "error setting up IO interrupt\n");
+		goto error;
 	}
+	rc = ena_request_io_irq(adapter);
+	if (unlikely(rc != 0)) {
+		ena_trace(ENA_ALERT, "err_req_irq\n");
+		goto error;
+	}
+
+	device_printf(adapter->pdev,
+	    "Creating %u IO queues. Rx queue size: %d, Tx queue size: %d, "
+	    "LLQ is %s\n",
+	    adapter->num_io_queues,
+	    adapter->requested_rx_ring_size,
+	    adapter->requested_tx_ring_size,
+	    (adapter->ena_dev->tx_mem_queue_type ==
+	        ENA_ADMIN_PLACEMENT_POLICY_DEV) ?  "ENABLED" : "DISABLED");
+
+	rc = create_queues_with_size_backoff(adapter);
+	if (unlikely(rc != 0)) {
+		ena_trace(ENA_ALERT,
+		    "error creating queues with size backoff\n");
+		goto err_create_queues_with_backoff;
+	}
+
+	if (ENA_FLAG_ISSET(ENA_FLAG_LINK_UP, adapter))
+		if_link_state_change(adapter->ifp, LINK_STATE_UP);
+
+	rc = ena_up_complete(adapter);
+	if (unlikely(rc != 0))
+		goto err_up_complete;
+
+	counter_u64_add(adapter->dev_stats.interface_up, 1);
+
+	ena_update_hwassist(adapter);
+
+	if_setdrvflagbits(adapter->ifp, IFF_DRV_RUNNING,
+		IFF_DRV_OACTIVE);
+
+	/* Activate timer service only if the device is running.
+		* If this flag is not set, it means that the driver is being
+		* reset and timer service will be activated afterwards.
+		*/
+	if (ENA_FLAG_ISSET(ENA_FLAG_DEVICE_RUNNING, adapter)) {
+		callout_reset_sbt(&adapter->timer_service, SBT_1S,
+			SBT_1S, ena_timer_service, (void *)adapter, 0);
+	}
+
+	ENA_FLAG_SET_ATOMIC(ENA_FLAG_DEV_UP, adapter);
+
+	ena_unmask_all_io_irqs(adapter);
 
 	return (0);
 
 err_up_complete:
 	ena_destroy_all_io_queues(adapter);
-err_io_que:
 	ena_free_all_rx_resources(adapter);
-err_setup_rx:
 	ena_free_all_tx_resources(adapter);
-err_setup_tx:
+err_create_queues_with_backoff:
 	ena_free_io_irq(adapter);
 error:
 	return (rc);
@@ -1875,6 +2179,8 @@ ena_get_counter(if_t ifp, ift_counter cnt)
 		return (counter_u64_fetch(stats->tx_bytes));
 	case IFCOUNTER_IQDROPS:
 		return (counter_u64_fetch(stats->rx_drops));
+	case IFCOUNTER_OQDROPS:
+		return (counter_u64_fetch(stats->tx_drops));
 	default:
 		return (if_get_counter_default(ifp, cnt));
 	}
@@ -1893,13 +2199,13 @@ ena_media_status(if_t ifp, struct ifmediareq *ifmr)
 	struct ena_adapter *adapter = if_getsoftc(ifp);
 	ena_trace(ENA_DBG, "enter\n");
 
-	mtx_lock(&adapter->global_mtx);
+	ENA_LOCK_LOCK(adapter);
 
 	ifmr->ifm_status = IFM_AVALID;
 	ifmr->ifm_active = IFM_ETHER;
 
 	if (!ENA_FLAG_ISSET(ENA_FLAG_LINK_UP, adapter)) {
-		mtx_unlock(&adapter->global_mtx);
+		ENA_LOCK_UNLOCK(adapter);
 		ena_trace(ENA_INFO, "Link is down\n");
 		return;
 	}
@@ -1907,7 +2213,7 @@ ena_media_status(if_t ifp, struct ifmediareq *ifmr)
 	ifmr->ifm_status |= IFM_ACTIVE;
 	ifmr->ifm_active |= IFM_UNKNOWN | IFM_FDX;
 
-	mtx_unlock(&adapter->global_mtx);
+	ENA_LOCK_UNLOCK(adapter);
 }
 
 static void
@@ -1916,9 +2222,9 @@ ena_init(void *arg)
 	struct ena_adapter *adapter = (struct ena_adapter *)arg;
 
 	if (!ENA_FLAG_ISSET(ENA_FLAG_DEV_UP, adapter)) {
-		sx_xlock(&adapter->ioctl_sx);
+		ENA_LOCK_LOCK(adapter);
 		ena_up(adapter);
-		sx_unlock(&adapter->ioctl_sx);
+		ENA_LOCK_UNLOCK(adapter);
 	}
 }
 
@@ -1940,13 +2246,13 @@ ena_ioctl(if_t ifp, u_long command, caddr_t data)
 	case SIOCSIFMTU:
 		if (ifp->if_mtu == ifr->ifr_mtu)
 			break;
-		sx_xlock(&adapter->ioctl_sx);
+		ENA_LOCK_LOCK(adapter);
 		ena_down(adapter);
 
 		ena_change_mtu(ifp, ifr->ifr_mtu);
 
 		rc = ena_up(adapter);
-		sx_unlock(&adapter->ioctl_sx);
+		ENA_LOCK_UNLOCK(adapter);
 		break;
 
 	case SIOCSIFFLAGS:
@@ -1958,15 +2264,15 @@ ena_ioctl(if_t ifp, u_long command, caddr_t data)
 					    "ioctl promisc/allmulti\n");
 				}
 			} else {
-				sx_xlock(&adapter->ioctl_sx);
+				ENA_LOCK_LOCK(adapter);
 				rc = ena_up(adapter);
-				sx_unlock(&adapter->ioctl_sx);
+				ENA_LOCK_UNLOCK(adapter);
 			}
 		} else {
 			if ((if_getdrvflags(ifp) & IFF_DRV_RUNNING) != 0) {
-				sx_xlock(&adapter->ioctl_sx);
+				ENA_LOCK_LOCK(adapter);
 				ena_down(adapter);
-				sx_unlock(&adapter->ioctl_sx);
+				ENA_LOCK_UNLOCK(adapter);
 			}
 		}
 		break;
@@ -1991,10 +2297,10 @@ ena_ioctl(if_t ifp, u_long command, caddr_t data)
 
 			if ((reinit != 0) &&
 			    ((if_getdrvflags(ifp) & IFF_DRV_RUNNING) != 0)) {
-				sx_xlock(&adapter->ioctl_sx);
+				ENA_LOCK_LOCK(adapter);
 				ena_down(adapter);
 				rc = ena_up(adapter);
-				sx_unlock(&adapter->ioctl_sx);
+				ENA_LOCK_UNLOCK(adapter);
 			}
 		}
 
@@ -2101,14 +2407,19 @@ ena_setup_ifnet(device_t pdev, struct ena_adapter *adapter,
 	if_setdev(ifp, pdev);
 	if_setsoftc(ifp, adapter);
 
+#if __FreeBSD_version > 1300081
+	if_setflags(ifp, IFF_BROADCAST | IFF_SIMPLEX | IFF_MULTICAST |
+	    IFF_KNOWSEPOCH);
+#else
 	if_setflags(ifp, IFF_BROADCAST | IFF_SIMPLEX | IFF_MULTICAST);
+#endif
 	if_setinitfn(ifp, ena_init);
 	if_settransmitfn(ifp, ena_mq_start);
 	if_setqflushfn(ifp, ena_qflush);
 	if_setioctlfn(ifp, ena_ioctl);
 	if_setgetcounterfn(ifp, ena_get_counter);
 
-	if_setsendqlen(ifp, adapter->tx_ring_size);
+	if_setsendqlen(ifp, adapter->requested_tx_ring_size);
 	if_setsendqready(ifp);
 	if_setmtu(ifp, ETHERMTU);
 	if_setbaudrate(ifp, 0);
@@ -2148,42 +2459,42 @@ ena_down(struct ena_adapter *adapter)
 {
 	int rc;
 
-	if (ENA_FLAG_ISSET(ENA_FLAG_DEV_UP, adapter)) {
-		device_printf(adapter->pdev, "device is going DOWN\n");
+	if (!ENA_FLAG_ISSET(ENA_FLAG_DEV_UP, adapter))
+		return;
 
-		callout_drain(&adapter->timer_service);
+	device_printf(adapter->pdev, "device is going DOWN\n");
 
-		ENA_FLAG_CLEAR_ATOMIC(ENA_FLAG_DEV_UP, adapter);
-		if_setdrvflagbits(adapter->ifp, IFF_DRV_OACTIVE,
-		    IFF_DRV_RUNNING);
+	callout_drain(&adapter->timer_service);
 
-		ena_free_io_irq(adapter);
+	ENA_FLAG_CLEAR_ATOMIC(ENA_FLAG_DEV_UP, adapter);
+	if_setdrvflagbits(adapter->ifp, IFF_DRV_OACTIVE,
+		IFF_DRV_RUNNING);
 
-		if (ENA_FLAG_ISSET(ENA_FLAG_TRIGGER_RESET, adapter)) {
-			rc = ena_com_dev_reset(adapter->ena_dev,
-			    adapter->reset_reason);
-			if (unlikely(rc != 0))
-				device_printf(adapter->pdev,
-				    "Device reset failed\n");
-		}
+	ena_free_io_irq(adapter);
 
-		ena_destroy_all_io_queues(adapter);
-
-		ena_free_all_tx_bufs(adapter);
-		ena_free_all_rx_bufs(adapter);
-		ena_free_all_tx_resources(adapter);
-		ena_free_all_rx_resources(adapter);
-
-		counter_u64_add(adapter->dev_stats.interface_down, 1);
+	if (ENA_FLAG_ISSET(ENA_FLAG_TRIGGER_RESET, adapter)) {
+		rc = ena_com_dev_reset(adapter->ena_dev,
+			adapter->reset_reason);
+		if (unlikely(rc != 0))
+			device_printf(adapter->pdev,
+				"Device reset failed\n");
 	}
+
+	ena_destroy_all_io_queues(adapter);
+
+	ena_free_all_tx_bufs(adapter);
+	ena_free_all_rx_bufs(adapter);
+	ena_free_all_tx_resources(adapter);
+	ena_free_all_rx_resources(adapter);
+
+	counter_u64_add(adapter->dev_stats.interface_down, 1);
 }
 
-static int
-ena_calc_io_queue_num(struct ena_adapter *adapter,
+static uint32_t
+ena_calc_max_io_queue_num(device_t pdev, struct ena_com_dev *ena_dev,
     struct ena_com_dev_get_features_ctx *get_feat_ctx)
 {
-	struct ena_com_dev *ena_dev = adapter->ena_dev;
-	int io_tx_sq_num, io_tx_cq_num, io_rx_num, io_queue_num;
+	uint32_t io_tx_sq_num, io_tx_cq_num, io_rx_num, max_num_io_queues;
 
 	/* Regular queues capabilities */
 	if (ena_dev->supported_features & BIT(ENA_ADMIN_MAX_QUEUES_EXT)) {
@@ -2206,21 +2517,22 @@ ena_calc_io_queue_num(struct ena_adapter *adapter,
 	if (ena_dev->tx_mem_queue_type == ENA_ADMIN_PLACEMENT_POLICY_DEV)
 		io_tx_sq_num = get_feat_ctx->llq.max_llq_num;
 
-	io_queue_num = min_t(int, mp_ncpus, ENA_MAX_NUM_IO_QUEUES);
-	io_queue_num = min_t(int, io_queue_num, io_rx_num);
-	io_queue_num = min_t(int, io_queue_num, io_tx_sq_num);
-	io_queue_num = min_t(int, io_queue_num, io_tx_cq_num);
+	max_num_io_queues = min_t(uint32_t, mp_ncpus, ENA_MAX_NUM_IO_QUEUES);
+	max_num_io_queues = min_t(uint32_t, max_num_io_queues, io_rx_num);
+	max_num_io_queues = min_t(uint32_t, max_num_io_queues, io_tx_sq_num);
+	max_num_io_queues = min_t(uint32_t, max_num_io_queues, io_tx_cq_num);
 	/* 1 IRQ for for mgmnt and 1 IRQ for each TX/RX pair */
-	io_queue_num = min_t(int, io_queue_num,
-	    pci_msix_count(adapter->pdev) - 1);
+	max_num_io_queues = min_t(uint32_t, max_num_io_queues,
+	    pci_msix_count(pdev) - 1);
 
-	return (io_queue_num);
+	return (max_num_io_queues);
 }
 
 static int
 ena_enable_wc(struct resource *res)
 {
 #if defined(__i386) || defined(__amd64) || defined(__aarch64__)
+#if __FreeBSD_version > 1300039
 	vm_offset_t va;
 	vm_size_t len;
 	int rc;
@@ -2235,6 +2547,27 @@ ena_enable_wc(struct resource *res)
 	}
 
 	return (0);
+#else /* __FreeBSD_version <= 1300039 */
+	vm_offset_t va;
+	vm_size_t len;
+
+	va = (vm_offset_t)rman_get_virtual(res);
+	len = rman_get_size(res);
+#if defined(__i386) || defined(__amd64)
+	int rc;
+	rc = pmap_change_attr(va, len, VM_MEMATTR_WRITE_COMBINING);
+	if (unlikely(rc != 0))
+		ena_trace(ENA_ALERT, "pmap_change_attr failed, %d\n", rc);
+
+	return (rc);
+#else /* defined(__aarch64__) */
+	vm_paddr_t pa;
+	pa = rman_get_start(res);
+	pmap_kenter(va, len, pa, VM_MEMATTR_WRITE_COMBINING);
+
+	return (0);
+#endif /* defined(__i386) || defined(__amd64) */
+#endif /* __FreeBSD_version > 1300039 */
 #endif
 	return (EOPNOTSUPP);
 }
@@ -2307,136 +2640,73 @@ void set_default_llq_configurations(struct ena_llq_configurations *llq_config)
 }
 
 static int
-ena_calc_queue_size(struct ena_adapter *adapter,
-    struct ena_calc_queue_size_ctx *ctx)
+ena_calc_io_queue_size(struct ena_calc_queue_size_ctx *ctx)
 {
 	struct ena_admin_feature_llq_desc *llq = &ctx->get_feat_ctx->llq;
 	struct ena_com_dev *ena_dev = ctx->ena_dev;
 	uint32_t tx_queue_size = ENA_DEFAULT_RING_SIZE;
-	uint32_t rx_queue_size = adapter->rx_ring_size;
+	uint32_t rx_queue_size = ENA_DEFAULT_RING_SIZE;
+	uint32_t max_tx_queue_size;
+	uint32_t max_rx_queue_size;
 
 	if (ena_dev->supported_features & BIT(ENA_ADMIN_MAX_QUEUES_EXT)) {
 		struct ena_admin_queue_ext_feature_fields *max_queue_ext =
 		    &ctx->get_feat_ctx->max_queue_ext.max_queue_ext;
-		rx_queue_size = min_t(uint32_t, rx_queue_size,
-		    max_queue_ext->max_rx_cq_depth);
-		rx_queue_size = min_t(uint32_t, rx_queue_size,
+		max_rx_queue_size = min_t(uint32_t,
+		    max_queue_ext->max_rx_cq_depth,
 		    max_queue_ext->max_rx_sq_depth);
-		tx_queue_size = min_t(uint32_t, tx_queue_size,
-		    max_queue_ext->max_tx_cq_depth);
+		max_tx_queue_size = max_queue_ext->max_tx_cq_depth;
 
 		if (ena_dev->tx_mem_queue_type ==
 		    ENA_ADMIN_PLACEMENT_POLICY_DEV)
-			tx_queue_size = min_t(uint32_t, tx_queue_size,
+			max_tx_queue_size = min_t(uint32_t, max_tx_queue_size,
 			    llq->max_llq_depth);
 		else
-			tx_queue_size = min_t(uint32_t, tx_queue_size,
+			max_tx_queue_size = min_t(uint32_t, max_tx_queue_size,
 			    max_queue_ext->max_tx_sq_depth);
 
-		ctx->max_rx_sgl_size = min_t(uint16_t, ENA_PKT_MAX_BUFS,
-		    max_queue_ext->max_per_packet_rx_descs);
 		ctx->max_tx_sgl_size = min_t(uint16_t, ENA_PKT_MAX_BUFS,
 		    max_queue_ext->max_per_packet_tx_descs);
+		ctx->max_rx_sgl_size = min_t(uint16_t, ENA_PKT_MAX_BUFS,
+		    max_queue_ext->max_per_packet_rx_descs);
 	} else {
 		struct ena_admin_queue_feature_desc *max_queues =
 		    &ctx->get_feat_ctx->max_queues;
-		rx_queue_size = min_t(uint32_t, rx_queue_size,
-		    max_queues->max_cq_depth);
-		rx_queue_size = min_t(uint32_t, rx_queue_size,
+		max_rx_queue_size = min_t(uint32_t,
+		    max_queues->max_cq_depth,
 		    max_queues->max_sq_depth);
-		tx_queue_size = min_t(uint32_t, tx_queue_size,
-		    max_queues->max_cq_depth);
+		max_tx_queue_size = max_queues->max_cq_depth;
 
 		if (ena_dev->tx_mem_queue_type ==
 		    ENA_ADMIN_PLACEMENT_POLICY_DEV)
-			tx_queue_size = min_t(uint32_t, tx_queue_size,
+			max_tx_queue_size = min_t(uint32_t, max_tx_queue_size,
 			    llq->max_llq_depth);
 		else
-			tx_queue_size = min_t(uint32_t, tx_queue_size,
+			max_tx_queue_size = min_t(uint32_t, max_tx_queue_size,
 			    max_queues->max_sq_depth);
 
-		ctx->max_rx_sgl_size = min_t(uint16_t, ENA_PKT_MAX_BUFS,
-		    max_queues->max_packet_tx_descs);
 		ctx->max_tx_sgl_size = min_t(uint16_t, ENA_PKT_MAX_BUFS,
+		    max_queues->max_packet_tx_descs);
+		ctx->max_rx_sgl_size = min_t(uint16_t, ENA_PKT_MAX_BUFS,
 		    max_queues->max_packet_rx_descs);
 	}
 
 	/* round down to the nearest power of 2 */
-	rx_queue_size = 1 << (fls(rx_queue_size) - 1);
-	tx_queue_size = 1 << (fls(tx_queue_size) - 1);
+	max_tx_queue_size = 1 << (flsl(max_tx_queue_size) - 1);
+	max_rx_queue_size = 1 << (flsl(max_rx_queue_size) - 1);
 
-	if (unlikely(rx_queue_size == 0 || tx_queue_size == 0)) {
-		device_printf(ctx->pdev, "Invalid queue size\n");
-		return (EFAULT);
-	}
+	tx_queue_size = clamp_val(tx_queue_size, ENA_MIN_RING_SIZE,
+	    max_tx_queue_size);
+	rx_queue_size = clamp_val(rx_queue_size, ENA_MIN_RING_SIZE,
+	    max_rx_queue_size);
 
-	ctx->rx_queue_size = rx_queue_size;
+	tx_queue_size = 1 << (flsl(tx_queue_size) - 1);
+	rx_queue_size = 1 << (flsl(rx_queue_size) - 1);
+
+	ctx->max_tx_queue_size = max_tx_queue_size;
+	ctx->max_rx_queue_size = max_rx_queue_size;
 	ctx->tx_queue_size = tx_queue_size;
-
-	return (0);
-}
-
-static int
-ena_handle_updated_queues(struct ena_adapter *adapter,
-    struct ena_com_dev_get_features_ctx *get_feat_ctx)
-{
-	struct ena_com_dev *ena_dev = adapter->ena_dev;
-	struct ena_calc_queue_size_ctx calc_queue_ctx = { 0 };
-	device_t pdev = adapter->pdev;
-	bool are_queues_changed = false;
-	int io_queue_num, rc;
-
-	calc_queue_ctx.ena_dev = ena_dev;
-	calc_queue_ctx.get_feat_ctx = get_feat_ctx;
-	calc_queue_ctx.pdev = pdev;
-
-	io_queue_num = ena_calc_io_queue_num(adapter, get_feat_ctx);
-	rc = ena_calc_queue_size(adapter, &calc_queue_ctx);
-	if (unlikely(rc != 0 || io_queue_num <= 0))
-		return EFAULT;
-
-	if (adapter->tx_ring->buf_ring_size != adapter->buf_ring_size)
-		are_queues_changed = true;
-
-	if (unlikely(adapter->tx_ring_size > calc_queue_ctx.tx_queue_size ||
-	    adapter->rx_ring_size > calc_queue_ctx.rx_queue_size)) {
-		device_printf(pdev,
-		    "Not enough resources to allocate requested queue sizes "
-		    "(TX,RX)=(%d,%d), falling back to queue sizes "
-		    "(TX,RX)=(%d,%d)\n",
-		    adapter->tx_ring_size,
-		    adapter->rx_ring_size,
-		    calc_queue_ctx.tx_queue_size,
-		    calc_queue_ctx.rx_queue_size);
-		adapter->tx_ring_size = calc_queue_ctx.tx_queue_size;
-		adapter->rx_ring_size = calc_queue_ctx.rx_queue_size;
-		adapter->max_tx_sgl_size = calc_queue_ctx.max_tx_sgl_size;
-		adapter->max_rx_sgl_size = calc_queue_ctx.max_rx_sgl_size;
-		are_queues_changed = true;
-	}
-
-	if (unlikely(adapter->num_queues > io_queue_num)) {
-		device_printf(pdev,
-		    "Not enough resources to allocate %d queues, "
-		    "falling back to %d queues\n",
-		    adapter->num_queues, io_queue_num);
-		adapter->num_queues = io_queue_num;
-		if (ENA_FLAG_ISSET(ENA_FLAG_RSS_ACTIVE, adapter)) {
-			ena_com_rss_destroy(ena_dev);
-			rc = ena_rss_init_default(adapter);
-			if (unlikely(rc != 0) && (rc != EOPNOTSUPP)) {
-				device_printf(pdev, "Cannot init RSS rc: %d\n",
-				    rc);
-				return (rc);
-			}
-		}
-		are_queues_changed = true;
-	}
-
-	if (unlikely(are_queues_changed)) {
-		ena_free_all_io_rings_resources(adapter);
-		ena_init_io_rings(adapter);
-	}
+	ctx->rx_queue_size = rx_queue_size;
 
 	return (0);
 }
@@ -2455,7 +2725,7 @@ ena_rss_init_default(struct ena_adapter *adapter)
 	}
 
 	for (i = 0; i < ENA_RX_RSS_TABLE_SIZE; i++) {
-		qid = i % adapter->num_queues;
+		qid = i % adapter->num_io_queues;
 		rc = ena_com_indirect_table_fill_entry(ena_dev, i,
 		    ENA_IO_RXQ_IDX(qid));
 		if (unlikely((rc != 0) && (rc != EOPNOTSUPP))) {
@@ -2657,8 +2927,7 @@ err_mmio_read_less:
 	return (rc);
 }
 
-static int ena_enable_msix_and_set_admin_interrupts(struct ena_adapter *adapter,
-    int io_vectors)
+static int ena_enable_msix_and_set_admin_interrupts(struct ena_adapter *adapter)
 {
 	struct ena_com_dev *ena_dev = adapter->ena_dev;
 	int rc;
@@ -2697,12 +2966,16 @@ static void ena_keep_alive_wd(void *adapter_data,
 	struct ena_admin_aenq_keep_alive_desc *desc;
 	sbintime_t stime;
 	uint64_t rx_drops;
+	uint64_t tx_drops;
 
 	desc = (struct ena_admin_aenq_keep_alive_desc *)aenq_e;
 
 	rx_drops = ((uint64_t)desc->rx_drops_high << 32) | desc->rx_drops_low;
+	tx_drops = ((uint64_t)desc->tx_drops_high << 32) | desc->tx_drops_low;
 	counter_u64_zero(adapter->hw_stats.rx_drops);
 	counter_u64_add(adapter->hw_stats.rx_drops, rx_drops);
+	counter_u64_zero(adapter->hw_stats.tx_drops);
+	counter_u64_add(adapter->hw_stats.tx_drops, tx_drops);
 
 	stime = getsbinuptime();
 	atomic_store_rel_64(&adapter->keep_alive_timestamp, stime);
@@ -2725,10 +2998,7 @@ static void check_for_missing_keep_alive(struct ena_adapter *adapter)
 		device_printf(adapter->pdev,
 		    "Keep alive watchdog timeout.\n");
 		counter_u64_add(adapter->dev_stats.wd_expired, 1);
-		if (likely(!ENA_FLAG_ISSET(ENA_FLAG_TRIGGER_RESET, adapter))) {
-			adapter->reset_reason = ENA_REGS_RESET_KEEP_ALIVE_TO;
-			ENA_FLAG_SET_ATOMIC(ENA_FLAG_TRIGGER_RESET, adapter);
-		}
+		ena_trigger_reset(adapter, ENA_REGS_RESET_KEEP_ALIVE_TO);
 	}
 }
 
@@ -2740,10 +3010,7 @@ static void check_for_admin_com_state(struct ena_adapter *adapter)
 		device_printf(adapter->pdev,
 		    "ENA admin queue is not in running state!\n");
 		counter_u64_add(adapter->dev_stats.admin_q_pause, 1);
-		if (likely(!ENA_FLAG_ISSET(ENA_FLAG_TRIGGER_RESET, adapter))) {
-			adapter->reset_reason = ENA_REGS_RESET_ADMIN_TO;
-			ENA_FLAG_SET_ATOMIC(ENA_FLAG_TRIGGER_RESET, adapter);
-		}
+		ena_trigger_reset(adapter, ENA_REGS_RESET_ADMIN_TO);
 	}
 }
 
@@ -2762,10 +3029,7 @@ check_for_rx_interrupt_queue(struct ena_adapter *adapter,
 	if (rx_ring->no_interrupt_event_cnt == ENA_MAX_NO_INTERRUPT_ITERATIONS) {
 		device_printf(adapter->pdev, "Potential MSIX issue on Rx side "
 		    "Queue = %d. Reset the device\n", rx_ring->qid);
-		if (likely(!ENA_FLAG_ISSET(ENA_FLAG_TRIGGER_RESET, adapter))) {
-			adapter->reset_reason = ENA_REGS_RESET_MISS_INTERRUPT;
-			ENA_FLAG_SET_ATOMIC(ENA_FLAG_TRIGGER_RESET, adapter);
-		}
+		ena_trigger_reset(adapter, ENA_REGS_RESET_MISS_INTERRUPT);
 		return (EIO);
 	}
 
@@ -2803,13 +3067,8 @@ check_missing_comp_in_tx_queue(struct ena_adapter *adapter,
 			device_printf(adapter->pdev,
 			    "Potential MSIX issue on Tx side Queue = %d. "
 			    "Reset the device\n", tx_ring->qid);
-			if (likely(!ENA_FLAG_ISSET(ENA_FLAG_TRIGGER_RESET,
-			    adapter))) {
-				adapter->reset_reason =
-				    ENA_REGS_RESET_MISS_INTERRUPT;
-				ENA_FLAG_SET_ATOMIC(ENA_FLAG_TRIGGER_RESET,
-				    adapter);
-			}
+			ena_trigger_reset(adapter,
+			    ENA_REGS_RESET_MISS_INTERRUPT);
 			return (EIO);
 		}
 
@@ -2831,10 +3090,7 @@ check_missing_comp_in_tx_queue(struct ena_adapter *adapter,
 		    "The number of lost tx completion is above the threshold "
 		    "(%d > %d). Reset the device\n",
 		    missed_tx, adapter->missing_tx_threshold);
-		if (likely(!ENA_FLAG_ISSET(ENA_FLAG_TRIGGER_RESET, adapter))) {
-			adapter->reset_reason = ENA_REGS_RESET_MISS_TX_CMPL;
-			ENA_FLAG_SET_ATOMIC(ENA_FLAG_TRIGGER_RESET, adapter);
-		}
+		ena_trigger_reset(adapter, ENA_REGS_RESET_MISS_TX_CMPL);
 		rc = EIO;
 	}
 
@@ -2870,7 +3126,7 @@ check_for_missing_completions(struct ena_adapter *adapter)
 
 	budget = adapter->missing_tx_max_queues;
 
-	for (i = adapter->next_monitored_tx_qid; i < adapter->num_queues; i++) {
+	for (i = adapter->next_monitored_tx_qid; i < adapter->num_io_queues; i++) {
 		tx_ring = &adapter->tx_ring[i];
 		rx_ring = &adapter->rx_ring[i];
 
@@ -2889,7 +3145,7 @@ check_for_missing_completions(struct ena_adapter *adapter)
 		}
 	}
 
-	adapter->next_monitored_tx_qid = i % adapter->num_queues;
+	adapter->next_monitored_tx_qid = i % adapter->num_io_queues;
 }
 
 /* trigger rx cleanup after 2 consecutive detections */
@@ -2916,10 +3172,10 @@ check_for_empty_rx_ring(struct ena_adapter *adapter)
 	if (ENA_FLAG_ISSET(ENA_FLAG_TRIGGER_RESET, adapter))
 		return;
 
-	for (i = 0; i < adapter->num_queues; i++) {
+	for (i = 0; i < adapter->num_io_queues; i++) {
 		rx_ring = &adapter->rx_ring[i];
 
-		refill_required = ena_com_free_desc(rx_ring->ena_com_io_sq);
+		refill_required = ena_com_free_q_entries(rx_ring->ena_com_io_sq);
 		if (unlikely(refill_required == (rx_ring->ring_size - 1))) {
 			rx_ring->empty_rx_queue++;
 
@@ -3023,8 +3279,6 @@ ena_destroy_device(struct ena_adapter *adapter, bool graceful)
 	dev_up = ENA_FLAG_ISSET(ENA_FLAG_DEV_UP, adapter);
 	if (dev_up)
 		ENA_FLAG_SET_ATOMIC(ENA_FLAG_DEV_UP_BEFORE_RESET, adapter);
-	else
-		ENA_FLAG_CLEAR_ATOMIC(ENA_FLAG_DEV_UP_BEFORE_RESET, adapter);
 
 	if (!graceful)
 		ena_com_set_admin_running_state(ena_dev, false);
@@ -3042,6 +3296,15 @@ ena_destroy_device(struct ena_adapter *adapter, bool graceful)
 	ena_free_mgmnt_irq(adapter);
 
 	ena_disable_msix(adapter);
+
+	/*
+	 * IO rings resources should be freed because `ena_restore_device()`
+	 * calls (not directly) `ena_enable_msix()`, which re-allocates MSIX
+	 * vectors. The amount of MSIX vectors after destroy-restore may be
+	 * different than before. Therefore, IO rings resources should be
+	 * established from scratch each time.
+	 */
+	ena_free_all_io_rings_resources(adapter);
 
 	ena_com_abort_admin_commands(ena_dev);
 
@@ -3108,21 +3371,28 @@ ena_restore_device(struct ena_adapter *adapter)
 		goto err_device_destroy;
 	}
 
-	rc = ena_handle_updated_queues(adapter, &get_feat_ctx);
-	if (rc != 0)
-		goto err_device_destroy;
-
 	ENA_FLAG_CLEAR_ATOMIC(ENA_FLAG_ONGOING_RESET, adapter);
 	/* Make sure we don't have a race with AENQ Links state handler */
 	if (ENA_FLAG_ISSET(ENA_FLAG_LINK_UP, adapter))
 		if_link_state_change(ifp, LINK_STATE_UP);
 
-	rc = ena_enable_msix_and_set_admin_interrupts(adapter,
-	    adapter->num_queues);
+	rc = ena_enable_msix_and_set_admin_interrupts(adapter);
 	if (rc != 0) {
 		device_printf(dev, "Enable MSI-X failed\n");
 		goto err_device_destroy;
 	}
+
+	/*
+	 * Effective value of used MSIX vectors should be the same as before
+	 * `ena_destroy_device()`, if possible, or closest to it if less vectors
+	 * are available.
+	 */
+	if ((adapter->msix_vecs - ENA_ADMIN_MSIX_VEC) < adapter->num_io_queues)
+		adapter->num_io_queues =
+		    adapter->msix_vecs - ENA_ADMIN_MSIX_VEC;
+
+	/* Re-initialize rings basic information */
+	ena_init_io_rings(adapter);
 
 	/* If the interface was up before the reset bring it up */
 	if (ENA_FLAG_ISSET(ENA_FLAG_DEV_UP_BEFORE_RESET, adapter)) {
@@ -3147,6 +3417,7 @@ ena_restore_device(struct ena_adapter *adapter)
 		callout_reset_sbt(&adapter->timer_service, SBT_1S, SBT_1S,
 		    ena_timer_service, (void *)adapter, 0);
 	}
+	ENA_FLAG_CLEAR_ATOMIC(ENA_FLAG_DEV_UP_BEFORE_RESET, adapter);
 
 	device_printf(dev,
 	    "Device reset completed successfully, Driver info: %s\n", ena_version);
@@ -3181,10 +3452,10 @@ ena_reset_task(void *arg, int pending)
 		return;
 	}
 
-	sx_xlock(&adapter->ioctl_sx);
+	ENA_LOCK_LOCK(adapter);
 	ena_destroy_device(adapter, false);
 	ena_restore_device(adapter);
-	sx_unlock(&adapter->ioctl_sx);
+	ENA_LOCK_UNLOCK(adapter);
 }
 
 /**
@@ -3206,18 +3477,19 @@ ena_attach(device_t pdev)
 	static int version_printed;
 	struct ena_adapter *adapter;
 	struct ena_com_dev *ena_dev = NULL;
-	const char *queue_type_str;
-	int io_queue_num;
+	uint32_t max_num_io_queues;
 	int rid, rc;
 
 	adapter = device_get_softc(pdev);
 	adapter->pdev = pdev;
 
-	mtx_init(&adapter->global_mtx, "ENA global mtx", NULL, MTX_DEF);
-	sx_init(&adapter->ioctl_sx, "ENA ioctl sx");
+	ENA_LOCK_INIT(adapter);
 
-	/* Set up the timer service */
-	callout_init_mtx(&adapter->timer_service, &adapter->global_mtx, 0);
+	/*
+	 * Set up the timer service - driver is responsible for avoiding
+	 * concurrency, as the callout won't be using any locking inside.
+	 */
+	callout_init(&adapter->timer_service, true);
 	adapter->keep_alive_timeout = DEFAULT_KEEP_ALIVE_TO;
 	adapter->missing_tx_timeout = DEFAULT_TX_CMP_TO;
 	adapter->missing_tx_max_queues = DEFAULT_TX_MONITORED_QUEUES;
@@ -3281,11 +3553,10 @@ ena_attach(device_t pdev)
 		goto err_com_free;
 	}
 
-	if (ena_dev->tx_mem_queue_type == ENA_ADMIN_PLACEMENT_POLICY_HOST)
-		queue_type_str = "Regular";
-	else
-		queue_type_str = "Low Latency";
-	device_printf(pdev, "Placement policy: %s\n", queue_type_str);
+	if (ena_dev->tx_mem_queue_type == ENA_ADMIN_PLACEMENT_POLICY_DEV)
+		adapter->disable_meta_caching =
+		    !!(get_feat_ctx.llq.accel_mode.u.get.supported_flags &
+		    BIT(ENA_ADMIN_DISABLE_META_CACHING));
 
 	adapter->keep_alive_timestamp = getsbinuptime();
 
@@ -3294,36 +3565,33 @@ ena_attach(device_t pdev)
 	memcpy(adapter->mac_addr, get_feat_ctx.dev_attr.mac_addr,
 	    ETHER_ADDR_LEN);
 
+	calc_queue_ctx.pdev = pdev;
 	calc_queue_ctx.ena_dev = ena_dev;
 	calc_queue_ctx.get_feat_ctx = &get_feat_ctx;
-	calc_queue_ctx.pdev = pdev;
 
-	/* calculate IO queue number to create */
-	io_queue_num = ena_calc_io_queue_num(adapter, &get_feat_ctx);
-
-	ENA_ASSERT(io_queue_num > 0, "Invalid queue number: %d\n",
-	    io_queue_num);
-	adapter->num_queues = io_queue_num;
-
-	adapter->max_mtu = get_feat_ctx.dev_attr.max_mtu;
-	// Set the requested Rx ring size
-	adapter->rx_ring_size = ENA_DEFAULT_RING_SIZE;
-	/* calculatre ring sizes */
-	rc = ena_calc_queue_size(adapter, &calc_queue_ctx);
-	if (unlikely((rc != 0) || (io_queue_num <= 0))) {
+	/* Calculate initial and maximum IO queue number and size */
+	max_num_io_queues = ena_calc_max_io_queue_num(pdev, ena_dev,
+	    &get_feat_ctx);
+	rc = ena_calc_io_queue_size(&calc_queue_ctx);
+	if (unlikely((rc != 0) || (max_num_io_queues <= 0))) {
 		rc = EFAULT;
 		goto err_com_free;
 	}
 
-	adapter->reset_reason = ENA_REGS_RESET_NORMAL;
-
-	adapter->tx_ring_size = calc_queue_ctx.tx_queue_size;
-	adapter->rx_ring_size = calc_queue_ctx.rx_queue_size;
-
+	adapter->requested_tx_ring_size = calc_queue_ctx.tx_queue_size;
+	adapter->requested_rx_ring_size = calc_queue_ctx.rx_queue_size;
+	adapter->max_tx_ring_size = calc_queue_ctx.max_tx_queue_size;
+	adapter->max_rx_ring_size = calc_queue_ctx.max_rx_queue_size;
 	adapter->max_tx_sgl_size = calc_queue_ctx.max_tx_sgl_size;
 	adapter->max_rx_sgl_size = calc_queue_ctx.max_rx_sgl_size;
 
+	adapter->max_num_io_queues = max_num_io_queues;
+
 	adapter->buf_ring_size = ENA_DEFAULT_BUF_RING_SIZE;
+
+	adapter->max_mtu = get_feat_ctx.dev_attr.max_mtu;
+
+	adapter->reset_reason = ENA_REGS_RESET_NORMAL;
 
 	/* set up dma tags for rx and tx buffers */
 	rc = ena_setup_tx_dma_tag(adapter);
@@ -3338,20 +3606,26 @@ ena_attach(device_t pdev)
 		goto err_tx_tag_free;
 	}
 
-	/* initialize rings basic information */
-	device_printf(pdev,
-	    "Creating %d io queues. Rx queue size: %d, Tx queue size: %d\n",
-	    io_queue_num,
-	    calc_queue_ctx.rx_queue_size,
-	    calc_queue_ctx.tx_queue_size);
-	ena_init_io_rings(adapter);
-
-	rc = ena_enable_msix_and_set_admin_interrupts(adapter, io_queue_num);
+	/*
+	 * The amount of requested MSIX vectors is equal to
+	 * adapter::max_num_io_queues (see `ena_enable_msix()`), plus a constant
+	 * number of admin queue interrupts. The former is initially determined
+	 * by HW capabilities (see `ena_calc_max_io_queue_num())` but may not be
+	 * achieved if there are not enough system resources. By default, the
+	 * number of effectively used IO queues is the same but later on it can
+	 * be limited by the user using sysctl interface.
+	 */
+	rc = ena_enable_msix_and_set_admin_interrupts(adapter);
 	if (unlikely(rc != 0)) {
 		device_printf(pdev,
 		    "Failed to enable and set the admin interrupts\n");
 		goto err_io_free;
 	}
+	/* By default all of allocated MSIX vectors are actively used */
+	adapter->num_io_queues = adapter->msix_vecs - ENA_ADMIN_MSIX_VEC;
+
+	/* initialize rings basic information */
+	ena_init_io_rings(adapter);
 
 	/* setup network interface */
 	rc = ena_setup_ifnet(pdev, adapter, &get_feat_ctx);
@@ -3436,22 +3710,24 @@ ena_detach(device_t pdev)
 
 	ether_ifdetach(adapter->ifp);
 
-	/* Free reset task and callout */
+	/* Stop timer service */
+	ENA_LOCK_LOCK(adapter);
 	callout_drain(&adapter->timer_service);
+	ENA_LOCK_UNLOCK(adapter);
+
+	/* Release reset task */
 	while (taskqueue_cancel(adapter->reset_tq, &adapter->reset_task, NULL))
 		taskqueue_drain(adapter->reset_tq, &adapter->reset_task);
 	taskqueue_free(adapter->reset_tq);
 
-	sx_xlock(&adapter->ioctl_sx);
+	ENA_LOCK_LOCK(adapter);
 	ena_down(adapter);
 	ena_destroy_device(adapter, true);
-	sx_unlock(&adapter->ioctl_sx);
+	ENA_LOCK_UNLOCK(adapter);
 
 #ifdef DEV_NETMAP
 	netmap_detach(adapter->ifp);
 #endif /* DEV_NETMAP */
-
-	ena_free_all_io_rings_resources(adapter);
 
 	ena_free_counters((counter_u64_t *)&adapter->hw_stats,
 	    sizeof(struct ena_hw_stats));
@@ -3477,8 +3753,7 @@ ena_detach(device_t pdev)
 
 	ena_com_delete_host_info(ena_dev);
 
-	mtx_destroy(&adapter->global_mtx);
-	sx_destroy(&adapter->ioctl_sx);
+	ENA_LOCK_DESTROY(adapter);
 
 	if_free(adapter->ifp);
 

--- a/kernel/fbsd/ena/ena.h
+++ b/kernel/fbsd/ena/ena.h
@@ -1,7 +1,7 @@
 /*-
  * BSD LICENSE
  *
- * Copyright (c) 2015-2019 Amazon.com, Inc. or its affiliates.
+ * Copyright (c) 2015-2020 Amazon.com, Inc. or its affiliates.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -40,8 +40,8 @@
 #include "ena_com/ena_eth_com.h"
 
 #define DRV_MODULE_VER_MAJOR	2
-#define DRV_MODULE_VER_MINOR	1
-#define DRV_MODULE_VER_SUBMINOR 1
+#define DRV_MODULE_VER_MINOR	2
+#define DRV_MODULE_VER_SUBMINOR 0
 
 #define DRV_MODULE_NAME		"ena"
 
@@ -69,6 +69,7 @@
 #define	ENA_DEFAULT_BUF_RING_SIZE	4096
 
 #define	ENA_DEFAULT_RING_SIZE		1024
+#define	ENA_MIN_RING_SIZE		256
 
 /*
  * Refill Rx queue when number of required descriptors is above
@@ -220,8 +221,10 @@ struct ena_calc_queue_size_ctx {
 	struct ena_com_dev_get_features_ctx *get_feat_ctx;
 	struct ena_com_dev *ena_dev;
 	device_t pdev;
-	uint16_t rx_queue_size;
-	uint16_t tx_queue_size;
+	uint32_t tx_queue_size;
+	uint32_t rx_queue_size;
+	uint32_t max_tx_queue_size;
+	uint32_t max_rx_queue_size;
 	uint16_t max_tx_sgl_size;
 	uint16_t max_rx_sgl_size;
 };
@@ -307,20 +310,18 @@ struct ena_ring {
 
 	/* Determines if device will use LLQ or normal mode for TX */
 	enum ena_admin_placement_policy_type tx_mem_queue_type;
-	/* The maximum length the driver can push to the device (For LLQ) */
-	uint8_t tx_max_header_size;
+	union {
+		/* The maximum length the driver can push to the device (For LLQ) */
+		uint8_t tx_max_header_size;
+		/* The maximum (and default) mbuf size for the Rx descriptor. */
+		uint16_t rx_mbuf_sz;
+
+	};
 
 	bool first_interrupt;
 	uint16_t no_interrupt_event_cnt;
 
 	struct ena_com_rx_buf_info ena_bufs[ENA_PKT_MAX_BUFS];
-
-	/*
-	 * Fields used for Adaptive Interrupt Modulation - to be implemented in
-	 * the future releases
-	 */
-	uint32_t  smoothed_interval;
-	enum ena_intr_moder_level moder_tbl_idx;
 
 	struct ena_que *que;
 	struct lro_ctrl lro;
@@ -382,6 +383,7 @@ struct ena_hw_stats {
 	counter_u64_t tx_bytes;
 
 	counter_u64_t rx_drops;
+	counter_u64_t tx_drops;
 };
 
 /* Board specific private data structure */
@@ -397,8 +399,7 @@ struct ena_adapter {
 	struct resource *memory;
 	struct resource *registers;
 
-	struct mtx global_mtx;
-	struct sx ioctl_sx;
+	struct sx global_lock;
 
 	/* MSI-X */
 	struct msix_entry *msix_entries;
@@ -411,18 +412,21 @@ struct ena_adapter {
 
 	uint32_t max_mtu;
 
+	uint32_t num_io_queues;
+	uint32_t max_num_io_queues;
+
+	uint32_t requested_tx_ring_size;
+	uint32_t requested_rx_ring_size;
+
+	uint32_t max_tx_ring_size;
+	uint32_t max_rx_ring_size;
+
 	uint16_t max_tx_sgl_size;
 	uint16_t max_rx_sgl_size;
 
 	uint32_t tx_offload_cap;
 
-	/* Tx fast path data */
-	int num_queues;
-
-	unsigned int tx_ring_size;
-	unsigned int rx_ring_size;
-
-	uint16_t buf_ring_size;
+	uint32_t buf_ring_size;
 
 	/* RSS*/
 	uint8_t	rss_ind_tbl[ENA_RX_RSS_TABLE_SIZE];
@@ -457,6 +461,7 @@ struct ena_adapter {
 	sbintime_t missing_tx_timeout;
 	uint32_t missing_tx_max_queues;
 	uint32_t missing_tx_threshold;
+	bool disable_meta_caching;
 
 	/* Statistics */
 	struct ena_stats_dev dev_stats;
@@ -469,6 +474,15 @@ struct ena_adapter {
 #define	ENA_RING_MTX_TRYLOCK(_ring)		mtx_trylock(&(_ring)->ring_mtx)
 #define	ENA_RING_MTX_UNLOCK(_ring)		mtx_unlock(&(_ring)->ring_mtx)
 
+#define ENA_LOCK_INIT(adapter)			\
+	sx_init(&(adapter)->global_lock, "ENA global lock")
+#define ENA_LOCK_DESTROY(adapter)	sx_destroy(&(adapter)->global_lock)
+#define ENA_LOCK_LOCK(adapter)		sx_xlock(&(adapter)->global_lock)
+#define ENA_LOCK_UNLOCK(adapter)	sx_unlock(&(adapter)->global_lock)
+
+#define clamp_t(type, _x, min, max)	min_t(type, max_t(type, _x, min), max)
+#define clamp_val(val, lo, hi)		clamp_t(__typeof(val), val, lo, hi)
+
 static inline int ena_mbuf_count(struct mbuf *mbuf)
 {
 	int count = 1;
@@ -479,11 +493,26 @@ static inline int ena_mbuf_count(struct mbuf *mbuf)
 	return count;
 }
 
-int	ena_up(struct ena_adapter *);
-void	ena_down(struct ena_adapter *);
-int	ena_restore_device(struct ena_adapter *);
-void	ena_destroy_device(struct ena_adapter *, bool);
-int	ena_refill_rx_bufs(struct ena_ring *, uint32_t);
+int	ena_up(struct ena_adapter *adapter);
+void	ena_down(struct ena_adapter *adapter);
+int	ena_restore_device(struct ena_adapter *adapter);
+void	ena_destroy_device(struct ena_adapter *adapter, bool graceful);
+int	ena_refill_rx_bufs(struct ena_ring *rx_ring, uint32_t num);
+int	ena_update_buf_ring_size(struct ena_adapter *adapter,
+    uint32_t new_buf_ring_size);
+int	ena_update_queue_size(struct ena_adapter *adapter, uint32_t new_tx_size,
+    uint32_t new_rx_size);
+int	ena_update_io_queue_nb(struct ena_adapter *adapter, uint32_t new_num);
+
+static inline void
+ena_trigger_reset(struct ena_adapter *adapter,
+    enum ena_regs_reset_reason_types reset_reason)
+{
+	if (likely(!ENA_FLAG_ISSET(ENA_FLAG_TRIGGER_RESET, adapter))) {
+		adapter->reset_reason = reset_reason;
+		ENA_FLAG_SET_ATOMIC(ENA_FLAG_TRIGGER_RESET, adapter);
+	}
+}
 
 static inline int
 validate_rx_req_id(struct ena_ring *rx_ring, uint16_t req_id)
@@ -496,10 +525,7 @@ validate_rx_req_id(struct ena_ring *rx_ring, uint16_t req_id)
 	counter_u64_add(rx_ring->rx_stats.bad_req_id, 1);
 
 	/* Trigger device reset */
-	if (likely(!ENA_FLAG_ISSET(ENA_FLAG_TRIGGER_RESET, rx_ring->adapter))) {
-		rx_ring->adapter->reset_reason = ENA_REGS_RESET_INV_RX_REQ_ID;
-		ENA_FLAG_SET_ATOMIC(ENA_FLAG_TRIGGER_RESET, rx_ring->adapter);
-	}
+	ena_trigger_reset(rx_ring->adapter, ENA_REGS_RESET_INV_RX_REQ_ID);
 
 	return (EFAULT);
 }

--- a/kernel/fbsd/ena/ena_com/ena_com.c
+++ b/kernel/fbsd/ena/ena_com/ena_com.c
@@ -1,7 +1,7 @@
 /*-
  * BSD LICENSE
  *
- * Copyright (c) 2015-2019 Amazon.com, Inc. or its affiliates.
+ * Copyright (c) 2015-2020 Amazon.com, Inc. or its affiliates.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -49,22 +49,6 @@
 #define ENA_EXTENDED_STAT_GET_QUEUE(_funct_queue) (_funct_queue >> 16)
 
 #endif /* ENA_EXTENDED_STATS */
-#ifdef ENA_DEBUG
-#define ENA_TRACE_TYPE_OFFSET 0xF00
-#define ENA_TRACE_SEVERITY_OFFSET 0xF04
-
-#define ENA_TRACE_SEVERITY_MIN	1
-#define ENA_TRACE_SEVERITY_MAX	8
-
-#define ENA_TRACE_TYPE_IO		0x10000000
-#define ENA_TRACE_TYPE_ADMIN		0x20000000
-#define ENA_TRACE_TYPE_REGS		0x40000000
-#define ENA_TRACE_TYPE_ENA		0x80000000
-
-#define ENA_TRACE_TYPE_ALL	\
-	(ENA_TRACE_TYPE_IO | ENA_TRACE_TYPE_ADMIN | \
-	ENA_TRACE_TYPE_REGS | ENA_TRACE_TYPE_ENA)
-#endif /* ENA_DEBUG */
 
 #define ENA_CTRL_MAJOR		0
 #define ENA_CTRL_MINOR		0
@@ -86,7 +70,9 @@
 
 #define ENA_REGS_ADMIN_INTR_MASK 1
 
-#define ENA_POLL_MS	5
+#define ENA_MIN_POLL_US 100
+
+#define ENA_MAX_POLL_US 5000
 
 /*****************************************************************************/
 /*****************************************************************************/
@@ -115,7 +101,7 @@ struct ena_com_stats_ctx {
 	struct ena_admin_acq_get_stats_resp get_resp;
 };
 
-static inline int ena_com_mem_addr_set(struct ena_com_dev *ena_dev,
+static int ena_com_mem_addr_set(struct ena_com_dev *ena_dev,
 				       struct ena_common_mem_addr *ena_addr,
 				       dma_addr_t addr)
 {
@@ -216,7 +202,7 @@ static int ena_com_admin_init_aenq(struct ena_com_dev *dev,
 	return 0;
 }
 
-static inline void comp_ctxt_release(struct ena_com_admin_queue *queue,
+static void comp_ctxt_release(struct ena_com_admin_queue *queue,
 				     struct ena_comp_ctx *comp_ctx)
 {
 	comp_ctx->occupied = false;
@@ -229,6 +215,11 @@ static struct ena_comp_ctx *get_comp_ctxt(struct ena_com_admin_queue *queue,
 	if (unlikely(command_id >= queue->q_depth)) {
 		ena_trc_err("command id is larger than the queue size. cmd_id: %u queue size %d\n",
 			    command_id, queue->q_depth);
+		return NULL;
+	}
+
+	if (unlikely(!queue->comp_ctx)) {
+		ena_trc_err("Completion context is NULL\n");
 		return NULL;
 	}
 
@@ -305,7 +296,7 @@ static struct ena_comp_ctx *__ena_com_submit_admin_cmd(struct ena_com_admin_queu
 	return comp_ctx;
 }
 
-static inline int ena_com_init_comp_ctxt(struct ena_com_admin_queue *queue)
+static int ena_com_init_comp_ctxt(struct ena_com_admin_queue *queue)
 {
 	size_t size = queue->q_depth * sizeof(struct ena_comp_ctx);
 	struct ena_comp_ctx *comp_ctx;
@@ -425,6 +416,8 @@ static int ena_com_init_io_sq(struct ena_com_dev *ena_dev,
 		       0x0, io_sq->llq_info.desc_list_entry_size);
 		io_sq->llq_buf_ctrl.descs_left_in_line =
 			io_sq->llq_info.descs_num_before_header;
+		io_sq->disable_meta_caching =
+			io_sq->llq_info.disable_meta_caching;
 
 		if (io_sq->llq_info.max_entries_in_tx_burst > 0)
 			io_sq->entries_in_tx_burst_left =
@@ -550,12 +543,9 @@ static int ena_com_comp_status_to_errno(u8 comp_status)
 	if (unlikely(comp_status != 0))
 		ena_trc_err("admin command failed[%u]\n", comp_status);
 
-	if (unlikely(comp_status > ENA_ADMIN_UNKNOWN_ERROR))
-		return ENA_COM_INVAL;
-
 	switch (comp_status) {
 	case ENA_ADMIN_SUCCESS:
-		return 0;
+		return ENA_COM_OK;
 	case ENA_ADMIN_RESOURCE_ALLOCATION_FAILURE:
 		return ENA_COM_NO_MEM;
 	case ENA_ADMIN_UNSUPPORTED_OPCODE:
@@ -567,24 +557,32 @@ static int ena_com_comp_status_to_errno(u8 comp_status)
 		return ENA_COM_INVAL;
 	}
 
-	return 0;
+	return ENA_COM_INVAL;
+}
+
+static inline void ena_delay_exponential_backoff_us(u32 exp, u32 delay_us)
+{
+	delay_us = ENA_MAX32(ENA_MIN_POLL_US, delay_us);
+	delay_us = ENA_MIN32(delay_us * (1 << exp), ENA_MAX_POLL_US);
+	ENA_USLEEP(delay_us);
 }
 
 static int ena_com_wait_and_process_admin_cq_polling(struct ena_comp_ctx *comp_ctx,
 						     struct ena_com_admin_queue *admin_queue)
 {
 	unsigned long flags = 0;
-	unsigned long timeout;
+	ena_time_t timeout;
 	int ret;
+	u32 exp = 0;
 
 	timeout = ENA_GET_SYSTEM_TIMEOUT(admin_queue->completion_timeout);
 
 	while (1) {
-                ENA_SPINLOCK_LOCK(admin_queue->q_lock, flags);
-                ena_com_handle_admin_completion(admin_queue);
-                ENA_SPINLOCK_UNLOCK(admin_queue->q_lock, flags);
+		ENA_SPINLOCK_LOCK(admin_queue->q_lock, flags);
+		ena_com_handle_admin_completion(admin_queue);
+		ENA_SPINLOCK_UNLOCK(admin_queue->q_lock, flags);
 
-                if (comp_ctx->status != ENA_CMD_SUBMITTED)
+		if (comp_ctx->status != ENA_CMD_SUBMITTED)
 			break;
 
 		if (ENA_TIME_EXPIRE(timeout)) {
@@ -599,7 +597,7 @@ static int ena_com_wait_and_process_admin_cq_polling(struct ena_comp_ctx *comp_c
 			goto err;
 		}
 
-		ENA_MSLEEP(ENA_POLL_MS);
+		ena_delay_exponential_backoff_us(exp++, admin_queue->ena_dev->ena_min_poll_delay_us);
 	}
 
 	if (unlikely(comp_ctx->status == ENA_CMD_ABORTED)) {
@@ -644,6 +642,14 @@ static int ena_com_set_llq(struct ena_com_dev *ena_dev)
 	cmd.u.llq.entry_size_ctrl_enabled = llq_info->desc_list_entry_size_ctrl;
 	cmd.u.llq.desc_num_before_header_enabled = llq_info->descs_num_before_header;
 	cmd.u.llq.descriptors_stride_ctrl_enabled = llq_info->desc_stride_ctrl;
+
+	if (llq_info->disable_meta_caching)
+		cmd.u.llq.accel_mode.u.set.enabled_flags |=
+			BIT(ENA_ADMIN_DISABLE_META_CACHING);
+
+	if (llq_info->max_entries_in_tx_burst)
+		cmd.u.llq.accel_mode.u.set.enabled_flags |=
+			BIT(ENA_ADMIN_LIMIT_TX_BURST);
 
 	ret = ena_com_execute_admin_command(admin_queue,
 					    (struct ena_admin_aq_entry *)&cmd,
@@ -764,15 +770,21 @@ static int ena_com_config_llq_info(struct ena_com_dev *ena_dev,
 			    supported_feat,
 			    llq_info->descs_num_before_header);
 	}
+	/* Check for accelerated queue supported */
+	llq_info->disable_meta_caching =
+		llq_features->accel_mode.u.get.supported_flags &
+		BIT(ENA_ADMIN_DISABLE_META_CACHING);
 
-	llq_info->max_entries_in_tx_burst =
-		(u16)(llq_features->max_tx_burst_size /	llq_default_cfg->llq_ring_entry_size_value);
+	if (llq_features->accel_mode.u.get.supported_flags & BIT(ENA_ADMIN_LIMIT_TX_BURST))
+		llq_info->max_entries_in_tx_burst =
+			llq_features->accel_mode.u.get.max_tx_burst_size /
+			llq_default_cfg->llq_ring_entry_size_value;
 
 	rc = ena_com_set_llq(ena_dev);
 	if (rc)
 		ena_trc_err("Cannot set LLQ configuration: %d\n", rc);
 
-	return 0;
+	return rc;
 }
 
 static int ena_com_wait_and_process_admin_cq_interrupts(struct ena_comp_ctx *comp_ctx,
@@ -795,16 +807,25 @@ static int ena_com_wait_and_process_admin_cq_interrupts(struct ena_comp_ctx *com
 		admin_queue->stats.no_completion++;
 		ENA_SPINLOCK_UNLOCK(admin_queue->q_lock, flags);
 
-		if (comp_ctx->status == ENA_CMD_COMPLETED)
-			ena_trc_err("The ena device have completion but the driver didn't receive any MSI-X interrupt (cmd %d)\n",
-				    comp_ctx->cmd_opcode);
-		else
-			ena_trc_err("The ena device doesn't send any completion for the admin cmd %d status %d\n",
+		if (comp_ctx->status == ENA_CMD_COMPLETED) {
+			ena_trc_err("The ena device sent a completion but the driver didn't receive a MSI-X interrupt (cmd %d), autopolling mode is %s\n",
+				    comp_ctx->cmd_opcode, admin_queue->auto_polling ? "ON" : "OFF");
+			/* Check if fallback to polling is enabled */
+			if (admin_queue->auto_polling)
+				admin_queue->polling = true;
+		} else {
+			ena_trc_err("The ena device didn't send a completion for the admin cmd %d status %d\n",
 				    comp_ctx->cmd_opcode, comp_ctx->status);
-
-		admin_queue->running_state = false;
-		ret = ENA_COM_TIMER_EXPIRED;
-		goto err;
+		}
+		/* Check if shifted to polling mode.
+		 * This will happen if there is a completion without an interrupt
+		 * and autopolling mode is enabled. Continuing normal execution in such case
+		 */
+		if (!admin_queue->polling) {
+			admin_queue->running_state = false;
+			ret = ENA_COM_TIMER_EXPIRED;
+			goto err;
+		}
 	}
 
 	ret = ena_com_comp_status_to_errno(comp_ctx->comp_status);
@@ -960,7 +981,9 @@ static void ena_com_io_queue_free(struct ena_com_dev *ena_dev,
 	}
 
 	if (io_sq->bounce_buf_ctrl.base_buffer) {
-		ENA_MEM_FREE(ena_dev->dmadev, io_sq->bounce_buf_ctrl.base_buffer);
+		ENA_MEM_FREE(ena_dev->dmadev,
+			     io_sq->bounce_buf_ctrl.base_buffer,
+			     (io_sq->llq_info.desc_list_entry_size * ENA_COM_BOUNCE_BUFFER_CNTRL_CNT));
 		io_sq->bounce_buf_ctrl.base_buffer = NULL;
 	}
 }
@@ -968,12 +991,13 @@ static void ena_com_io_queue_free(struct ena_com_dev *ena_dev,
 static int wait_for_reset_state(struct ena_com_dev *ena_dev, u32 timeout,
 				u16 exp_state)
 {
-	u32 val, i;
+	u32 val, exp = 0;
+	ena_time_t timeout_stamp;
 
-	/* Convert timeout from resolution of 100ms to ENA_POLL_MS */
-	timeout = (timeout * 100) / ENA_POLL_MS;
+	/* Convert timeout from resolution of 100ms to us resolution. */
+	timeout_stamp = ENA_GET_SYSTEM_TIMEOUT(100 * 1000 * timeout);
 
-	for (i = 0; i < timeout; i++) {
+	while (1) {
 		val = ena_com_reg_bar_read32(ena_dev, ENA_REGS_DEV_STS_OFF);
 
 		if (unlikely(val == ENA_MMIO_READ_TIMEOUT)) {
@@ -985,10 +1009,11 @@ static int wait_for_reset_state(struct ena_com_dev *ena_dev, u32 timeout,
 			exp_state)
 			return 0;
 
-		ENA_MSLEEP(ENA_POLL_MS);
-	}
+		if (ENA_TIME_EXPIRE(timeout_stamp))
+			return ENA_COM_TIMER_EXPIRED;
 
-	return ENA_COM_TIMER_EXPIRED;
+		ena_delay_exponential_backoff_us(exp++, ena_dev->ena_min_poll_delay_us);
+	}
 }
 
 static bool ena_com_check_supported_feature_id(struct ena_com_dev *ena_dev,
@@ -1071,9 +1096,33 @@ static int ena_com_get_feature(struct ena_com_dev *ena_dev,
 				      feature_ver);
 }
 
+int ena_com_get_current_hash_function(struct ena_com_dev *ena_dev)
+{
+	return ena_dev->rss.hash_func;
+}
+
+static void ena_com_hash_key_fill_default_key(struct ena_com_dev *ena_dev)
+{
+	struct ena_admin_feature_rss_flow_hash_control *hash_key =
+		(ena_dev->rss).hash_key;
+
+	ENA_RSS_FILL_KEY(&hash_key->key, sizeof(hash_key->key));
+	/* The key buffer is stored in the device in an array of
+	 * uint32 elements. Therefore the number of elements can be derived
+	 * by dividing the buffer length by the size of each array element.
+	 * In current implementation each element is sized at uint32_t
+	 * so it's actually a division by 4 but if the element size changes,
+	 * there is no need to rewrite this code.
+	 */
+	hash_key->keys_num = sizeof(hash_key->key) / sizeof(hash_key->key[0]);
+}
+
 static int ena_com_hash_key_allocate(struct ena_com_dev *ena_dev)
 {
 	struct ena_rss *rss = &ena_dev->rss;
+
+	if (!ena_com_check_supported_feature_id(ena_dev, ENA_ADMIN_RSS_HASH_FUNCTION))
+		return ENA_COM_UNSUPPORTED;
 
 	ENA_MEM_ALLOC_COHERENT(ena_dev->dmadev,
 			       sizeof(*rss->hash_key),
@@ -1202,7 +1251,9 @@ static void ena_com_indirect_table_destroy(struct ena_com_dev *ena_dev)
 	rss->rss_ind_tbl = NULL;
 
 	if (rss->host_rss_ind_tbl)
-		ENA_MEM_FREE(ena_dev->dmadev, rss->host_rss_ind_tbl);
+		ENA_MEM_FREE(ena_dev->dmadev,
+			     rss->host_rss_ind_tbl,
+			     ((1ULL << rss->tbl_log_size) * sizeof(u16)));
 	rss->host_rss_ind_tbl = NULL;
 }
 
@@ -1303,63 +1354,29 @@ static int ena_com_ind_tbl_convert_to_device(struct ena_com_dev *ena_dev)
 	return 0;
 }
 
-static int ena_com_ind_tbl_convert_from_device(struct ena_com_dev *ena_dev)
-{
-	u16 dev_idx_to_host_tbl[ENA_TOTAL_NUM_QUEUES] = { (u16)-1 };
-	struct ena_rss *rss = &ena_dev->rss;
-	u8 idx;
-	u16 i;
-
-	for (i = 0; i < ENA_TOTAL_NUM_QUEUES; i++)
-		dev_idx_to_host_tbl[ena_dev->io_sq_queues[i].idx] = i;
-
-	for (i = 0; i < 1 << rss->tbl_log_size; i++) {
-		if (rss->rss_ind_tbl[i].cq_idx > ENA_TOTAL_NUM_QUEUES)
-			return ENA_COM_INVAL;
-		idx = (u8)rss->rss_ind_tbl[i].cq_idx;
-
-		if (dev_idx_to_host_tbl[idx] > ENA_TOTAL_NUM_QUEUES)
-			return ENA_COM_INVAL;
-
-		rss->host_rss_ind_tbl[i] = dev_idx_to_host_tbl[idx];
-	}
-
-	return 0;
-}
-
-static int ena_com_init_interrupt_moderation_table(struct ena_com_dev *ena_dev)
-{
-	size_t size;
-
-	size = sizeof(struct ena_intr_moder_entry) * ENA_INTR_MAX_NUM_OF_LEVELS;
-
-	ena_dev->intr_moder_tbl = ENA_MEM_ALLOC(ena_dev->dmadev, size);
-	if (!ena_dev->intr_moder_tbl)
-		return ENA_COM_NO_MEM;
-
-	ena_com_config_default_interrupt_moderation_table(ena_dev);
-
-	return 0;
-}
-
 static void ena_com_update_intr_delay_resolution(struct ena_com_dev *ena_dev,
 						 u16 intr_delay_resolution)
 {
-	struct ena_intr_moder_entry *intr_moder_tbl = ena_dev->intr_moder_tbl;
-	unsigned int i;
+	u16 prev_intr_delay_resolution = ena_dev->intr_delay_resolution;
 
-	if (!intr_delay_resolution) {
+	if (unlikely(!intr_delay_resolution)) {
 		ena_trc_err("Illegal intr_delay_resolution provided. Going to use default 1 usec resolution\n");
-		intr_delay_resolution = 1;
+		intr_delay_resolution = ENA_DEFAULT_INTR_DELAY_RESOLUTION;
 	}
-	ena_dev->intr_delay_resolution = intr_delay_resolution;
 
 	/* update Rx */
-	for (i = 0; i < ENA_INTR_MAX_NUM_OF_LEVELS; i++)
-		intr_moder_tbl[i].intr_moder_interval /= intr_delay_resolution;
+	ena_dev->intr_moder_rx_interval =
+		ena_dev->intr_moder_rx_interval *
+		prev_intr_delay_resolution /
+		intr_delay_resolution;
 
 	/* update Tx */
-	ena_dev->intr_moder_tx_interval /= intr_delay_resolution;
+	ena_dev->intr_moder_tx_interval =
+		ena_dev->intr_moder_tx_interval *
+		prev_intr_delay_resolution /
+		intr_delay_resolution;
+
+	ena_dev->intr_delay_resolution = intr_delay_resolution;
 }
 
 /*****************************************************************************/
@@ -1498,11 +1515,12 @@ void ena_com_wait_for_abort_completion(struct ena_com_dev *ena_dev)
 {
 	struct ena_com_admin_queue *admin_queue = &ena_dev->admin_queue;
 	unsigned long flags = 0;
+	u32 exp = 0;
 
 	ENA_SPINLOCK_LOCK(admin_queue->q_lock, flags);
 	while (ATOMIC32_READ(&admin_queue->outstanding_cmds) != 0) {
 		ENA_SPINLOCK_UNLOCK(admin_queue->q_lock, flags);
-		ENA_MSLEEP(ENA_POLL_MS);
+		ena_delay_exponential_backoff_us(exp++, ena_dev->ena_min_poll_delay_us);
 		ENA_SPINLOCK_LOCK(admin_queue->q_lock, flags);
 	}
 	ENA_SPINLOCK_UNLOCK(admin_queue->q_lock, flags);
@@ -1683,7 +1701,9 @@ void ena_com_admin_destroy(struct ena_com_dev *ena_dev)
 
 	ENA_WAIT_EVENT_DESTROY(admin_queue->comp_ctx->wait_event);
 	if (admin_queue->comp_ctx)
-		ENA_MEM_FREE(ena_dev->dmadev, admin_queue->comp_ctx);
+		ENA_MEM_FREE(ena_dev->dmadev,
+			     admin_queue->comp_ctx,
+			     (admin_queue->q_depth * sizeof(struct ena_comp_ctx)));
 	admin_queue->comp_ctx = NULL;
 	size = ADMIN_SQ_SIZE(admin_queue->q_depth);
 	if (sq->entries)
@@ -1715,6 +1735,17 @@ void ena_com_set_admin_polling_mode(struct ena_com_dev *ena_dev, bool polling)
 	ENA_REG_WRITE32(ena_dev->bus, mask_value,
 			ena_dev->reg_bar + ENA_REGS_INTR_MASK_OFF);
 	ena_dev->admin_queue.polling = polling;
+}
+
+bool ena_com_get_admin_polling_mode(struct ena_com_dev *ena_dev)
+{
+	return ena_dev->admin_queue.polling;
+}
+
+void ena_com_set_admin_auto_polling_mode(struct ena_com_dev *ena_dev,
+					 bool polling)
+{
+	ena_dev->admin_queue.auto_polling = polling;
 }
 
 int ena_com_mmio_reg_read_request_init(struct ena_com_dev *ena_dev)
@@ -1854,6 +1885,7 @@ int ena_com_admin_init(struct ena_com_dev *ena_dev,
 	if (ret)
 		goto error;
 
+	admin_queue->ena_dev = ena_dev;
 	admin_queue->running_state = true;
 
 	return 0;
@@ -1948,62 +1980,6 @@ int ena_com_get_link_params(struct ena_com_dev *ena_dev,
 			    struct ena_admin_get_feat_resp *resp)
 {
 	return ena_com_get_feature(ena_dev, resp, ENA_ADMIN_LINK_CONFIG, 0);
-}
-
-int ena_com_extra_properties_strings_init(struct ena_com_dev *ena_dev)
-{
-	struct ena_admin_get_feat_resp resp;
-	struct ena_extra_properties_strings *extra_properties_strings =
-			&ena_dev->extra_properties_strings;
-	u32 rc;
-	extra_properties_strings->size = ENA_ADMIN_EXTRA_PROPERTIES_COUNT *
-		ENA_ADMIN_EXTRA_PROPERTIES_STRING_LEN;
-
-	ENA_MEM_ALLOC_COHERENT(ena_dev->dmadev,
-			       extra_properties_strings->size,
-			       extra_properties_strings->virt_addr,
-			       extra_properties_strings->dma_addr,
-			       extra_properties_strings->dma_handle);
-	if (unlikely(!extra_properties_strings->virt_addr)) {
-		ena_trc_err("Failed to allocate extra properties strings\n");
-		return 0;
-	}
-
-	rc = ena_com_get_feature_ex(ena_dev, &resp,
-				    ENA_ADMIN_EXTRA_PROPERTIES_STRINGS,
-				    extra_properties_strings->dma_addr,
-				    extra_properties_strings->size, 0);
-	if (rc) {
-		ena_trc_dbg("Failed to get extra properties strings\n");
-		goto err;
-	}
-
-	return resp.u.extra_properties_strings.count;
-err:
-	ena_com_delete_extra_properties_strings(ena_dev);
-	return 0;
-}
-
-void ena_com_delete_extra_properties_strings(struct ena_com_dev *ena_dev)
-{
-	struct ena_extra_properties_strings *extra_properties_strings =
-				&ena_dev->extra_properties_strings;
-
-	if (extra_properties_strings->virt_addr) {
-		ENA_MEM_FREE_COHERENT(ena_dev->dmadev,
-				      extra_properties_strings->size,
-				      extra_properties_strings->virt_addr,
-				      extra_properties_strings->dma_addr,
-				      extra_properties_strings->dma_handle);
-		extra_properties_strings->virt_addr = NULL;
-	}
-}
-
-int ena_com_get_extra_properties_flags(struct ena_com_dev *ena_dev,
-				       struct ena_admin_get_feat_resp *resp)
-{
-	return ena_com_get_feature(ena_dev, resp,
-				   ENA_ADMIN_EXTRA_PROPERTIES_FLAGS, 0);
 }
 
 int ena_com_get_dev_attr_feat(struct ena_com_dev *ena_dev,
@@ -2127,7 +2103,7 @@ void ena_com_aenq_intr_handler(struct ena_com_dev *dev, void *data)
 	struct ena_admin_aenq_entry *aenq_e;
 	struct ena_admin_aenq_common_desc *aenq_common;
 	struct ena_com_aenq *aenq  = &dev->aenq;
-	unsigned long long timestamp;
+	u64 timestamp;
 	ena_aenq_handler handler_cb;
 	u16 masked_head, processed = 0;
 	u8 phase;
@@ -2145,9 +2121,9 @@ void ena_com_aenq_intr_handler(struct ena_com_dev *dev, void *data)
 		 */
 		dma_rmb();
 
-		timestamp = (unsigned long long)aenq_common->timestamp_low |
-			((unsigned long long)aenq_common->timestamp_high << 32);
-		ena_trc_dbg("AENQ! Group[%x] Syndrom[%x] timestamp: [%llus]\n",
+		timestamp = (u64)aenq_common->timestamp_low |
+			((u64)aenq_common->timestamp_high << 32);
+		ena_trc_dbg("AENQ! Group[%x] Syndrom[%x] timestamp: [%" ENA_PRIu64 "s]\n",
 			    aenq_common->group,
 			    aenq_common->syndrom,
 			    timestamp);
@@ -2203,69 +2179,6 @@ int ena_com_extended_stats_set_func_queue(struct ena_com_dev *ena_dev,
 }
 
 #endif /* ENA_EXTENDED_STATS */
-#ifdef ENA_DEBUG
-int ena_com_trace_usage(char *buf, size_t size)
-{
-	return snprintf(buf, size, "Usage: [severity] [type]\n"
-		"Supported severities:\n"
-		" *** EMERGENCY - 1 ***\n"
-		" *** ALERT     - 2 ***\n"
-		" *** CRITICAL  - 3 ***\n"
-		" *** ERROR     - 4 ***\n"
-		" *** WARNING   - 5 ***\n"
-		" *** NOTICE    - 6 ***\n"
-		" *** INFO      - 7 ***\n"
-		" *** DEBUG     - 8 ***\n"
-		"\n"
-		"Supported types: (bit fields)\n"
-		" *** ENA       - 0x%x ***\n"
-		" *** REGS      - 0x%x ***\n"
-		" *** ADMIN     - 0x%x ***\n"
-		" *** IO        - 0x%x ***\n",
-		ENA_TRACE_TYPE_ENA,
-		ENA_TRACE_TYPE_REGS,
-		ENA_TRACE_TYPE_ADMIN,
-		ENA_TRACE_TYPE_IO);
-}
-
-int ena_com_set_trace(struct ena_com_dev *ena_dev, u32 severity,
-		      u32 type)
-{
-	void __iomem *addr;
-
-	if ((severity < ENA_TRACE_SEVERITY_MIN) ||
-			(severity > ENA_TRACE_SEVERITY_MAX)) {
-		ena_trc_err("Invalid severity\n");
-		return ENA_COM_INVAL;
-	}
-
-	if ((type & ~ENA_TRACE_TYPE_ALL) != 0) {
-		ena_trc_err("Invalid type\n");
-		return ENA_COM_INVAL;
-	}
-
-	addr = (void __iomem *)((uintptr_t)ena_dev->reg_bar +
-			ENA_TRACE_TYPE_OFFSET);
-	ENA_REG_WRITE32(ena_dev->bus, type, addr);
-
-	addr = (void __iomem *)((uintptr_t)ena_dev->reg_bar +
-			ENA_TRACE_SEVERITY_OFFSET);
-	ENA_REG_WRITE32(ena_dev->bus, severity, addr);
-
-	return 0;
-}
-
-void ena_com_get_trace(struct ena_com_dev *ena_dev, u32 *severity,
-		       u32 *type)
-{
-	if (type)
-		*type = ena_com_reg_bar_read32(ena_dev, ENA_TRACE_TYPE_OFFSET);
-
-	if (severity)
-		*severity = ena_com_reg_bar_read32(ena_dev,
-			ENA_TRACE_SEVERITY_OFFSET);
-}
-#endif /* ENA_DEBUG */
 
 int ena_com_dev_reset(struct ena_com_dev *ena_dev,
 		      enum ena_regs_reset_reason_types reset_reason)
@@ -2326,11 +2239,6 @@ int ena_com_dev_reset(struct ena_com_dev *ena_dev,
 	else
 		ena_dev->admin_queue.completion_timeout = ADMIN_CMD_TIMEOUT_US;
 
-#ifdef ENA_DEBUG
-	/* TODO ENA doesn't wait until all the IODMA trax were completed.
-	 * Wait for 10 ms to ensure we can continue running */
-	ENA_MSLEEP(10);
-#endif /* ENA_DEBUG */
 	return 0;
 }
 
@@ -2536,11 +2444,13 @@ int ena_com_fill_hash_function(struct ena_com_dev *ena_dev,
 			       enum ena_admin_hash_functions func,
 			       const u8 *key, u16 key_len, u32 init_val)
 {
-	struct ena_rss *rss = &ena_dev->rss;
+	struct ena_admin_feature_rss_flow_hash_control *hash_key;
 	struct ena_admin_get_feat_resp get_resp;
-	struct ena_admin_feature_rss_flow_hash_control *hash_key =
-		rss->hash_key;
+	enum ena_admin_hash_functions old_func;
+	struct ena_rss *rss = &ena_dev->rss;
 	int rc;
+
+	hash_key = rss->hash_key;
 
 	/* Make sure size is a mult of DWs */
 	if (unlikely(key_len & 0x3))
@@ -2553,22 +2463,23 @@ int ena_com_fill_hash_function(struct ena_com_dev *ena_dev,
 	if (unlikely(rc))
 		return rc;
 
-	if (!((1 << func) & get_resp.u.flow_hash_func.supported_func)) {
+	if (!(BIT(func) & get_resp.u.flow_hash_func.supported_func)) {
 		ena_trc_err("Flow hash function %d isn't supported\n", func);
 		return ENA_COM_UNSUPPORTED;
 	}
 
 	switch (func) {
 	case ENA_ADMIN_TOEPLITZ:
-		if (key_len > sizeof(hash_key->key)) {
-			ena_trc_err("key len (%hu) is bigger than the max supported (%zu)\n",
-				    key_len, sizeof(hash_key->key));
-			return ENA_COM_INVAL;
+		if (key) {
+			if (key_len != sizeof(hash_key->key)) {
+				ena_trc_err("key len (%hu) doesn't equal the supported size (%zu)\n",
+					     key_len, sizeof(hash_key->key));
+				return ENA_COM_INVAL;
+			}
+			memcpy(hash_key->key, key, key_len);
+			rss->hash_init_val = init_val;
+			hash_key->keys_num = key_len / sizeof(hash_key->key[0]);
 		}
-
-		memcpy(hash_key->key, key, key_len);
-		rss->hash_init_val = init_val;
-		hash_key->keys_num = key_len >> 2;
 		break;
 	case ENA_ADMIN_CRC32:
 		rss->hash_init_val = init_val;
@@ -2578,25 +2489,26 @@ int ena_com_fill_hash_function(struct ena_com_dev *ena_dev,
 		return ENA_COM_INVAL;
 	}
 
+	old_func = rss->hash_func;
 	rss->hash_func = func;
 	rc = ena_com_set_hash_function(ena_dev);
 
 	/* Restore the old function */
 	if (unlikely(rc))
-		ena_com_get_hash_function(ena_dev, NULL, NULL);
+		rss->hash_func = old_func;
 
 	return rc;
 }
 
 int ena_com_get_hash_function(struct ena_com_dev *ena_dev,
-			      enum ena_admin_hash_functions *func,
-			      u8 *key)
+			      enum ena_admin_hash_functions *func)
 {
 	struct ena_rss *rss = &ena_dev->rss;
 	struct ena_admin_get_feat_resp get_resp;
-	struct ena_admin_feature_rss_flow_hash_control *hash_key =
-		rss->hash_key;
 	int rc;
+
+	if (unlikely(!func))
+		return ENA_COM_INVAL;
 
 	rc = ena_com_get_feature_ex(ena_dev, &get_resp,
 				    ENA_ADMIN_RSS_HASH_FUNCTION,
@@ -2605,9 +2517,20 @@ int ena_com_get_hash_function(struct ena_com_dev *ena_dev,
 	if (unlikely(rc))
 		return rc;
 
-	rss->hash_func = get_resp.u.flow_hash_func.selected_func;
-	if (func)
-		*func = rss->hash_func;
+	/* ENA_FFS() returns 1 in case the lsb is set */
+	rss->hash_func = ENA_FFS(get_resp.u.flow_hash_func.selected_func);
+	if (rss->hash_func)
+		rss->hash_func--;
+
+	*func = rss->hash_func;
+
+	return 0;
+}
+
+int ena_com_get_hash_key(struct ena_com_dev *ena_dev, u8 *key)
+{
+	struct ena_admin_feature_rss_flow_hash_control *hash_key =
+		ena_dev->rss.hash_key;
 
 	if (key)
 		memcpy(key, hash_key->key, (size_t)(hash_key->keys_num) << 2);
@@ -2869,10 +2792,6 @@ int ena_com_indirect_table_get(struct ena_com_dev *ena_dev, u32 *ind_tbl)
 	if (!ind_tbl)
 		return 0;
 
-	rc = ena_com_ind_tbl_convert_from_device(ena_dev);
-	if (unlikely(rc))
-		return rc;
-
 	for (i = 0; i < (1 << rss->tbl_log_size); i++)
 		ind_tbl[i] = rss->host_rss_ind_tbl[i];
 
@@ -2889,8 +2808,14 @@ int ena_com_rss_init(struct ena_com_dev *ena_dev, u16 indr_tbl_log_size)
 	if (unlikely(rc))
 		goto err_indr_tbl;
 
+	/* The following function might return unsupported in case the
+	 * device doesn't support setting the key / hash function. We can safely
+	 * ignore this error and have indirection table support only.
+	 */
 	rc = ena_com_hash_key_allocate(ena_dev);
-	if (unlikely(rc))
+	if (likely(!rc))
+		ena_com_hash_key_fill_default_key(ena_dev);
+	else if (rc != ENA_COM_UNSUPPORTED)
 		goto err_hash_key;
 
 	rc = ena_com_hash_ctrl_init(ena_dev);
@@ -3040,42 +2965,35 @@ bool ena_com_interrupt_moderation_supported(struct ena_com_dev *ena_dev)
 						  ENA_ADMIN_INTERRUPT_MODERATION);
 }
 
-int ena_com_update_nonadaptive_moderation_interval_tx(struct ena_com_dev *ena_dev,
-						      u32 tx_coalesce_usecs)
+static int ena_com_update_nonadaptive_moderation_interval(u32 coalesce_usecs,
+							  u32 intr_delay_resolution,
+							  u32 *intr_moder_interval)
 {
-	if (!ena_dev->intr_delay_resolution) {
+	if (!intr_delay_resolution) {
 		ena_trc_err("Illegal interrupt delay granularity value\n");
 		return ENA_COM_FAULT;
 	}
 
-	ena_dev->intr_moder_tx_interval = tx_coalesce_usecs /
-		ena_dev->intr_delay_resolution;
+	*intr_moder_interval = coalesce_usecs / intr_delay_resolution;
 
 	return 0;
+}
+
+
+int ena_com_update_nonadaptive_moderation_interval_tx(struct ena_com_dev *ena_dev,
+						      u32 tx_coalesce_usecs)
+{
+	return ena_com_update_nonadaptive_moderation_interval(tx_coalesce_usecs,
+							      ena_dev->intr_delay_resolution,
+							      &ena_dev->intr_moder_tx_interval);
 }
 
 int ena_com_update_nonadaptive_moderation_interval_rx(struct ena_com_dev *ena_dev,
 						      u32 rx_coalesce_usecs)
 {
-	if (!ena_dev->intr_delay_resolution) {
-		ena_trc_err("Illegal interrupt delay granularity value\n");
-		return ENA_COM_FAULT;
-	}
-
-	/* We use LOWEST entry of moderation table for storing
-	 * nonadaptive interrupt coalescing values
-	 */
-	ena_dev->intr_moder_tbl[ENA_INTR_MODER_LOWEST].intr_moder_interval =
-		rx_coalesce_usecs / ena_dev->intr_delay_resolution;
-
-	return 0;
-}
-
-void ena_com_destroy_interrupt_moderation(struct ena_com_dev *ena_dev)
-{
-	if (ena_dev->intr_moder_tbl)
-		ENA_MEM_FREE(ena_dev->dmadev, ena_dev->intr_moder_tbl);
-	ena_dev->intr_moder_tbl = NULL;
+	return ena_com_update_nonadaptive_moderation_interval(rx_coalesce_usecs,
+							      ena_dev->intr_delay_resolution,
+							      &ena_dev->intr_moder_rx_interval);
 }
 
 int ena_com_init_interrupt_moderation(struct ena_com_dev *ena_dev)
@@ -3102,62 +3020,14 @@ int ena_com_init_interrupt_moderation(struct ena_com_dev *ena_dev)
 		return rc;
 	}
 
-	rc = ena_com_init_interrupt_moderation_table(ena_dev);
-	if (rc)
-		goto err;
-
 	/* if moderation is supported by device we set adaptive moderation */
 	delay_resolution = get_resp.u.intr_moderation.intr_delay_resolution;
 	ena_com_update_intr_delay_resolution(ena_dev, delay_resolution);
-	ena_com_enable_adaptive_moderation(ena_dev);
+
+	/* Disable adaptive moderation by default - can be enabled later */
+	ena_com_disable_adaptive_moderation(ena_dev);
 
 	return 0;
-err:
-	ena_com_destroy_interrupt_moderation(ena_dev);
-	return rc;
-}
-
-void ena_com_config_default_interrupt_moderation_table(struct ena_com_dev *ena_dev)
-{
-	struct ena_intr_moder_entry *intr_moder_tbl = ena_dev->intr_moder_tbl;
-
-	if (!intr_moder_tbl)
-		return;
-
-	intr_moder_tbl[ENA_INTR_MODER_LOWEST].intr_moder_interval =
-		ENA_INTR_LOWEST_USECS;
-	intr_moder_tbl[ENA_INTR_MODER_LOWEST].pkts_per_interval =
-		ENA_INTR_LOWEST_PKTS;
-	intr_moder_tbl[ENA_INTR_MODER_LOWEST].bytes_per_interval =
-		ENA_INTR_LOWEST_BYTES;
-
-	intr_moder_tbl[ENA_INTR_MODER_LOW].intr_moder_interval =
-		ENA_INTR_LOW_USECS;
-	intr_moder_tbl[ENA_INTR_MODER_LOW].pkts_per_interval =
-		ENA_INTR_LOW_PKTS;
-	intr_moder_tbl[ENA_INTR_MODER_LOW].bytes_per_interval =
-		ENA_INTR_LOW_BYTES;
-
-	intr_moder_tbl[ENA_INTR_MODER_MID].intr_moder_interval =
-		ENA_INTR_MID_USECS;
-	intr_moder_tbl[ENA_INTR_MODER_MID].pkts_per_interval =
-		ENA_INTR_MID_PKTS;
-	intr_moder_tbl[ENA_INTR_MODER_MID].bytes_per_interval =
-		ENA_INTR_MID_BYTES;
-
-	intr_moder_tbl[ENA_INTR_MODER_HIGH].intr_moder_interval =
-		ENA_INTR_HIGH_USECS;
-	intr_moder_tbl[ENA_INTR_MODER_HIGH].pkts_per_interval =
-		ENA_INTR_HIGH_PKTS;
-	intr_moder_tbl[ENA_INTR_MODER_HIGH].bytes_per_interval =
-		ENA_INTR_HIGH_BYTES;
-
-	intr_moder_tbl[ENA_INTR_MODER_HIGHEST].intr_moder_interval =
-		ENA_INTR_HIGHEST_USECS;
-	intr_moder_tbl[ENA_INTR_MODER_HIGHEST].pkts_per_interval =
-		ENA_INTR_HIGHEST_PKTS;
-	intr_moder_tbl[ENA_INTR_MODER_HIGHEST].bytes_per_interval =
-		ENA_INTR_HIGHEST_BYTES;
 }
 
 unsigned int ena_com_get_nonadaptive_moderation_interval_tx(struct ena_com_dev *ena_dev)
@@ -3167,57 +3037,15 @@ unsigned int ena_com_get_nonadaptive_moderation_interval_tx(struct ena_com_dev *
 
 unsigned int ena_com_get_nonadaptive_moderation_interval_rx(struct ena_com_dev *ena_dev)
 {
-	struct ena_intr_moder_entry *intr_moder_tbl = ena_dev->intr_moder_tbl;
-
-	if (intr_moder_tbl)
-		return intr_moder_tbl[ENA_INTR_MODER_LOWEST].intr_moder_interval;
-
-	return 0;
-}
-
-void ena_com_init_intr_moderation_entry(struct ena_com_dev *ena_dev,
-					enum ena_intr_moder_level level,
-					struct ena_intr_moder_entry *entry)
-{
-	struct ena_intr_moder_entry *intr_moder_tbl = ena_dev->intr_moder_tbl;
-
-	if (level >= ENA_INTR_MAX_NUM_OF_LEVELS)
-		return;
-
-	intr_moder_tbl[level].intr_moder_interval = entry->intr_moder_interval;
-	if (ena_dev->intr_delay_resolution)
-		intr_moder_tbl[level].intr_moder_interval /=
-			ena_dev->intr_delay_resolution;
-	intr_moder_tbl[level].pkts_per_interval = entry->pkts_per_interval;
-
-	/* use hardcoded value until ethtool supports bytecount parameter */
-	if (entry->bytes_per_interval != ENA_INTR_BYTE_COUNT_NOT_SUPPORTED)
-		intr_moder_tbl[level].bytes_per_interval = entry->bytes_per_interval;
-}
-
-void ena_com_get_intr_moderation_entry(struct ena_com_dev *ena_dev,
-				       enum ena_intr_moder_level level,
-				       struct ena_intr_moder_entry *entry)
-{
-	struct ena_intr_moder_entry *intr_moder_tbl = ena_dev->intr_moder_tbl;
-
-	if (level >= ENA_INTR_MAX_NUM_OF_LEVELS)
-		return;
-
-	entry->intr_moder_interval = intr_moder_tbl[level].intr_moder_interval;
-	if (ena_dev->intr_delay_resolution)
-		entry->intr_moder_interval *= ena_dev->intr_delay_resolution;
-	entry->pkts_per_interval =
-	intr_moder_tbl[level].pkts_per_interval;
-	entry->bytes_per_interval = intr_moder_tbl[level].bytes_per_interval;
+	return ena_dev->intr_moder_rx_interval;
 }
 
 int ena_com_config_dev_mode(struct ena_com_dev *ena_dev,
 			    struct ena_admin_feature_llq_desc *llq_features,
 			    struct ena_llq_configurations *llq_default_cfg)
 {
+	struct ena_com_llq_info *llq_info = &ena_dev->llq_info;
 	int rc;
-	int size;
 
 	if (!llq_features->max_llq_num) {
 		ena_dev->tx_mem_queue_type = ENA_ADMIN_PLACEMENT_POLICY_HOST;
@@ -3228,14 +3056,12 @@ int ena_com_config_dev_mode(struct ena_com_dev *ena_dev,
 	if (rc)
 		return rc;
 
-	/* Validate the descriptor is not too big */
-	size = ena_dev->tx_max_header_size;
-	size += ena_dev->llq_info.descs_num_before_header *
-		sizeof(struct ena_eth_io_tx_desc);
+	ena_dev->tx_max_header_size = llq_info->desc_list_entry_size -
+		(llq_info->descs_num_before_header * sizeof(struct ena_eth_io_tx_desc));
 
-	if (unlikely(ena_dev->llq_info.desc_list_entry_size < size)) {
+	if (unlikely(ena_dev->tx_max_header_size == 0)) {
 		ena_trc_err("the size of the LLQ entry is smaller than needed\n");
-		return ENA_COM_INVAL;
+		return -EINVAL;
 	}
 
 	ena_dev->tx_mem_queue_type = ENA_ADMIN_PLACEMENT_POLICY_DEV;

--- a/kernel/fbsd/ena/ena_com/ena_com.h
+++ b/kernel/fbsd/ena/ena_com/ena_com.h
@@ -1,7 +1,7 @@
 /*-
  * BSD LICENSE
  *
- * Copyright (c) 2015-2019 Amazon.com, Inc. or its affiliates.
+ * Copyright (c) 2015-2020 Amazon.com, Inc. or its affiliates.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -36,9 +36,9 @@
 
 #include "ena_plat.h"
 
-#define ENA_MAX_NUM_IO_QUEUES		128U
+#define ENA_MAX_NUM_IO_QUEUES 128U
 /* We need to queues for each IO (on for Tx and one for Rx) */
-#define ENA_TOTAL_NUM_QUEUES		(2 * (ENA_MAX_NUM_IO_QUEUES))
+#define ENA_TOTAL_NUM_QUEUES (2 * (ENA_MAX_NUM_IO_QUEUES))
 
 #define ENA_MAX_HANDLERS 256
 
@@ -55,45 +55,15 @@
 /*****************************************************************************/
 /* ENA adaptive interrupt moderation settings */
 
-#define ENA_INTR_LOWEST_USECS           (0)
-#define ENA_INTR_LOWEST_PKTS            (3)
-#define ENA_INTR_LOWEST_BYTES           (2 * 1524)
+#define ENA_INTR_INITIAL_TX_INTERVAL_USECS ENA_INTR_INITIAL_TX_INTERVAL_USECS_PLAT
+#define ENA_INTR_INITIAL_RX_INTERVAL_USECS 0
+#define ENA_DEFAULT_INTR_DELAY_RESOLUTION 1
 
-#define ENA_INTR_LOW_USECS              (32)
-#define ENA_INTR_LOW_PKTS               (12)
-#define ENA_INTR_LOW_BYTES              (16 * 1024)
+#define ENA_HASH_KEY_SIZE 40
 
-#define ENA_INTR_MID_USECS              (80)
-#define ENA_INTR_MID_PKTS               (48)
-#define ENA_INTR_MID_BYTES              (64 * 1024)
+#define ENA_HW_HINTS_NO_TIMEOUT	0xFFFF
 
-#define ENA_INTR_HIGH_USECS             (128)
-#define ENA_INTR_HIGH_PKTS              (96)
-#define ENA_INTR_HIGH_BYTES             (128 * 1024)
-
-#define ENA_INTR_HIGHEST_USECS          (192)
-#define ENA_INTR_HIGHEST_PKTS           (128)
-#define ENA_INTR_HIGHEST_BYTES          (192 * 1024)
-
-#define ENA_INTR_INITIAL_TX_INTERVAL_USECS		196
-#define ENA_INTR_INITIAL_RX_INTERVAL_USECS		4
-#define ENA_INTR_DELAY_OLD_VALUE_WEIGHT			6
-#define ENA_INTR_DELAY_NEW_VALUE_WEIGHT			4
-#define ENA_INTR_MODER_LEVEL_STRIDE			1
-#define ENA_INTR_BYTE_COUNT_NOT_SUPPORTED		0xFFFFFF
-
-#define ENA_HW_HINTS_NO_TIMEOUT				0xFFFF
-
-#define ENA_FEATURE_MAX_QUEUE_EXT_VER	1
-
-enum ena_intr_moder_level {
-	ENA_INTR_MODER_LOWEST = 0,
-	ENA_INTR_MODER_LOW,
-	ENA_INTR_MODER_MID,
-	ENA_INTR_MODER_HIGH,
-	ENA_INTR_MODER_HIGHEST,
-	ENA_INTR_MAX_NUM_OF_LEVELS,
-};
+#define ENA_FEATURE_MAX_QUEUE_EXT_VER 1
 
 struct ena_llq_configurations {
 	enum ena_admin_llq_header_location llq_header_location;
@@ -101,12 +71,6 @@ struct ena_llq_configurations {
 	enum ena_admin_llq_stride_ctrl  llq_stride_ctrl;
 	enum ena_admin_llq_num_descs_before_header llq_num_decs_before_header;
 	u16 llq_ring_entry_size_value;
-};
-
-struct ena_intr_moder_entry {
-	unsigned int intr_moder_interval;
-	unsigned int pkts_per_interval;
-	unsigned int bytes_per_interval;
 };
 
 enum queue_direction {
@@ -146,6 +110,7 @@ struct ena_com_llq_info {
 	u16 descs_num_before_header;
 	u16 descs_per_entry;
 	u16 max_entries_in_tx_burst;
+	bool disable_meta_caching;
 };
 
 struct ena_com_io_cq {
@@ -210,6 +175,8 @@ struct ena_com_io_sq {
 	enum queue_direction direction;
 	enum ena_admin_placement_policy_type mem_queue_type;
 
+	bool disable_meta_caching;
+
 	u32 msix_vector;
 	struct ena_com_tx_meta cached_tx_meta;
 	struct ena_com_llq_info llq_info;
@@ -253,16 +220,17 @@ struct ena_com_admin_sq {
 };
 
 struct ena_com_stats_admin {
-	u32 aborted_cmd;
-	u32 submitted_cmd;
-	u32 completed_cmd;
-	u32 out_of_space;
-	u32 no_completion;
+	u64 aborted_cmd;
+	u64 submitted_cmd;
+	u64 completed_cmd;
+	u64 out_of_space;
+	u64 no_completion;
 };
 
 struct ena_com_admin_queue {
 	void *q_dmadev;
 	void *bus;
+	struct ena_com_dev *ena_dev;
 	ena_spinlock_t q_lock; /* spinlock for the admin queue */
 
 	struct ena_comp_ctx *comp_ctx;
@@ -273,6 +241,9 @@ struct ena_com_admin_queue {
 
 	/* Indicate if the admin queue should poll for completion */
 	bool polling;
+
+	/* Define if fallback to polling mode should occur */
+	bool auto_polling;
 
 	u16 curr_cmd_id;
 
@@ -345,13 +316,6 @@ struct ena_host_attribute {
 	ena_mem_handle_t host_info_dma_handle;
 };
 
-struct ena_extra_properties_strings {
-	u8 *virt_addr;
-	dma_addr_t dma_addr;
-	ena_mem_handle_t dma_handle;
-	u32 size;
-};
-
 /* Each ena_dev is a PCI function. */
 struct ena_com_dev {
 	struct ena_com_admin_queue admin_queue;
@@ -377,11 +341,18 @@ struct ena_com_dev {
 	struct ena_host_attribute host_attr;
 	bool adaptive_coalescing;
 	u16 intr_delay_resolution;
+
+	/* interrupt moderation intervals are in usec divided by
+	 * intr_delay_resolution, which is supplied by the device.
+	 */
 	u32 intr_moder_tx_interval;
+	u32 intr_moder_rx_interval;
+
 	struct ena_intr_moder_entry *intr_moder_tbl;
 
 	struct ena_com_llq_info llq_info;
-	struct ena_extra_properties_strings extra_properties_strings;
+
+	u32 ena_min_poll_delay_us;
 };
 
 struct ena_com_dev_get_features_ctx {
@@ -430,7 +401,7 @@ extern "C" {
  */
 int ena_com_mmio_reg_read_request_init(struct ena_com_dev *ena_dev);
 
-/* ena_com_set_mmio_read_mode - Enable/disable the mmio reg read mechanism
+/* ena_com_set_mmio_read_mode - Enable/disable the indirect mmio reg read mechanism
  * @ena_dev: ENA communication layer struct
  * @readless_supported: readless mode (enable/disable)
  */
@@ -538,7 +509,7 @@ bool ena_com_get_admin_running_state(struct ena_com_dev *ena_dev);
  */
 void ena_com_set_admin_polling_mode(struct ena_com_dev *ena_dev, bool polling);
 
-/* ena_com_set_admin_polling_mode - Get the admin completion queue polling mode
+/* ena_com_get_admin_polling_mode - Get the admin completion queue polling mode
  * @ena_dev: ENA communication layer struct
  *
  * Get the admin completion mode.
@@ -548,12 +519,23 @@ void ena_com_set_admin_polling_mode(struct ena_com_dev *ena_dev, bool polling);
  *
  * @return state
  */
-bool ena_com_get_ena_admin_polling_mode(struct ena_com_dev *ena_dev);
+bool ena_com_get_admin_polling_mode(struct ena_com_dev *ena_dev);
+
+/* ena_com_set_admin_auto_polling_mode - Enable autoswitch to polling mode
+ * @ena_dev: ENA communication layer struct
+ * @polling: Enable/Disable polling mode
+ *
+ * Set the autopolling mode.
+ * If autopolling is on:
+ * In case of missing interrupt when data is available switch to polling.
+ */
+void ena_com_set_admin_auto_polling_mode(struct ena_com_dev *ena_dev,
+					 bool polling);
 
 /* ena_com_admin_q_comp_intr_handler - admin queue interrupt handler
  * @ena_dev: ENA communication layer struct
  *
- * This method go over the admin completion queue and wake up all the pending
+ * This method goes over the admin completion queue and wakes up all the pending
  * threads that wait on the commands wait event.
  *
  * @note: Should be called after MSI-X interrupt.
@@ -563,7 +545,7 @@ void ena_com_admin_q_comp_intr_handler(struct ena_com_dev *ena_dev);
 /* ena_com_aenq_intr_handler - AENQ interrupt handler
  * @ena_dev: ENA communication layer struct
  *
- * This method go over the async event notification queue and call the proper
+ * This method goes over the async event notification queue and calls the proper
  * aenq handler.
  */
 void ena_com_aenq_intr_handler(struct ena_com_dev *dev, void *data);
@@ -580,14 +562,14 @@ void ena_com_abort_admin_commands(struct ena_com_dev *ena_dev);
 /* ena_com_wait_for_abort_completion - Wait for admin commands abort.
  * @ena_dev: ENA communication layer struct
  *
- * This method wait until all the outstanding admin commands will be completed.
+ * This method waits until all the outstanding admin commands are completed.
  */
 void ena_com_wait_for_abort_completion(struct ena_com_dev *ena_dev);
 
 /* ena_com_validate_version - Validate the device parameters
  * @ena_dev: ENA communication layer struct
  *
- * This method validate the device parameters are the same as the saved
+ * This method verifies the device parameters are the same as the saved
  * parameters in ena_dev.
  * This method is useful after device reset, to validate the device mac address
  * and the device offloads are the same as before the reset.
@@ -607,31 +589,6 @@ int ena_com_validate_version(struct ena_com_dev *ena_dev);
  */
 int ena_com_get_link_params(struct ena_com_dev *ena_dev,
 			    struct ena_admin_get_feat_resp *resp);
-
-/* ena_com_extra_properties_strings_init - Initialize the extra properties strings buffer.
- * @ena_dev: ENA communication layer struct
- *
- * Initialize the extra properties strings buffer.
- */
-int ena_com_extra_properties_strings_init(struct ena_com_dev *ena_dev);
-
-/* ena_com_delete_extra_properties_strings - Free the extra properties strings buffer.
- * @ena_dev: ENA communication layer struct
- *
- * Free the allocated extra properties strings buffer.
- */
-void ena_com_delete_extra_properties_strings(struct ena_com_dev *ena_dev);
-
-/* ena_com_get_extra_properties_flags - Retrieve extra properties flags.
- * @ena_dev: ENA communication layer struct
- * @resp: Extra properties flags.
- *
- * Retrieve the extra properties flags.
- *
- * @return - 0 on Success negative value otherwise.
- */
-int ena_com_get_extra_properties_flags(struct ena_com_dev *ena_dev,
-				       struct ena_admin_get_feat_resp *resp);
 
 /* ena_com_get_dma_width - Retrieve physical dma address width the device
  * supports.
@@ -707,6 +664,14 @@ int ena_com_rss_init(struct ena_com_dev *ena_dev, u16 log_size);
  */
 void ena_com_rss_destroy(struct ena_com_dev *ena_dev);
 
+/* ena_com_get_current_hash_function - Get RSS hash function
+ * @ena_dev: ENA communication layer struct
+ *
+ * Return the current hash function.
+ * @return: 0 or one of the ena_admin_hash_functions values.
+ */
+int ena_com_get_current_hash_function(struct ena_com_dev *ena_dev);
+
 /* ena_com_fill_hash_function - Fill RSS hash function
  * @ena_dev: ENA communication layer struct
  * @func: The hash function (Toeplitz or crc)
@@ -738,23 +703,32 @@ int ena_com_fill_hash_function(struct ena_com_dev *ena_dev,
  */
 int ena_com_set_hash_function(struct ena_com_dev *ena_dev);
 
-/* ena_com_get_hash_function - Retrieve the hash function and the hash key
- * from the device.
+/* ena_com_get_hash_function - Retrieve the hash function from the device.
  * @ena_dev: ENA communication layer struct
  * @func: hash function
- * @key: hash key
  *
- * Retrieve the hash function and the hash key from the device.
+ * Retrieve the hash function from the device.
  *
- * @note: If the caller called ena_com_fill_hash_function but didn't flash
+ * @note: If the caller called ena_com_fill_hash_function but didn't flush
  * it to the device, the new configuration will be lost.
  *
  * @return: 0 on Success and negative value otherwise.
  */
 int ena_com_get_hash_function(struct ena_com_dev *ena_dev,
-			      enum ena_admin_hash_functions *func,
-			      u8 *key);
+			      enum ena_admin_hash_functions *func);
 
+/* ena_com_get_hash_key - Retrieve the hash key
+ * @ena_dev: ENA communication layer struct
+ * @key: hash key
+ *
+ * Retrieve the hash key.
+ *
+ * @note: If the caller called ena_com_fill_hash_key but didn't flush
+ * it to the device, the new configuration will be lost.
+ *
+ * @return: 0 on Success and negative value otherwise.
+ */
+int ena_com_get_hash_key(struct ena_com_dev *ena_dev, u8 *key);
 /* ena_com_fill_hash_ctrl - Fill RSS hash control
  * @ena_dev: ENA communication layer struct.
  * @proto: The protocol to configure.
@@ -789,7 +763,7 @@ int ena_com_set_hash_ctrl(struct ena_com_dev *ena_dev);
  *
  * Retrieve the hash control from the device.
  *
- * @note, If the caller called ena_com_fill_hash_ctrl but didn't flash
+ * @note: If the caller called ena_com_fill_hash_ctrl but didn't flush
  * it to the device, the new configuration will be lost.
  *
  * @return: 0 on Success and negative value otherwise.
@@ -841,7 +815,7 @@ int ena_com_indirect_table_set(struct ena_com_dev *ena_dev);
  *
  * Retrieve the RSS indirection table from the device.
  *
- * @note: If the caller called ena_com_indirect_table_fill_entry but didn't flash
+ * @note: If the caller called ena_com_indirect_table_fill_entry but didn't flush
  * it to the device, the new configuration will be lost.
  *
  * @return: 0 on Success and negative value otherwise.
@@ -867,14 +841,14 @@ int ena_com_allocate_debug_area(struct ena_com_dev *ena_dev,
 /* ena_com_delete_debug_area - Free the debug area resources.
  * @ena_dev: ENA communication layer struct
  *
- * Free the allocate debug area.
+ * Free the allocated debug area.
  */
 void ena_com_delete_debug_area(struct ena_com_dev *ena_dev);
 
 /* ena_com_delete_host_info - Free the host info resources.
  * @ena_dev: ENA communication layer struct
  *
- * Free the allocate host info.
+ * Free the allocated host info.
  */
 void ena_com_delete_host_info(struct ena_com_dev *ena_dev);
 
@@ -915,9 +889,9 @@ int ena_com_destroy_io_cq(struct ena_com_dev *ena_dev,
  * @cmd_completion: command completion return value.
  * @cmd_comp_size: command completion size.
 
- * Submit an admin command and then wait until the device will return a
+ * Submit an admin command and then wait until the device returns a
  * completion.
- * The completion will be copyed into cmd_comp.
+ * The completion will be copied into cmd_comp.
  *
  * @return - 0 on success, negative value on failure.
  */
@@ -934,23 +908,12 @@ int ena_com_execute_admin_command(struct ena_com_admin_queue *admin_queue,
  */
 int ena_com_init_interrupt_moderation(struct ena_com_dev *ena_dev);
 
-/* ena_com_destroy_interrupt_moderation - Destroy interrupt moderation resources
- * @ena_dev: ENA communication layer struct
- */
-void ena_com_destroy_interrupt_moderation(struct ena_com_dev *ena_dev);
-
 /* ena_com_interrupt_moderation_supported - Return if interrupt moderation
  * capability is supported by the device.
  *
  * @return - supported or not.
  */
 bool ena_com_interrupt_moderation_supported(struct ena_com_dev *ena_dev);
-
-/* ena_com_config_default_interrupt_moderation_table - Restore the interrupt
- * moderation table back to the default parameters.
- * @ena_dev: ENA communication layer struct
- */
-void ena_com_config_default_interrupt_moderation_table(struct ena_com_dev *ena_dev);
 
 /* ena_com_update_nonadaptive_moderation_interval_tx - Update the
  * non-adaptive interval in Tx direction.
@@ -988,29 +951,6 @@ unsigned int ena_com_get_nonadaptive_moderation_interval_tx(struct ena_com_dev *
  */
 unsigned int ena_com_get_nonadaptive_moderation_interval_rx(struct ena_com_dev *ena_dev);
 
-/* ena_com_init_intr_moderation_entry - Update a single entry in the interrupt
- * moderation table.
- * @ena_dev: ENA communication layer struct
- * @level: Interrupt moderation table level
- * @entry: Entry value
- *
- * Update a single entry in the interrupt moderation table.
- */
-void ena_com_init_intr_moderation_entry(struct ena_com_dev *ena_dev,
-					enum ena_intr_moder_level level,
-					struct ena_intr_moder_entry *entry);
-
-/* ena_com_get_intr_moderation_entry - Init ena_intr_moder_entry.
- * @ena_dev: ENA communication layer struct
- * @level: Interrupt moderation table level
- * @entry: Entry to fill.
- *
- * Initialize the entry according to the adaptive interrupt moderation table.
- */
-void ena_com_get_intr_moderation_entry(struct ena_com_dev *ena_dev,
-				       enum ena_intr_moder_level level,
-				       struct ena_intr_moder_entry *entry);
-
 /* ena_com_config_dev_mode - Configure the placement policy of the device.
  * @ena_dev: ENA communication layer struct
  * @llq_features: LLQ feature descriptor, retrieve via
@@ -1036,80 +976,11 @@ static inline void ena_com_disable_adaptive_moderation(struct ena_com_dev *ena_d
 	ena_dev->adaptive_coalescing = false;
 }
 
-/* ena_com_calculate_interrupt_delay - Calculate new interrupt delay
- * @ena_dev: ENA communication layer struct
- * @pkts: Number of packets since the last update
- * @bytes: Number of bytes received since the last update.
- * @smoothed_interval: Returned interval
- * @moder_tbl_idx: Current table level as input update new level as return
- * value.
- */
-static inline void ena_com_calculate_interrupt_delay(struct ena_com_dev *ena_dev,
-						     unsigned int pkts,
-						     unsigned int bytes,
-						     unsigned int *smoothed_interval,
-						     unsigned int *moder_tbl_idx)
-{
-	enum ena_intr_moder_level curr_moder_idx, new_moder_idx;
-	struct ena_intr_moder_entry *curr_moder_entry;
-	struct ena_intr_moder_entry *pred_moder_entry;
-	struct ena_intr_moder_entry *new_moder_entry;
-	struct ena_intr_moder_entry *intr_moder_tbl = ena_dev->intr_moder_tbl;
-	unsigned int interval;
-
-	/* We apply adaptive moderation on Rx path only.
-	 * Tx uses static interrupt moderation.
-	 */
-	if (!pkts || !bytes)
-		/* Tx interrupt, or spurious interrupt,
-		 * in both cases we just use same delay values
-		 */
-		return;
-
-	curr_moder_idx = (enum ena_intr_moder_level)(*moder_tbl_idx);
-	if (unlikely(curr_moder_idx >=  ENA_INTR_MAX_NUM_OF_LEVELS)) {
-		ena_trc_err("Wrong moderation index %u\n", curr_moder_idx);
-		return;
-	}
-
-	curr_moder_entry = &intr_moder_tbl[curr_moder_idx];
-	new_moder_idx = curr_moder_idx;
-
-	if (curr_moder_idx == ENA_INTR_MODER_LOWEST) {
-		if ((pkts > curr_moder_entry->pkts_per_interval) ||
-		    (bytes > curr_moder_entry->bytes_per_interval))
-			new_moder_idx =
-				(enum ena_intr_moder_level)(curr_moder_idx + ENA_INTR_MODER_LEVEL_STRIDE);
-	} else {
-		pred_moder_entry = &intr_moder_tbl[curr_moder_idx - ENA_INTR_MODER_LEVEL_STRIDE];
-
-		if ((pkts <= pred_moder_entry->pkts_per_interval) ||
-		    (bytes <= pred_moder_entry->bytes_per_interval))
-			new_moder_idx =
-				(enum ena_intr_moder_level)(curr_moder_idx - ENA_INTR_MODER_LEVEL_STRIDE);
-		else if ((pkts > curr_moder_entry->pkts_per_interval) ||
-			 (bytes > curr_moder_entry->bytes_per_interval)) {
-			if (curr_moder_idx != ENA_INTR_MODER_HIGHEST)
-				new_moder_idx =
-					(enum ena_intr_moder_level)(curr_moder_idx + ENA_INTR_MODER_LEVEL_STRIDE);
-		}
-	}
-	new_moder_entry = &intr_moder_tbl[new_moder_idx];
-
-	interval = new_moder_entry->intr_moder_interval;
-	*smoothed_interval = (
-		(interval * ENA_INTR_DELAY_NEW_VALUE_WEIGHT +
-		ENA_INTR_DELAY_OLD_VALUE_WEIGHT * (*smoothed_interval)) + 5) /
-		10;
-
-	*moder_tbl_idx = new_moder_idx;
-}
-
 /* ena_com_update_intr_reg - Prepare interrupt register
  * @intr_reg: interrupt register to update.
  * @rx_delay_interval: Rx interval in usecs
  * @tx_delay_interval: Tx interval in usecs
- * @unmask: unask enable/disable
+ * @unmask: unmask enable/disable
  *
  * Prepare interrupt update register with the supplied parameters.
  */
@@ -1154,15 +1025,6 @@ int ena_com_get_dev_extended_stats(struct ena_com_dev *ena_dev, char *buff,
 int ena_com_extended_stats_set_func_queue(struct ena_com_dev *ena_dev,
 					  u32 funct_queue);
 #endif
-#ifdef ENA_DEBUG
-int ena_com_set_trace(struct ena_com_dev *ena_dev, u32 severity,
-		      u32 type);
-
-void ena_com_get_trace(struct ena_com_dev *ena_dev, u32 *severity,
-		       u32 *type);
-
-int ena_com_trace_usage(char *buf, size_t size);
-#endif /* ENA_DEBUG */
 #if defined(__cplusplus)
 }
 #endif /* __cplusplus */

--- a/kernel/fbsd/ena/ena_com/ena_defs/ena_common_defs.h
+++ b/kernel/fbsd/ena/ena_com/ena_defs/ena_common_defs.h
@@ -1,7 +1,7 @@
 /*-
  * BSD LICENSE
  *
- * Copyright (c) 2015-2019 Amazon.com, Inc. or its affiliates.
+ * Copyright (c) 2015-2020 Amazon.com, Inc. or its affiliates.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -46,4 +46,4 @@ struct ena_common_mem_addr {
 	uint16_t reserved16;
 };
 
-#endif /*_ENA_COMMON_H_ */
+#endif /* _ENA_COMMON_H_ */

--- a/kernel/fbsd/ena/ena_com/ena_defs/ena_eth_io_defs.h
+++ b/kernel/fbsd/ena/ena_com/ena_defs/ena_eth_io_defs.h
@@ -1,7 +1,7 @@
 /*-
  * BSD LICENSE
  *
- * Copyright (c) 2015-2019 Amazon.com, Inc. or its affiliates.
+ * Copyright (c) 2015-2020 Amazon.com, Inc. or its affiliates.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -265,7 +265,9 @@ struct ena_eth_io_rx_cdesc_base {
 
 	uint16_t sub_qid;
 
-	uint16_t reserved;
+	uint8_t offset;
+
+	uint8_t reserved;
 };
 
 /* 8-word format */
@@ -965,4 +967,4 @@ static inline void set_ena_eth_io_numa_node_cfg_reg_enabled(struct ena_eth_io_nu
 }
 
 #endif /* !defined(DEFS_LINUX_MAINLINE) */
-#endif /*_ENA_ETH_IO_H_ */
+#endif /* _ENA_ETH_IO_H_ */

--- a/kernel/fbsd/ena/ena_com/ena_defs/ena_gen_info.h
+++ b/kernel/fbsd/ena/ena_com/ena_defs/ena_gen_info.h
@@ -1,7 +1,7 @@
 /*-
  * BSD LICENSE
  *
- * Copyright (c) 2015-2019 Amazon.com, Inc. or its affiliates.
+ * Copyright (c) 2015-2020 Amazon.com, Inc. or its affiliates.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -30,5 +30,5 @@
  * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
-#define	ENA_GEN_DATE	"Mon Oct  8 20:25:08 DST 2018"
-#define	ENA_GEN_COMMIT	"e70f3a6"
+#define	ENA_GEN_DATE	"Mon Apr 20 15:41:59 DST 2020"
+#define	ENA_GEN_COMMIT	"daa45ac"

--- a/kernel/fbsd/ena/ena_com/ena_defs/ena_regs_defs.h
+++ b/kernel/fbsd/ena/ena_com/ena_defs/ena_regs_defs.h
@@ -1,7 +1,7 @@
 /*-
  * BSD LICENSE
  *
- * Copyright (c) 2015-2019 Amazon.com, Inc. or its affiliates.
+ * Copyright (c) 2015-2020 Amazon.com, Inc. or its affiliates.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -49,6 +49,7 @@ enum ena_regs_reset_reason_types {
 	ENA_REGS_RESET_USER_TRIGGER                 = 12,
 	ENA_REGS_RESET_GENERIC                      = 13,
 	ENA_REGS_RESET_MISS_INTERRUPT               = 14,
+	ENA_REGS_RESET_LAST,
 };
 
 /* ena_registers offsets */
@@ -155,4 +156,4 @@ enum ena_regs_reset_reason_types {
 #define ENA_REGS_RSS_IND_ENTRY_UPDATE_CQ_IDX_SHIFT          16
 #define ENA_REGS_RSS_IND_ENTRY_UPDATE_CQ_IDX_MASK           0xffff0000
 
-#endif /*_ENA_REGS_H_ */
+#endif /* _ENA_REGS_H_ */

--- a/kernel/fbsd/ena/ena_com/ena_eth_com.c
+++ b/kernel/fbsd/ena/ena_com/ena_eth_com.c
@@ -1,7 +1,7 @@
 /*-
  * BSD LICENSE
  *
- * Copyright (c) 2015-2019 Amazon.com, Inc. or its affiliates.
+ * Copyright (c) 2015-2020 Amazon.com, Inc. or its affiliates.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -33,7 +33,7 @@
 
 #include "ena_eth_com.h"
 
-static inline struct ena_eth_io_rx_cdesc_base *ena_com_get_next_rx_cdesc(
+static struct ena_eth_io_rx_cdesc_base *ena_com_get_next_rx_cdesc(
 	struct ena_com_io_cq *io_cq)
 {
 	struct ena_eth_io_rx_cdesc_base *cdesc;
@@ -60,7 +60,7 @@ static inline struct ena_eth_io_rx_cdesc_base *ena_com_get_next_rx_cdesc(
 	return cdesc;
 }
 
-static inline void *get_sq_desc_regular_queue(struct ena_com_io_sq *io_sq)
+static void *get_sq_desc_regular_queue(struct ena_com_io_sq *io_sq)
 {
 	u16 tail_masked;
 	u32 offset;
@@ -72,7 +72,7 @@ static inline void *get_sq_desc_regular_queue(struct ena_com_io_sq *io_sq)
 	return (void *)((uintptr_t)io_sq->desc_addr.virt_addr + offset);
 }
 
-static inline int ena_com_write_bounce_buffer_to_dev(struct ena_com_io_sq *io_sq,
+static int ena_com_write_bounce_buffer_to_dev(struct ena_com_io_sq *io_sq,
 						     u8 *bounce_buffer)
 {
 	struct ena_com_llq_info *llq_info = &io_sq->llq_info;
@@ -113,7 +113,7 @@ static inline int ena_com_write_bounce_buffer_to_dev(struct ena_com_io_sq *io_sq
 	return ENA_COM_OK;
 }
 
-static inline int ena_com_write_header_to_bounce(struct ena_com_io_sq *io_sq,
+static int ena_com_write_header_to_bounce(struct ena_com_io_sq *io_sq,
 						 u8 *header_src,
 						 u16 header_len)
 {
@@ -143,7 +143,7 @@ static inline int ena_com_write_header_to_bounce(struct ena_com_io_sq *io_sq,
 	return 0;
 }
 
-static inline void *get_sq_desc_llq(struct ena_com_io_sq *io_sq)
+static void *get_sq_desc_llq(struct ena_com_io_sq *io_sq)
 {
 	struct ena_com_llq_pkt_ctrl *pkt_ctrl = &io_sq->llq_buf_ctrl;
 	u8 *bounce_buffer;
@@ -163,7 +163,7 @@ static inline void *get_sq_desc_llq(struct ena_com_io_sq *io_sq)
 	return sq_desc;
 }
 
-static inline int ena_com_close_bounce_buffer(struct ena_com_io_sq *io_sq)
+static int ena_com_close_bounce_buffer(struct ena_com_io_sq *io_sq)
 {
 	struct ena_com_llq_pkt_ctrl *pkt_ctrl = &io_sq->llq_buf_ctrl;
 	struct ena_com_llq_info *llq_info = &io_sq->llq_info;
@@ -176,8 +176,10 @@ static inline int ena_com_close_bounce_buffer(struct ena_com_io_sq *io_sq)
 	if (pkt_ctrl->idx) {
 		rc = ena_com_write_bounce_buffer_to_dev(io_sq,
 							pkt_ctrl->curr_bounce_buf);
-		if (unlikely(rc))
+		if (unlikely(rc)) {
+			ena_trc_err("failed to write bounce buffer to device\n");
 			return rc;
+		}
 
 		pkt_ctrl->curr_bounce_buf =
 			ena_com_get_next_bounce_buffer(&io_sq->bounce_buf_ctrl);
@@ -190,7 +192,7 @@ static inline int ena_com_close_bounce_buffer(struct ena_com_io_sq *io_sq)
 	return ENA_COM_OK;
 }
 
-static inline void *get_sq_desc(struct ena_com_io_sq *io_sq)
+static void *get_sq_desc(struct ena_com_io_sq *io_sq)
 {
 	if (io_sq->mem_queue_type == ENA_ADMIN_PLACEMENT_POLICY_DEV)
 		return get_sq_desc_llq(io_sq);
@@ -198,7 +200,7 @@ static inline void *get_sq_desc(struct ena_com_io_sq *io_sq)
 	return get_sq_desc_regular_queue(io_sq);
 }
 
-static inline int ena_com_sq_update_llq_tail(struct ena_com_io_sq *io_sq)
+static int ena_com_sq_update_llq_tail(struct ena_com_io_sq *io_sq)
 {
 	struct ena_com_llq_pkt_ctrl *pkt_ctrl = &io_sq->llq_buf_ctrl;
 	struct ena_com_llq_info *llq_info = &io_sq->llq_info;
@@ -207,13 +209,15 @@ static inline int ena_com_sq_update_llq_tail(struct ena_com_io_sq *io_sq)
 	if (!pkt_ctrl->descs_left_in_line) {
 		rc = ena_com_write_bounce_buffer_to_dev(io_sq,
 							pkt_ctrl->curr_bounce_buf);
-		if (unlikely(rc))
+		if (unlikely(rc)) {
+			ena_trc_err("failed to write bounce buffer to device\n");
 			return rc;
+		}
 
 		pkt_ctrl->curr_bounce_buf =
 			ena_com_get_next_bounce_buffer(&io_sq->bounce_buf_ctrl);
-			memset(io_sq->llq_buf_ctrl.curr_bounce_buf,
-			       0x0, llq_info->desc_list_entry_size);
+		memset(io_sq->llq_buf_ctrl.curr_bounce_buf,
+		       0x0, llq_info->desc_list_entry_size);
 
 		pkt_ctrl->idx = 0;
 		if (unlikely(llq_info->desc_stride_ctrl == ENA_ADMIN_SINGLE_DESC_PER_ENTRY))
@@ -226,7 +230,7 @@ static inline int ena_com_sq_update_llq_tail(struct ena_com_io_sq *io_sq)
 	return ENA_COM_OK;
 }
 
-static inline int ena_com_sq_update_tail(struct ena_com_io_sq *io_sq)
+static int ena_com_sq_update_tail(struct ena_com_io_sq *io_sq)
 {
 	if (io_sq->mem_queue_type == ENA_ADMIN_PLACEMENT_POLICY_DEV)
 		return ena_com_sq_update_llq_tail(io_sq);
@@ -240,7 +244,7 @@ static inline int ena_com_sq_update_tail(struct ena_com_io_sq *io_sq)
 	return ENA_COM_OK;
 }
 
-static inline struct ena_eth_io_rx_cdesc_base *
+static struct ena_eth_io_rx_cdesc_base *
 	ena_com_rx_cdesc_idx_to_ptr(struct ena_com_io_cq *io_cq, u16 idx)
 {
 	idx &= (io_cq->q_depth - 1);
@@ -249,7 +253,7 @@ static inline struct ena_eth_io_rx_cdesc_base *
 		idx * io_cq->cdesc_entry_size_in_bytes);
 }
 
-static inline u16 ena_com_cdesc_rx_pkt_get(struct ena_com_io_cq *io_cq,
+static u16 ena_com_cdesc_rx_pkt_get(struct ena_com_io_cq *io_cq,
 					   u16 *first_cdesc_idx)
 {
 	struct ena_eth_io_rx_cdesc_base *cdesc;
@@ -286,11 +290,10 @@ static inline u16 ena_com_cdesc_rx_pkt_get(struct ena_com_io_cq *io_cq,
 	return count;
 }
 
-static inline int ena_com_create_and_store_tx_meta_desc(struct ena_com_io_sq *io_sq,
-							struct ena_com_tx_ctx *ena_tx_ctx)
+static int ena_com_create_meta(struct ena_com_io_sq *io_sq,
+			       struct ena_com_tx_meta *ena_meta)
 {
 	struct ena_eth_io_tx_meta_desc *meta_desc = NULL;
-	struct ena_com_tx_meta *ena_meta = &ena_tx_ctx->ena_meta;
 
 	meta_desc = get_sq_desc(io_sq);
 	memset(meta_desc, 0x0, sizeof(struct ena_eth_io_tx_meta_desc));
@@ -310,12 +313,13 @@ static inline int ena_com_create_and_store_tx_meta_desc(struct ena_com_io_sq *io
 
 	/* Extended meta desc */
 	meta_desc->len_ctrl |= ENA_ETH_IO_TX_META_DESC_ETH_META_TYPE_MASK;
-	meta_desc->len_ctrl |= ENA_ETH_IO_TX_META_DESC_META_STORE_MASK;
 	meta_desc->len_ctrl |= (io_sq->phase <<
 		ENA_ETH_IO_TX_META_DESC_PHASE_SHIFT) &
 		ENA_ETH_IO_TX_META_DESC_PHASE_MASK;
 
 	meta_desc->len_ctrl |= ENA_ETH_IO_TX_META_DESC_FIRST_MASK;
+	meta_desc->len_ctrl |= ENA_ETH_IO_TX_META_DESC_META_STORE_MASK;
+
 	meta_desc->word2 |= ena_meta->l3_hdr_len &
 		ENA_ETH_IO_TX_META_DESC_L3_HDR_LEN_MASK;
 	meta_desc->word2 |= (ena_meta->l3_hdr_offset <<
@@ -326,16 +330,37 @@ static inline int ena_com_create_and_store_tx_meta_desc(struct ena_com_io_sq *io
 		ENA_ETH_IO_TX_META_DESC_L4_HDR_LEN_IN_WORDS_SHIFT) &
 		ENA_ETH_IO_TX_META_DESC_L4_HDR_LEN_IN_WORDS_MASK;
 
-	meta_desc->len_ctrl |= ENA_ETH_IO_TX_META_DESC_META_STORE_MASK;
-
-	/* Cached the meta desc */
-	memcpy(&io_sq->cached_tx_meta, ena_meta,
-	       sizeof(struct ena_com_tx_meta));
-
 	return ena_com_sq_update_tail(io_sq);
 }
 
-static inline void ena_com_rx_set_flags(struct ena_com_rx_ctx *ena_rx_ctx,
+static int ena_com_create_and_store_tx_meta_desc(struct ena_com_io_sq *io_sq,
+						 struct ena_com_tx_ctx *ena_tx_ctx,
+						 bool *have_meta)
+{
+	struct ena_com_tx_meta *ena_meta = &ena_tx_ctx->ena_meta;
+
+	/* When disable meta caching is set, don't bother to save the meta and
+	 * compare it to the stored version, just create the meta
+	 */
+	if (io_sq->disable_meta_caching) {
+		if (unlikely(!ena_tx_ctx->meta_valid))
+			return ENA_COM_INVAL;
+
+		*have_meta = true;
+		return ena_com_create_meta(io_sq, ena_meta);
+	} else if (ena_com_meta_desc_changed(io_sq, ena_tx_ctx)) {
+		*have_meta = true;
+		/* Cache the meta desc */
+		memcpy(&io_sq->cached_tx_meta, ena_meta,
+		       sizeof(struct ena_com_tx_meta));
+		return ena_com_create_meta(io_sq, ena_meta);
+	} else {
+		*have_meta = false;
+		return ENA_COM_OK;
+	}
+}
+
+static void ena_com_rx_set_flags(struct ena_com_rx_ctx *ena_rx_ctx,
 					struct ena_eth_io_rx_cdesc_base *cdesc)
 {
 	ena_rx_ctx->l3_proto = cdesc->status &
@@ -401,24 +426,26 @@ int ena_com_prepare_tx(struct ena_com_io_sq *io_sq,
 	}
 
 	if (unlikely(io_sq->mem_queue_type == ENA_ADMIN_PLACEMENT_POLICY_DEV
-		     && !buffer_to_push))
+		     && !buffer_to_push)) {
+		ena_trc_err("push header wasn't provided on LLQ mode\n");
 		return ENA_COM_INVAL;
+	}
 
 	rc = ena_com_write_header_to_bounce(io_sq, buffer_to_push, header_len);
 	if (unlikely(rc))
 		return rc;
 
-	have_meta = ena_tx_ctx->meta_valid && ena_com_meta_desc_changed(io_sq,
-			ena_tx_ctx);
-	if (have_meta) {
-		rc = ena_com_create_and_store_tx_meta_desc(io_sq, ena_tx_ctx);
-		if (unlikely(rc))
-			return rc;
+	rc = ena_com_create_and_store_tx_meta_desc(io_sq, ena_tx_ctx, &have_meta);
+	if (unlikely(rc)) {
+		ena_trc_err("failed to create and store tx meta desc\n");
+		return rc;
 	}
 
 	/* If the caller doesn't want to send packets */
 	if (unlikely(!num_bufs && !header_len)) {
 		rc = ena_com_close_bounce_buffer(io_sq);
+		if (rc)
+			ena_trc_err("failed to write buffers to LLQ\n");
 		*nb_hw_desc = io_sq->tail - start_tail;
 		return rc;
 	}
@@ -478,8 +505,10 @@ int ena_com_prepare_tx(struct ena_com_io_sq *io_sq,
 		/* The first desc share the same desc as the header */
 		if (likely(i != 0)) {
 			rc = ena_com_sq_update_tail(io_sq);
-			if (unlikely(rc))
+			if (unlikely(rc)) {
+				ena_trc_err("failed to update sq tail\n");
 				return rc;
+			}
 
 			desc = get_sq_desc(io_sq);
 			if (unlikely(!desc))
@@ -508,10 +537,14 @@ int ena_com_prepare_tx(struct ena_com_io_sq *io_sq,
 	desc->len_ctrl |= ENA_ETH_IO_TX_DESC_LAST_MASK;
 
 	rc = ena_com_sq_update_tail(io_sq);
-	if (unlikely(rc))
+	if (unlikely(rc)) {
+		ena_trc_err("failed to update sq tail of the last descriptor\n");
 		return rc;
+	}
 
 	rc = ena_com_close_bounce_buffer(io_sq);
+	if (rc)
+		ena_trc_err("failed when closing bounce buffer\n");
 
 	*nb_hw_desc = io_sq->tail - start_tail;
 	return rc;
@@ -525,7 +558,7 @@ int ena_com_rx_pkt(struct ena_com_io_cq *io_cq,
 	struct ena_eth_io_rx_cdesc_base *cdesc = NULL;
 	u16 cdesc_idx = 0;
 	u16 nb_hw_desc;
-	u16 i;
+	u16 i = 0;
 
 	ENA_WARN(io_cq->direction != ENA_COM_IO_QUEUE_DIRECTION_RX,
 		 "wrong Q type");
@@ -545,13 +578,14 @@ int ena_com_rx_pkt(struct ena_com_io_cq *io_cq,
 		return ENA_COM_NO_SPACE;
 	}
 
-	for (i = 0; i < nb_hw_desc; i++) {
-		cdesc = ena_com_rx_cdesc_idx_to_ptr(io_cq, cdesc_idx + i);
+	cdesc = ena_com_rx_cdesc_idx_to_ptr(io_cq, cdesc_idx);
+	ena_rx_ctx->pkt_offset = cdesc->offset;
 
+	do {
 		ena_buf->len = cdesc->length;
 		ena_buf->req_id = cdesc->req_id;
 		ena_buf++;
-	}
+	} while ((++i < nb_hw_desc) && (cdesc = ena_com_rx_cdesc_idx_to_ptr(io_cq, cdesc_idx + i)));
 
 	/* Update SQ head ptr */
 	io_sq->next_to_comp += nb_hw_desc;

--- a/kernel/fbsd/ena/ena_com/ena_eth_com.h
+++ b/kernel/fbsd/ena/ena_com/ena_eth_com.h
@@ -1,7 +1,7 @@
 /*-
  * BSD LICENSE
  *
- * Copyright (c) 2015-2019 Amazon.com, Inc. or its affiliates.
+ * Copyright (c) 2015-2020 Amazon.com, Inc. or its affiliates.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -77,6 +77,7 @@ struct ena_com_rx_ctx {
 	u32 hash;
 	u16 descs;
 	int max_bufs;
+	u8 pkt_offset;
 };
 
 int ena_com_prepare_tx(struct ena_com_io_sq *io_sq,
@@ -99,7 +100,7 @@ static inline void ena_com_unmask_intr(struct ena_com_io_cq *io_cq,
 	ENA_REG_WRITE32(io_cq->bus, intr_reg->intr_control, io_cq->unmask_reg);
 }
 
-static inline int ena_com_free_desc(struct ena_com_io_sq *io_sq)
+static inline int ena_com_free_q_entries(struct ena_com_io_sq *io_sq)
 {
 	u16 tail, next_to_comp, cnt;
 
@@ -117,7 +118,7 @@ static inline bool ena_com_sq_have_enough_space(struct ena_com_io_sq *io_sq,
 	int temp;
 
 	if (io_sq->mem_queue_type == ENA_ADMIN_PLACEMENT_POLICY_HOST)
-		return ena_com_free_desc(io_sq) >= required_buffers;
+		return ena_com_free_q_entries(io_sq) >= required_buffers;
 
 	/* This calculation doesn't need to be 100% accurate. So to reduce
 	 * the calculation overhead just Subtract 2 lines from the free descs
@@ -126,7 +127,7 @@ static inline bool ena_com_sq_have_enough_space(struct ena_com_io_sq *io_sq,
 	 */
 	temp = required_buffers / io_sq->llq_info.descs_per_entry + 2;
 
-	return ena_com_free_desc(io_sq) > temp;
+	return ena_com_free_q_entries(io_sq) > temp;
 }
 
 static inline bool ena_com_meta_desc_changed(struct ena_com_io_sq *io_sq,
@@ -160,7 +161,8 @@ static inline bool ena_com_is_doorbell_needed(struct ena_com_io_sq *io_sq,
 	llq_info = &io_sq->llq_info;
 	num_descs = ena_tx_ctx->num_bufs;
 
-	if (unlikely(ena_com_meta_desc_changed(io_sq, ena_tx_ctx)))
+	if (llq_info->disable_meta_caching ||
+	    unlikely(ena_com_meta_desc_changed(io_sq, ena_tx_ctx)))
 		++num_descs;
 
 	if (num_descs > llq_info->descs_num_before_header) {
@@ -177,8 +179,8 @@ static inline bool ena_com_is_doorbell_needed(struct ena_com_io_sq *io_sq,
 
 static inline int ena_com_write_sq_doorbell(struct ena_com_io_sq *io_sq)
 {
-	u16 tail = io_sq->tail;
 	u16 max_entries_in_tx_burst = io_sq->llq_info.max_entries_in_tx_burst;
+	u16 tail = io_sq->tail;
 
 	ena_trc_dbg("write submission queue doorbell for queue: %d tail: %d\n",
 		    io_sq->qid, tail);
@@ -199,15 +201,17 @@ static inline int ena_com_update_dev_comp_head(struct ena_com_io_cq *io_cq)
 	u16 unreported_comp, head;
 	bool need_update;
 
-	head = io_cq->head;
-	unreported_comp = head - io_cq->last_head_update;
-	need_update = unreported_comp > (io_cq->q_depth / ENA_COMP_HEAD_THRESH);
+	if (unlikely(io_cq->cq_head_db_reg)) {
+		head = io_cq->head;
+		unreported_comp = head - io_cq->last_head_update;
+		need_update = unreported_comp > (io_cq->q_depth / ENA_COMP_HEAD_THRESH);
 
-	if (io_cq->cq_head_db_reg && need_update) {
-		ena_trc_dbg("Write completion queue doorbell for queue %d: head: %d\n",
-			    io_cq->qid, head);
-		ENA_REG_WRITE32(io_cq->bus, head, io_cq->cq_head_db_reg);
-		io_cq->last_head_update = head;
+		if (unlikely(need_update)) {
+			ena_trc_dbg("Write completion queue doorbell for queue %d: head: %d\n",
+				    io_cq->qid, head);
+			ENA_REG_WRITE32(io_cq->bus, head, io_cq->cq_head_db_reg);
+			io_cq->last_head_update = head;
+		}
 	}
 
 	return 0;

--- a/kernel/fbsd/ena/ena_com/ena_plat.h
+++ b/kernel/fbsd/ena/ena_com/ena_plat.h
@@ -1,7 +1,7 @@
 /*-
  * BSD LICENSE
  *
- * Copyright (c) 2015-2019 Amazon.com, Inc. or its affiliates.
+ * Copyright (c) 2015-2020 Amazon.com, Inc. or its affiliates.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -65,6 +65,7 @@ __FBSDID("$FreeBSD$");
 #include <machine/in_cksum.h>
 #include <machine/pcpu.h>
 #include <machine/resource.h>
+#include <machine/_inttypes.h>
 
 #include <net/bpf.h>
 #include <net/ethernet.h>
@@ -124,8 +125,8 @@ extern int ena_log_level;
 #define ena_trc_warn(format, arg...) 	ena_trace(ENA_WARNING, format, ##arg)
 #define ena_trc_err(format, arg...) 	ena_trace(ENA_ALERT, format, ##arg)
 
-#define unlikely(x)	__predict_false(x)
-#define likely(x)  	__predict_true(x)
+#define unlikely(x)	__predict_false(!!(x))
+#define likely(x)  	__predict_true(!!(x))
 
 #define __iomem
 #define ____cacheline_aligned __aligned(CACHE_LINE_SIZE)
@@ -186,10 +187,11 @@ static inline long PTR_ERR(const void *ptr)
 #define ENA_COM_TIMER_EXPIRED	ETIMEDOUT
 
 #define ENA_MSLEEP(x) 		pause_sbt("ena", SBT_1MS * (x), SBT_1MS, 0)
+#define ENA_USLEEP(x) 		pause_sbt("ena", SBT_1US * (x), SBT_1US, 0)
 #define ENA_UDELAY(x) 		DELAY(x)
 #define ENA_GET_SYSTEM_TIMEOUT(timeout_us) \
     ((long)cputick2usec(cpu_ticks()) + (timeout_us))
-#define ENA_TIME_EXPIRE(timeout)  ((timeout) < (long)cputick2usec(cpu_ticks()))
+#define ENA_TIME_EXPIRE(timeout)  ((timeout) < cputick2usec(cpu_ticks()))
 #define ENA_MIGHT_SLEEP()
 
 #define min_t(type, _x, _y) ((type)(_x) < (type)(_y) ? (type)(_x) : (type)(_y))
@@ -276,10 +278,22 @@ struct ena_bus {
 
 typedef uint32_t ena_atomic32_t;
 
+#define ENA_PRIu64 PRIu64
+
+typedef uint64_t ena_time_t;
+
 void	ena_dmamap_callback(void *arg, bus_dma_segment_t *segs, int nseg,
     int error);
 int	ena_dma_alloc(device_t dmadev, bus_size_t size, ena_mem_handle_t *dma,
     int mapflags);
+
+static inline uint32_t
+ena_reg_read32(struct ena_bus *bus, bus_size_t offset)
+{
+	uint32_t v = bus_space_read_4(bus->reg_bar_t, bus->reg_bar_h, offset);
+	rmb();
+	return v;
+}
 
 #define ENA_MEMCPY_TO_DEVICE_64(dst, src, size)				\
 	do {								\
@@ -294,7 +308,11 @@ int	ena_dma_alloc(device_t dmadev, bus_size_t size, ena_mem_handle_t *dma,
 
 #define ENA_MEM_ALLOC(dmadev, size) malloc(size, M_DEVBUF, M_NOWAIT | M_ZERO)
 #define ENA_MEM_ALLOC_NODE(dmadev, size, virt, node, dev_node) (virt = NULL)
-#define ENA_MEM_FREE(dmadev, ptr) free(ptr, M_DEVBUF)
+#define ENA_MEM_FREE(dmadev, ptr, size)					\
+	do { 								\
+		(void)(size);						\
+		free(ptr, M_DEVBUF);					\
+	} while (0)
 #define ENA_MEM_ALLOC_COHERENT_NODE(dmadev, size, virt, phys, handle, node, \
     dev_node)								\
 	do {								\
@@ -321,18 +339,19 @@ int	ena_dma_alloc(device_t dmadev, bus_size_t size, ena_mem_handle_t *dma,
 
 /* Register R/W methods */
 #define ENA_REG_WRITE32(bus, value, offset)				\
+	do {								\
+		wmb();							\
+		ENA_REG_WRITE32_RELAXED(bus, value, offset);		\
+	} while (0)
+
+#define ENA_REG_WRITE32_RELAXED(bus, value, offset)			\
 	bus_space_write_4(						\
 			  ((struct ena_bus*)bus)->reg_bar_t,		\
 			  ((struct ena_bus*)bus)->reg_bar_h,		\
 			  (bus_size_t)(offset), (value))
-#define ENA_REG_WRITE32_RELAXED(bus, value, offset)			\
-	ENA_REG_WRITE32(bus, value, offset)
 
 #define ENA_REG_READ32(bus, offset)					\
-	bus_space_read_4(						\
-			 ((struct ena_bus*)bus)->reg_bar_t,		\
-			 ((struct ena_bus*)bus)->reg_bar_h,		\
-			 (bus_size_t)(offset))
+	ena_reg_read32((struct ena_bus*)(bus), (bus_size_t)(offset))
 
 #define ENA_DB_SYNC_WRITE(mem_handle) bus_dmamap_sync(			\
 	(mem_handle)->tag, (mem_handle)->map, BUS_DMASYNC_PREWRITE)
@@ -383,6 +402,12 @@ int	ena_dma_alloc(device_t dmadev, bus_size_t size, ena_mem_handle_t *dma,
 #define lower_32_bits(n) ((uint32_t)(n))
 
 #define DIV_ROUND_UP(n, d) (((n) + (d) - 1) / (d))
+
+#define ENA_FFS(x) ffs(x)
+
+void	ena_rss_key_fill(void *key, size_t size);
+
+#define ENA_RSS_FILL_KEY(key, size) ena_rss_key_fill(key, size)
 
 #include "ena_defs/ena_includes.h"
 

--- a/kernel/fbsd/ena/ena_datapath.h
+++ b/kernel/fbsd/ena/ena_datapath.h
@@ -1,7 +1,7 @@
 /*-
  * BSD LICENSE
  *
- * Copyright (c) 2015-2019 Amazon.com, Inc. or its affiliates.
+ * Copyright (c) 2015-2020 Amazon.com, Inc. or its affiliates.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -34,9 +34,9 @@
 #ifndef ENA_TXRX_H
 #define ENA_TXRX_H
 
-void	ena_cleanup(void *, int);
-void	ena_qflush(if_t);
-int	ena_mq_start(if_t, struct mbuf *);
-void	ena_deferred_mq_start(void *, int);
+void	ena_cleanup(void *arg, int pending);
+void	ena_qflush(if_t ifp);
+int	ena_mq_start(if_t ifp, struct mbuf *m);
+void	ena_deferred_mq_start(void *arg, int pending);
 
 #endif /* ENA_TXRX_H */

--- a/kernel/fbsd/ena/ena_netmap.h
+++ b/kernel/fbsd/ena/ena_netmap.h
@@ -1,7 +1,7 @@
 /*-
  * BSD LICENSE
  *
- * Copyright (c) 2015-2019 Amazon.com, Inc. or its affiliates.
+ * Copyright (c) 2015-2020 Amazon.com, Inc. or its affiliates.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -46,15 +46,15 @@
 #include <sys/selinfo.h>
 #include <dev/netmap/netmap_kern.h>
 
-int	ena_netmap_attach(struct ena_adapter *);
-int	ena_netmap_alloc_rx_slot(struct ena_adapter *, struct ena_ring *,
-    struct ena_rx_buffer *);
-void	ena_netmap_free_rx_slot(struct ena_adapter *, struct ena_ring *,
-    struct ena_rx_buffer *);
-bool	ena_rx_ring_in_netmap(struct ena_adapter *, int);
-bool	ena_tx_ring_in_netmap(struct ena_adapter *, int);
-void	ena_netmap_reset_rx_ring(struct ena_adapter *, int);
-void	ena_netmap_reset_tx_ring(struct ena_adapter *, int);
-void	ena_netmap_unload(struct ena_adapter *, bus_dmamap_t);
+int	ena_netmap_attach(struct ena_adapter *adapter);
+int	ena_netmap_alloc_rx_slot(struct ena_adapter *adapter,
+    struct ena_ring *rx_ring, struct ena_rx_buffer *rx_info);
+void	ena_netmap_free_rx_slot(struct ena_adapter *adapter,
+    struct ena_ring *rx_ring, struct ena_rx_buffer *rx_info);
+bool	ena_rx_ring_in_netmap(struct ena_adapter *adapter, int qid);
+bool	ena_tx_ring_in_netmap(struct ena_adapter *adapter, int qid);
+void	ena_netmap_reset_rx_ring(struct ena_adapter *adapter, int qid);
+void	ena_netmap_reset_tx_ring(struct ena_adapter *adapter, int qid);
+void	ena_netmap_unload(struct ena_adapter *adapter, bus_dmamap_t map);
 
 #endif /* _ENA_NETMAP_H_ */

--- a/kernel/fbsd/ena/ena_sysctl.h
+++ b/kernel/fbsd/ena/ena_sysctl.h
@@ -1,7 +1,7 @@
 /*-
  * BSD LICENSE
  *
- * Copyright (c) 2015-2019 Amazon.com, Inc. or its affiliates.
+ * Copyright (c) 2015-2020 Amazon.com, Inc. or its affiliates.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -39,6 +39,9 @@
 
 #include "ena.h"
 
-void	ena_sysctl_add_nodes(struct ena_adapter *);
+void	ena_sysctl_add_nodes(struct ena_adapter *adapter);
+
+extern int ena_enable_9k_mbufs;
+#define ena_mbuf_sz (ena_enable_9k_mbufs ? MJUM9BYTES : MJUMPAGESIZE)
 
 #endif /* !(ENA_SYSCTL_H) */


### PR DESCRIPTION
Changes since last release (v2.1.1)

**New Features**
* Add 'Tx drops' statistic which can be acquired by probing sysctl:
  dev.ena.#.hw_stats.tx_drops
  Where # stands for the interface number (0, 1, 2, ...).
* Mark the driver as epoch ready, to properly support latest FreeBSD 13
  stack changes.
* Allow changing the number of IO queues during runtime by using sysctl:
  dev.ena.#.io_queues_nb
  Where # stands for the interface number (0, 1, 2, ...).
* Generate default RSS key using RNG in order to improve security.

**Bug Fixes**
* Fix ENA IO memory read/write macros - add appropriate barriers where
  needed and remove them where they are no longer needed.
* Tx DMA mapping in case of the LLQ is being used was totally reworked
  to improve stability and simplicity.
* Rx refill optimization for low memory conditions - by default page
  size clusters are now being used. It can be reverted, as it may affect
  performance a bit, by setting sysctl "hw.ena.enable_9k_mbufs" to "1"
  in "/boot/loader.conf" file.
* Prevent driver from limiting IO queue number in case number of
  MSIx vectors changed between device resets.
* Update 'make clean' to remove 'opt_global.h' which started to appear on
  FreeBSD 13.
* Fix build for arm64 FreeBSD 12.

**Minor Changes**
* Update HAL to the newer version.
* Driver version can now be acquired probing sysctl:
  hw.ena.driver_version
* Improve locking on the configuration path - the driver was using two
  different locks and now it is unified.
* Rework Rx queue size configuration to do not use hardcoded values and
  to avoid device reset upon doing so.
* Tx buffer ring size reconfiguration was also reworked for the same
  purpose.
* Create queues with optional backoff in case the OS cannot provide
  enough resources while setting up the queues.
* Allow to disable meta caching for Tx path - it may be requested by the
  device.
* Set all sysctl nodes and procedures as MP safe.

Signed-off-by: Michal Krawczyk <mk@semihalf.com>

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
