### PR TITLE
dpdk/ena: backport patches from up 19.11, 20.02 and 20.05

### DIFF
--- a/userspace/dpdk/16.04/0001-Backport-ENA-PMD-to-v16.04.patch
+++ b/userspace/dpdk/16.04/0001-Backport-ENA-PMD-to-v16.04.patch
@@ -1,7 +1,7 @@
 From 65a31061fe33969bfc2dc73862d5446f0327041c Mon Sep 17 00:00:00 2001
 From: Michal Krawczyk <mk@semihalf.com>
 Date: Mon, 4 Sep 2017 14:46:32 +0200
-Subject: [PATCH 01/14] Backport ENA PMD to v16.04
+Subject: [PATCH 01/21] Backport ENA PMD to v16.04
 
 The ENA PMD was backported from the commit:
 222555480a7f9979d10faa9bb8b9773b0e1aa058
@@ -27,7 +27,7 @@ net/ena: add memory initialization for the allocation macros
  11 files changed, 793 insertions(+), 728 deletions(-)
 
 diff --git a/drivers/net/ena/Makefile b/drivers/net/ena/Makefile
-index ac2b55dc7..bf1f5da07 100644
+index ac2b55dc7b..bf1f5da07c 100644
 --- a/drivers/net/ena/Makefile
 +++ b/drivers/net/ena/Makefile
 @@ -51,11 +51,6 @@ SRCS-$(CONFIG_RTE_LIBRTE_ENA_PMD) += ena_ethdev.c
@@ -43,7 +43,7 @@ index ac2b55dc7..bf1f5da07 100644
  
  include $(RTE_SDK)/mk/rte.lib.mk
 diff --git a/drivers/net/ena/base/ena_com.c b/drivers/net/ena/base/ena_com.c
-index a21a95130..38a058775 100644
+index a21a951304..38a0587754 100644
 --- a/drivers/net/ena/base/ena_com.c
 +++ b/drivers/net/ena/base/ena_com.c
 @@ -42,9 +42,6 @@
@@ -667,7 +667,7 @@ index a21a95130..38a058775 100644
  
  	rc = ena_com_get_feature(ena_dev, &get_resp,
 diff --git a/drivers/net/ena/base/ena_com.h b/drivers/net/ena/base/ena_com.h
-index 19e53ffbf..e53459262 100644
+index 19e53ffbf7..e534592620 100644
 --- a/drivers/net/ena/base/ena_com.h
 +++ b/drivers/net/ena/base/ena_com.h
 @@ -120,8 +120,8 @@ struct ena_com_rx_buf_info {
@@ -850,7 +850,7 @@ index 19e53ffbf..e53459262 100644
  		ena_trc_err("Wrong moderation index %u\n", curr_moder_idx);
  		return;
 diff --git a/drivers/net/ena/base/ena_defs/ena_admin_defs.h b/drivers/net/ena/base/ena_defs/ena_admin_defs.h
-index fe4124697..7a031d903 100644
+index fe4124697a..7a031d903d 100644
 --- a/drivers/net/ena/base/ena_defs/ena_admin_defs.h
 +++ b/drivers/net/ena/base/ena_defs/ena_admin_defs.h
 @@ -58,30 +58,6 @@ enum ena_admin_aq_opcode {
@@ -1072,7 +1072,7 @@ index fe4124697..7a031d903 100644
  
  static inline uint16_t
 diff --git a/drivers/net/ena/base/ena_defs/ena_eth_io_defs.h b/drivers/net/ena/base/ena_defs/ena_eth_io_defs.h
-index a547033d1..6bc3d6a7c 100644
+index a547033d1c..6bc3d6a7cf 100644
 --- a/drivers/net/ena/base/ena_defs/ena_eth_io_defs.h
 +++ b/drivers/net/ena/base/ena_defs/ena_eth_io_defs.h
 @@ -87,28 +87,17 @@ struct ena_eth_io_tx_desc {
@@ -1848,7 +1848,7 @@ index a547033d1..6bc3d6a7c 100644
  #endif /* !defined(ENA_DEFS_LINUX_MAINLINE) */
  #endif /*_ENA_ETH_IO_H_ */
 diff --git a/drivers/net/ena/base/ena_defs/ena_gen_info.h b/drivers/net/ena/base/ena_defs/ena_gen_info.h
-index 4abdffed7..3d2520963 100644
+index 4abdffed77..3d25209632 100644
 --- a/drivers/net/ena/base/ena_defs/ena_gen_info.h
 +++ b/drivers/net/ena/base/ena_defs/ena_gen_info.h
 @@ -31,5 +31,5 @@
@@ -1860,7 +1860,7 @@ index 4abdffed7..3d2520963 100644
 +#define	ENA_GEN_DATE	"Sun Jun  5 10:24:39 IDT 2016"
 +#define	ENA_GEN_COMMIT	"17146ed"
 diff --git a/drivers/net/ena/base/ena_eth_com.c b/drivers/net/ena/base/ena_eth_com.c
-index 459e0bbb9..290a5666f 100644
+index 459e0bbb9d..290a5666fb 100644
 --- a/drivers/net/ena/base/ena_eth_com.c
 +++ b/drivers/net/ena/base/ena_eth_com.c
 @@ -62,7 +62,7 @@ static inline void ena_com_cq_inc_head(struct ena_com_io_cq *io_cq)
@@ -1964,7 +1964,7 @@ index 459e0bbb9..290a5666f 100644
  	ena_com_cq_inc_head(io_cq);
  
 diff --git a/drivers/net/ena/base/ena_eth_com.h b/drivers/net/ena/base/ena_eth_com.h
-index 325d69c0f..71a880c0f 100644
+index 325d69c0f5..71a880c0f1 100644
 --- a/drivers/net/ena/base/ena_eth_com.h
 +++ b/drivers/net/ena/base/ena_eth_com.h
 @@ -142,6 +142,20 @@ static inline int ena_com_update_dev_comp_head(struct ena_com_io_cq *io_cq)
@@ -1989,7 +1989,7 @@ index 325d69c0f..71a880c0f 100644
  {
  	io_sq->next_to_comp += elem;
 diff --git a/drivers/net/ena/base/ena_plat_dpdk.h b/drivers/net/ena/base/ena_plat_dpdk.h
-index aab2ac865..a812d75e2 100644
+index aab2ac8656..a812d75e2c 100644
 --- a/drivers/net/ena/base/ena_plat_dpdk.h
 +++ b/drivers/net/ena/base/ena_plat_dpdk.h
 @@ -62,10 +62,10 @@ typedef uint64_t dma_addr_t;
@@ -2096,7 +2096,7 @@ index aab2ac865..a812d75e2 100644
  static inline void writel(u32 value, volatile void  *addr)
  {
 diff --git a/drivers/net/ena/ena_ethdev.c b/drivers/net/ena/ena_ethdev.c
-index 02af67a24..8823c51cf 100644
+index 02af67a24b..8823c51cf8 100644
 --- a/drivers/net/ena/ena_ethdev.c
 +++ b/drivers/net/ena/ena_ethdev.c
 @@ -37,6 +37,8 @@
@@ -2917,7 +2917,7 @@ index 02af67a24..8823c51cf 100644
  
  PMD_REGISTER_DRIVER(ena_pmd_drv);
 diff --git a/drivers/net/ena/ena_ethdev.h b/drivers/net/ena/ena_ethdev.h
-index ba6f01e66..dc3080ffd 100644
+index ba6f01e666..dc3080ffd3 100644
 --- a/drivers/net/ena/ena_ethdev.h
 +++ b/drivers/net/ena/ena_ethdev.h
 @@ -42,30 +42,12 @@

--- a/userspace/dpdk/16.04/0002-net-ena-do-not-set-Tx-L4-offloads-in-Rx-path.patch
+++ b/userspace/dpdk/16.04/0002-net-ena-do-not-set-Tx-L4-offloads-in-Rx-path.patch
@@ -1,7 +1,7 @@
 From 3941b2982c75bd966ab918e429f76acef8eb3a0e Mon Sep 17 00:00:00 2001
 From: Rafal Kozik <rk@semihalf.com>
 Date: Tue, 9 Jan 2018 16:19:08 +0100
-Subject: [PATCH 02/14] net/ena: do not set Tx L4 offloads in Rx path
+Subject: [PATCH 02/21] net/ena: do not set Tx L4 offloads in Rx path
 
 [ upstream commit fd617795679019c7aea5ab1e8c85db02cf53f169 ]
 
@@ -23,7 +23,7 @@ Signed-off-by: Michal Krawczyk <mk@semihalf.com>
  1 file changed, 6 insertions(+), 4 deletions(-)
 
 diff --git a/drivers/net/ena/ena_ethdev.c b/drivers/net/ena/ena_ethdev.c
-index 8823c51cf..9d677b8d7 100644
+index 8823c51cf8..9d677b8d7f 100644
 --- a/drivers/net/ena/ena_ethdev.c
 +++ b/drivers/net/ena/ena_ethdev.c
 @@ -258,16 +258,17 @@ static inline void ena_rx_mbuf_prepare(struct rte_mbuf *mbuf,

--- a/userspace/dpdk/16.04/0003-net-ena-check-pointer-before-memset.patch
+++ b/userspace/dpdk/16.04/0003-net-ena-check-pointer-before-memset.patch
@@ -1,7 +1,7 @@
 From 262082943426689695cb5d4688abceef809f0dab Mon Sep 17 00:00:00 2001
 From: Rafal Kozik <rk@semihalf.com>
 Date: Thu, 7 Jun 2018 11:43:18 +0200
-Subject: [PATCH 03/14] net/ena: check pointer before memset
+Subject: [PATCH 03/21] net/ena: check pointer before memset
 
 [ upstream commit 46916aa17d4b2007df8c0454f99ba0ca8b8cb93b ]
 
@@ -19,7 +19,7 @@ Acked-by: Michal Krawczyk <mk@semihalf.com>
  1 file changed, 16 insertions(+), 6 deletions(-)
 
 diff --git a/drivers/net/ena/base/ena_plat_dpdk.h b/drivers/net/ena/base/ena_plat_dpdk.h
-index a812d75e2..cc69b3372 100644
+index a812d75e2c..cc69b33726 100644
 --- a/drivers/net/ena/base/ena_plat_dpdk.h
 +++ b/drivers/net/ena/base/ena_plat_dpdk.h
 @@ -188,10 +188,15 @@ typedef uint64_t dma_addr_t;

--- a/userspace/dpdk/16.04/0004-net-ena-change-memory-type.patch
+++ b/userspace/dpdk/16.04/0004-net-ena-change-memory-type.patch
@@ -1,7 +1,7 @@
 From db52b57f5e85c103a254cf1f055dbd641a316881 Mon Sep 17 00:00:00 2001
 From: Rafal Kozik <rk@semihalf.com>
 Date: Thu, 7 Jun 2018 11:43:19 +0200
-Subject: [PATCH 04/14] net/ena: change memory type
+Subject: [PATCH 04/21] net/ena: change memory type
 
 [ upstream commit 9f32c7e7e6ce58ab772913f54f8328c1c0186a17 ]
 
@@ -22,7 +22,7 @@ Acked-by: Michal Krawczyk <mk@semihalf.com>
  1 file changed, 1 insertion(+), 7 deletions(-)
 
 diff --git a/drivers/net/ena/base/ena_plat_dpdk.h b/drivers/net/ena/base/ena_plat_dpdk.h
-index cc69b3372..ff873e807 100644
+index cc69b33726..ff873e807d 100644
 --- a/drivers/net/ena/base/ena_plat_dpdk.h
 +++ b/drivers/net/ena/base/ena_plat_dpdk.h
 @@ -223,14 +223,8 @@ typedef uint64_t dma_addr_t;

--- a/userspace/dpdk/16.04/0005-net-ena-fix-GENMASK_ULL-macro.patch
+++ b/userspace/dpdk/16.04/0005-net-ena-fix-GENMASK_ULL-macro.patch
@@ -1,7 +1,7 @@
 From 0bdbbc2dd91c97c89fa5ca57e37013a4f204693c Mon Sep 17 00:00:00 2001
 From: Rafal Kozik <rk@semihalf.com>
 Date: Thu, 7 Jun 2018 11:43:20 +0200
-Subject: [PATCH 05/14] net/ena: fix GENMASK_ULL macro
+Subject: [PATCH 05/21] net/ena: fix GENMASK_ULL macro
 
 [ upstream commit 7544aee8d0b4ae0262b1ba7e1539cf8171664df7 ]
 
@@ -20,7 +20,7 @@ Acked-by: Michal Krawczyk <mk@semihalf.com>
  1 file changed, 3 insertions(+), 1 deletion(-)
 
 diff --git a/drivers/net/ena/base/ena_plat_dpdk.h b/drivers/net/ena/base/ena_plat_dpdk.h
-index ff873e807..791b44ff7 100644
+index ff873e807d..791b44ff72 100644
 --- a/drivers/net/ena/base/ena_plat_dpdk.h
 +++ b/drivers/net/ena/base/ena_plat_dpdk.h
 @@ -115,11 +115,13 @@ typedef uint64_t dma_addr_t;

--- a/userspace/dpdk/16.04/0006-net-ena-set-link-speed-as-none.patch
+++ b/userspace/dpdk/16.04/0006-net-ena-set-link-speed-as-none.patch
@@ -1,7 +1,7 @@
 From 36c229d1eeb16670c7b3cc219cbe7287554e7738 Mon Sep 17 00:00:00 2001
 From: Rafal Kozik <rk@semihalf.com>
 Date: Thu, 7 Jun 2018 11:43:22 +0200
-Subject: [PATCH 06/14] net/ena: set link speed as none
+Subject: [PATCH 06/21] net/ena: set link speed as none
 
 [ upstream commit 41e59028dd8ab2038a7655c6fc3098222661aa53 ]
 
@@ -21,7 +21,7 @@ Acked-by: Michal Krawczyk <mk@semihalf.com>
  1 file changed, 1 insertion(+), 1 deletion(-)
 
 diff --git a/drivers/net/ena/ena_ethdev.c b/drivers/net/ena/ena_ethdev.c
-index 9d677b8d7..98848e935 100644
+index 9d677b8d7f..98848e935f 100644
 --- a/drivers/net/ena/ena_ethdev.c
 +++ b/drivers/net/ena/ena_ethdev.c
 @@ -707,7 +707,7 @@ static int ena_link_update(struct rte_eth_dev *dev,

--- a/userspace/dpdk/16.04/0007-net-ena-fix-SIGFPE-with-0-Rx-queue.patch
+++ b/userspace/dpdk/16.04/0007-net-ena-fix-SIGFPE-with-0-Rx-queue.patch
@@ -1,7 +1,7 @@
 From f85679db3886449cdc79d112fbfb8170b256cf8a Mon Sep 17 00:00:00 2001
 From: Daria Kolistratova <daria.kolistratova@intel.com>
 Date: Tue, 26 Jun 2018 18:38:56 +0100
-Subject: [PATCH 07/14] net/ena: fix SIGFPE with 0 Rx queue
+Subject: [PATCH 07/21] net/ena: fix SIGFPE with 0 Rx queue
 
 [ upstream commit 361913ad6f8c05fc541fe4bfdae3b0dc095ae3af ]
 
@@ -19,7 +19,7 @@ Acked-by: Michal Krawczyk <mk@semihalf.com>
  1 file changed, 1 insertion(+), 1 deletion(-)
 
 diff --git a/drivers/net/ena/ena_ethdev.c b/drivers/net/ena/ena_ethdev.c
-index 98848e935..3a257a9e5 100644
+index 98848e935f..3a257a9e57 100644
 --- a/drivers/net/ena/ena_ethdev.c
 +++ b/drivers/net/ena/ena_ethdev.c
 @@ -904,7 +904,7 @@ static int ena_start(struct rte_eth_dev *dev)

--- a/userspace/dpdk/16.04/0008-net-ena-fix-passing-RSS-hash-to-mbuf.patch
+++ b/userspace/dpdk/16.04/0008-net-ena-fix-passing-RSS-hash-to-mbuf.patch
@@ -1,7 +1,7 @@
 From f32b3ec7c7dec3683b1cf2cd2e8de038d2ef3585 Mon Sep 17 00:00:00 2001
 From: Stewart Allen <allenste@amazon.com>
 Date: Thu, 25 Oct 2018 19:59:22 +0200
-Subject: [PATCH 08/14] net/ena: fix passing RSS hash to mbuf
+Subject: [PATCH 08/21] net/ena: fix passing RSS hash to mbuf
 
 [ upstream commit e5df9f33db00eb9d322abaefff30da74fd0e625d ]
 
@@ -19,7 +19,7 @@ Acked-by: Michal Krawczyk <mk@semihalf.com>
  1 file changed, 1 insertion(+), 1 deletion(-)
 
 diff --git a/drivers/net/ena/ena_ethdev.c b/drivers/net/ena/ena_ethdev.c
-index 3a257a9e5..24e319764 100644
+index 3a257a9e57..24e3197649 100644
 --- a/drivers/net/ena/ena_ethdev.c
 +++ b/drivers/net/ena/ena_ethdev.c
 @@ -1559,7 +1559,7 @@ static uint16_t eth_ena_recv_pkts(void *rx_queue, struct rte_mbuf **rx_pkts,

--- a/userspace/dpdk/16.04/0009-net-ena-add-supported-RSS-offloads-types.patch
+++ b/userspace/dpdk/16.04/0009-net-ena-add-supported-RSS-offloads-types.patch
@@ -1,7 +1,7 @@
 From 94a6f13df8511a16ccc97b79e83e4bc719fdff44 Mon Sep 17 00:00:00 2001
 From: Rafal Kozik <rk@semihalf.com>
 Date: Fri, 14 Dec 2018 14:18:38 +0100
-Subject: [PATCH 09/14] net/ena: add supported RSS offloads types
+Subject: [PATCH 09/21] net/ena: add supported RSS offloads types
 
 [ upstream commit b01ead202beb45346d7daeb2f2b1a608006af644 ]
 
@@ -20,7 +20,7 @@ Acked-by: Michal Krawczyk <mk@semihalf.com>
  1 file changed, 3 insertions(+)
 
 diff --git a/drivers/net/ena/ena_ethdev.c b/drivers/net/ena/ena_ethdev.c
-index 24e319764..e355c4c2f 100644
+index 24e3197649..e355c4c2f6 100644
 --- a/drivers/net/ena/ena_ethdev.c
 +++ b/drivers/net/ena/ena_ethdev.c
 @@ -1479,6 +1479,9 @@ static void ena_infos_get(struct rte_eth_dev *dev,

--- a/userspace/dpdk/16.04/0010-net-ena-fix-dev-init-with-multi-process.patch
+++ b/userspace/dpdk/16.04/0010-net-ena-fix-dev-init-with-multi-process.patch
@@ -1,7 +1,7 @@
 From 0904bb2a43de0893a768900a760170f3a15cb5ca Mon Sep 17 00:00:00 2001
 From: Michal Krawczyk <mk@semihalf.com>
 Date: Fri, 25 Jan 2019 09:10:25 +0100
-Subject: [PATCH 10/14] net/ena: fix dev init with multi-process
+Subject: [PATCH 10/21] net/ena: fix dev init with multi-process
 
 [ upstream commit fd9768905870856a2340266d25f8c0100dfccfff ]
 
@@ -22,7 +22,7 @@ Signed-off-by: Michal Krawczyk <mk@semihalf.com>
  1 file changed, 5 insertions(+), 5 deletions(-)
 
 diff --git a/drivers/net/ena/ena_ethdev.c b/drivers/net/ena/ena_ethdev.c
-index e355c4c2f..dd0a9a27b 100644
+index e355c4c2f6..dd0a9a27bd 100644
 --- a/drivers/net/ena/ena_ethdev.c
 +++ b/drivers/net/ena/ena_ethdev.c
 @@ -1266,18 +1266,18 @@ static int eth_ena_dev_init(struct rte_eth_dev *eth_dev)

--- a/userspace/dpdk/16.04/0011-net-ena-get-device-info-statically.patch
+++ b/userspace/dpdk/16.04/0011-net-ena-get-device-info-statically.patch
@@ -1,7 +1,7 @@
 From 647a39dd8e973f48fec3e54e3c55bcffeadb5a31 Mon Sep 17 00:00:00 2001
 From: Michal Krawczyk <mk@semihalf.com>
 Date: Fri, 15 Feb 2019 09:36:39 +0100
-Subject: [PATCH 11/14] net/ena: get device info statically
+Subject: [PATCH 11/21] net/ena: get device info statically
 
 [ upstream commit 117ba4a60488a0f96a5737f38ddba6d0f9a728b6 ]
 
@@ -22,7 +22,7 @@ Signed-off-by: Michal Krawczyk <mk@semihalf.com>
  2 files changed, 18 insertions(+), 19 deletions(-)
 
 diff --git a/drivers/net/ena/ena_ethdev.c b/drivers/net/ena/ena_ethdev.c
-index dd0a9a27b..6c986cfc0 100644
+index dd0a9a27bd..6c986cfc0e 100644
 --- a/drivers/net/ena/ena_ethdev.c
 +++ b/drivers/net/ena/ena_ethdev.c
 @@ -1348,9 +1348,14 @@ static int eth_ena_dev_init(struct rte_eth_dev *eth_dev)
@@ -84,7 +84,7 @@ index dd0a9a27b..6c986cfc0 100644
  			DEV_RX_OFFLOAD_UDP_CKSUM  |
  			DEV_RX_OFFLOAD_TCP_CKSUM;
 diff --git a/drivers/net/ena/ena_ethdev.h b/drivers/net/ena/ena_ethdev.h
-index dc3080ffd..4791c53b5 100644
+index dc3080ffd3..4791c53b5a 100644
 --- a/drivers/net/ena/ena_ethdev.h
 +++ b/drivers/net/ena/ena_ethdev.h
 @@ -143,6 +143,12 @@ struct ena_stats_rx {

--- a/userspace/dpdk/16.04/0012-net-ena-fix-checksum-feature-flag.patch
+++ b/userspace/dpdk/16.04/0012-net-ena-fix-checksum-feature-flag.patch
@@ -1,7 +1,7 @@
 From ec0b65c55948813480d15c77633177a48af20731 Mon Sep 17 00:00:00 2001
 From: Michal Krawczyk <mk@semihalf.com>
 Date: Mon, 8 Apr 2019 12:27:44 +0200
-Subject: [PATCH 12/14] net/ena: fix checksum feature flag
+Subject: [PATCH 12/21] net/ena: fix checksum feature flag
 
 [ upstream commit ef538c1a7f565c9b58518375a500aa864445fd11 ]
 
@@ -18,7 +18,7 @@ Signed-off-by: Michal Krawczyk <mk@semihalf.com>
  1 file changed, 1 insertion(+), 1 deletion(-)
 
 diff --git a/drivers/net/ena/ena_ethdev.c b/drivers/net/ena/ena_ethdev.c
-index 6c986cfc0..068641ee5 100644
+index 6c986cfc0e..068641ee51 100644
 --- a/drivers/net/ena/ena_ethdev.c
 +++ b/drivers/net/ena/ena_ethdev.c
 @@ -1353,7 +1353,7 @@ static int eth_ena_dev_init(struct rte_eth_dev *eth_dev)

--- a/userspace/dpdk/16.04/0013-net-ena-fix-Rx-checksum-errors-statistics.patch
+++ b/userspace/dpdk/16.04/0013-net-ena-fix-Rx-checksum-errors-statistics.patch
@@ -1,7 +1,7 @@
 From fc3dbe3a20809ea0457d4a117313d13b1fe8358e Mon Sep 17 00:00:00 2001
 From: Michal Krawczyk <mk@semihalf.com>
 Date: Tue, 28 May 2019 10:28:34 +0200
-Subject: [PATCH 13/14] net/ena: fix Rx checksum errors statistics
+Subject: [PATCH 13/21] net/ena: fix Rx checksum errors statistics
 
 [ upstream commit ef74b5f7b69b9502ddab81121611243efcfe1dde ]
 
@@ -21,7 +21,7 @@ Signed-off-by: Michal Krawczyk <mk@semihalf.com>
  1 file changed, 5 insertions(+), 4 deletions(-)
 
 diff --git a/drivers/net/ena/ena_ethdev.c b/drivers/net/ena/ena_ethdev.c
-index 068641ee5..2863ecbc9 100644
+index 068641ee51..2863ecbc99 100644
 --- a/drivers/net/ena/ena_ethdev.c
 +++ b/drivers/net/ena/ena_ethdev.c
 @@ -1555,6 +1555,11 @@ static uint16_t eth_ena_recv_pkts(void *rx_queue, struct rte_mbuf **rx_pkts,

--- a/userspace/dpdk/16.04/0014-net-ena-fix-assigning-NUMA-node-to-IO-queue.patch
+++ b/userspace/dpdk/16.04/0014-net-ena-fix-assigning-NUMA-node-to-IO-queue.patch
@@ -1,7 +1,7 @@
 From 964ad4e89de9d039667e12547a545c42926d8031 Mon Sep 17 00:00:00 2001
 From: Michal Krawczyk <mk@semihalf.com>
 Date: Tue, 4 Jun 2019 12:59:36 +0200
-Subject: [PATCH 14/14] net/ena: fix assigning NUMA node to IO queue
+Subject: [PATCH 14/21] net/ena: fix assigning NUMA node to IO queue
 
 [ upstream commit 4217cb0b7d2c5385f06f531af7f14b860927aba7 ]
 
@@ -23,7 +23,7 @@ Reviewed-by: David Marchand <david.marchand@redhat.com>
  2 files changed, 8 insertions(+), 17 deletions(-)
 
 diff --git a/drivers/net/ena/ena_ethdev.c b/drivers/net/ena/ena_ethdev.c
-index 2863ecbc9..ac21f0628 100644
+index 2863ecbc99..ac21f0628b 100644
 --- a/drivers/net/ena/ena_ethdev.c
 +++ b/drivers/net/ena/ena_ethdev.c
 @@ -38,7 +38,6 @@
@@ -106,7 +106,7 @@ index 2863ecbc9..ac21f0628 100644
  
  	rxq->rx_buffer_info = rte_zmalloc("rxq->buffer_info",
 diff --git a/drivers/net/ena/ena_ethdev.h b/drivers/net/ena/ena_ethdev.h
-index 4791c53b5..8d5eb5a7c 100644
+index 4791c53b5a..8d5eb5a7ca 100644
 --- a/drivers/net/ena/ena_ethdev.h
 +++ b/drivers/net/ena/ena_ethdev.h
 @@ -90,6 +90,8 @@ struct ena_ring {

--- a/userspace/dpdk/16.04/0015-net-ena-base-fix-node-deallocation.patch
+++ b/userspace/dpdk/16.04/0015-net-ena-base-fix-node-deallocation.patch
@@ -1,0 +1,59 @@
+From e47e50e4ae518b3da5346a49cc4bc0fab1e8dcbf Mon Sep 17 00:00:00 2001
+From: Michal Krawczyk <mk@semihalf.com>
+Date: Thu, 2 Jul 2020 10:25:03 +0000
+Subject: [PATCH 15/21] net/ena/base: fix node deallocation
+
+The memzone handle wasn't saved anywhere - it could cause free of the
+invalid memory, as the mem_handle was never holding the right value.
+
+Signed-off-by: Michal Krawczyk <mk@semihalf.com>
+---
+ drivers/net/ena/base/ena_com.c       | 2 ++
+ drivers/net/ena/base/ena_plat_dpdk.h | 4 +++-
+ 2 files changed, 5 insertions(+), 1 deletion(-)
+
+diff --git a/drivers/net/ena/base/ena_com.c b/drivers/net/ena/base/ena_com.c
+index 38a0587754..1c38a1138d 100644
+--- a/drivers/net/ena/base/ena_com.c
++++ b/drivers/net/ena/base/ena_com.c
+@@ -347,6 +347,7 @@ static int ena_com_init_io_sq(struct ena_com_dev *ena_dev,
+ 					    size,
+ 					    io_sq->desc_addr.virt_addr,
+ 					    io_sq->desc_addr.phys_addr,
++					    io_sq->desc_addr.mem_handle,
+ 					    ctx->numa_node,
+ 					    dev_node);
+ 		if (!io_sq->desc_addr.virt_addr)
+@@ -400,6 +401,7 @@ static int ena_com_init_io_cq(struct ena_com_dev *ena_dev,
+ 				    size,
+ 				    io_cq->cdesc_addr.virt_addr,
+ 				    io_cq->cdesc_addr.phys_addr,
++				    io_cq->cdesc_addr.mem_handle,
+ 				    ctx->numa_node,
+ 				    prev_node);
+ 	if (!io_cq->cdesc_addr.virt_addr)
+diff --git a/drivers/net/ena/base/ena_plat_dpdk.h b/drivers/net/ena/base/ena_plat_dpdk.h
+index 791b44ff72..42f454ccd5 100644
+--- a/drivers/net/ena/base/ena_plat_dpdk.h
++++ b/drivers/net/ena/base/ena_plat_dpdk.h
+@@ -205,7 +205,8 @@ typedef uint64_t dma_addr_t;
+ 		   ENA_TOUCH(dmadev);					\
+ 		   rte_memzone_free(handle); })
+ 
+-#define ENA_MEM_ALLOC_COHERENT_NODE(dmadev, size, virt, phys, node, dev_node) \
++#define ENA_MEM_ALLOC_COHERENT_NODE(					\
++	dmadev, size, virt, phys, mem_handle, node, dev_node)		\
+ 	do {								\
+ 		const struct rte_memzone *mz;				\
+ 		char z_name[RTE_MEMZONE_NAMESIZE];			\
+@@ -213,6 +214,7 @@ typedef uint64_t dma_addr_t;
+ 		snprintf(z_name, sizeof(z_name),			\
+ 				"ena_alloc_%d", ena_alloc_cnt++);	\
+ 		mz = rte_memzone_reserve(z_name, size, node, 0); \
++		mem_handle = mz;					\
+ 		if (mz == NULL) {					\
+ 			virt = NULL;					\
+ 			phys = 0;					\
+-- 
+2.20.1
+

--- a/userspace/dpdk/16.04/0016-net-ena-fix-indication-of-bad-L4-Rx-checksums.patch
+++ b/userspace/dpdk/16.04/0016-net-ena-fix-indication-of-bad-L4-Rx-checksums.patch
@@ -1,0 +1,42 @@
+From 60adf2d2ef7345173230ced72edef6caa2d4b740 Mon Sep 17 00:00:00 2001
+From: Igor Chauskin <igorch@amazon.com>
+Date: Mon, 28 Oct 2019 11:23:33 +0100
+Subject: [PATCH 16/21] net/ena: fix indication of bad L4 Rx checksums
+
+[ upstream commit 05817057faba9356900ced61e24a22eef6bc4c87 ]
+
+Add checking of l4_csum_checked and frag flags before checking the
+l4_csum_error flag.
+
+In case of IP fragment/unchecked L4 csum - add PKT_RX_L4_CKSUM_UNKNOWN
+flag to the indicated mbuf.
+
+Fixes: 1173fca25af9 ("ena: add polling-mode driver")
+Cc: stable@dpdk.org
+
+Change-Id: I9f1414741eb44ca289a8bfd11d7e66110c95040e
+Signed-off-by: Igor Chauskin <igorch@amazon.com>
+Reviewed-by: Maciej Bielski <mba@semihalf.com>
+Reviewed-by: Michal Krawczyk <mk@semihalf.com>
+---
+ drivers/net/ena/ena_ethdev.c | 3 ++-
+ 1 file changed, 2 insertions(+), 1 deletion(-)
+
+diff --git a/drivers/net/ena/ena_ethdev.c b/drivers/net/ena/ena_ethdev.c
+index ac21f0628b..9daeefad86 100644
+--- a/drivers/net/ena/ena_ethdev.c
++++ b/drivers/net/ena/ena_ethdev.c
+@@ -257,8 +257,9 @@ static inline void ena_rx_mbuf_prepare(struct rte_mbuf *mbuf,
+ 	else if (ena_rx_ctx->l3_proto == ENA_ETH_IO_L3_PROTO_IPV6)
+ 		packet_type |= RTE_PTYPE_L3_IPV6;
+ 
+-	if (unlikely(ena_rx_ctx->l4_csum_err))
++	if (unlikely(ena_rx_ctx->l4_csum_err) && !ena_rx_ctx->frag)
+ 		ol_flags |= PKT_RX_L4_CKSUM_BAD;
++
+ 	if (unlikely(ena_rx_ctx->l3_csum_err))
+ 		ol_flags |= PKT_RX_IP_CKSUM_BAD;
+ 
+-- 
+2.20.1
+

--- a/userspace/dpdk/16.04/0017-net-ena-ensure-Rx-buffer-size-is-at-least-1400B.patch
+++ b/userspace/dpdk/16.04/0017-net-ena-ensure-Rx-buffer-size-is-at-least-1400B.patch
@@ -1,0 +1,84 @@
+From baba0317210436dc1848f9d720b0207625f3fc54 Mon Sep 17 00:00:00 2001
+From: Michal Krawczyk <mk@semihalf.com>
+Date: Wed, 8 Apr 2020 10:28:52 +0200
+Subject: [PATCH 17/21] net/ena: ensure Rx buffer size is at least 1400B
+
+[ upstream commit 38364c2687ead97b99402310087c27131a97748c ]
+
+Some of the ENA devices can't handle buffers which are smaller than a
+1400B. Because of this limitation, size of the buffer is being checked
+and limited during the Rx queue setup.
+
+If it's below the allowed value, PMD won't finish it's configuration
+successfully..
+
+Change-Id: Ib402d3bfad98a3fc4f91095d5c6f90c6069da021
+Signed-off-by: Michal Krawczyk <mk@semihalf.com>
+Reviewed-by: Igor Chauskin <igorch@amazon.com>
+Reviewed-by: Guy Tzalik <gtzalik@amazon.com>
+---
+ drivers/net/ena/ena_ethdev.c | 12 +++++++++++-
+ drivers/net/ena/ena_ethdev.h |  3 ++-
+ 2 files changed, 13 insertions(+), 2 deletions(-)
+
+diff --git a/drivers/net/ena/ena_ethdev.c b/drivers/net/ena/ena_ethdev.c
+index 9daeefad86..26d9e37395 100644
+--- a/drivers/net/ena/ena_ethdev.c
++++ b/drivers/net/ena/ena_ethdev.c
+@@ -1,7 +1,7 @@
+ /*-
+ * BSD LICENSE
+ *
+-* Copyright (c) 2015-2016 Amazon.com, Inc. or its affiliates.
++* Copyright (c) 2015-2020 Amazon.com, Inc. or its affiliates.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+@@ -1045,6 +1045,7 @@ static int ena_rx_queue_setup(struct rte_eth_dev *dev,
+ 	struct ena_adapter *adapter =
+ 		(struct ena_adapter *)(dev->data->dev_private);
+ 	struct ena_ring *rxq = NULL;
++	size_t buffer_size;
+ 	uint16_t ena_qid = 0;
+ 	int rc = 0;
+ 	struct ena_com_dev *ena_dev = &adapter->ena_dev;
+@@ -1071,6 +1072,15 @@ static int ena_rx_queue_setup(struct rte_eth_dev *dev,
+ 		return -EINVAL;
+ 	}
+ 
++	/* ENA isn't supporting buffers smaller than 1400 bytes */
++	buffer_size = rte_pktmbuf_data_room_size(mp) - RTE_PKTMBUF_HEADROOM;
++	if (buffer_size < ENA_RX_BUF_MIN_SIZE) {
++		PMD_DRV_LOG(ERR,
++			"Unsupported size of RX buffer: %zu (min size: %d)\n",
++			buffer_size, ENA_RX_BUF_MIN_SIZE);
++		return -EINVAL;
++	}
++
+ 	ena_qid = ENA_IO_RXQ_IDX(queue_idx);
+ 
+ 	ctx.qid = ena_qid;
+diff --git a/drivers/net/ena/ena_ethdev.h b/drivers/net/ena/ena_ethdev.h
+index 8d5eb5a7ca..d6e5e730e1 100644
+--- a/drivers/net/ena/ena_ethdev.h
++++ b/drivers/net/ena/ena_ethdev.h
+@@ -1,7 +1,7 @@
+ /*-
+ * BSD LICENSE
+ *
+-* Copyright (c) 2015-2016 Amazon.com, Inc. or its affiliates.
++* Copyright (c) 2015-2020 Amazon.com, Inc. or its affiliates.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+@@ -46,6 +46,7 @@
+ #define ENA_MIN_FRAME_LEN	64
+ #define ENA_NAME_MAX_LEN	20
+ #define ENA_PKT_MAX_BUFS	17
++#define ENA_RX_BUF_MIN_SIZE	1400
+ 
+ #define ENA_MMIO_DISABLE_REG_READ	BIT(0)
+ 
+-- 
+2.20.1
+

--- a/userspace/dpdk/16.04/0018-net-ena-base-make-allocation-macros-thread-safe.patch
+++ b/userspace/dpdk/16.04/0018-net-ena-base-make-allocation-macros-thread-safe.patch
@@ -1,0 +1,103 @@
+From 4cb6ba58ae33a2b571c23116a026414668989fb5 Mon Sep 17 00:00:00 2001
+From: Igor Chauskin <igorch@amazon.com>
+Date: Wed, 8 Apr 2020 10:28:53 +0200
+Subject: [PATCH 18/21] net/ena/base: make allocation macros thread-safe
+
+[ upstream commit b14fcac035fd8514851c9140a4e26d765b61c532 ]
+
+Memory allocation region id could possibly be non-unique
+due to non-atomic increment, causing allocation failure.
+
+Fixes: 9ba7981ec992 ("ena: add communication layer for DPDK")
+Cc: stable@dpdk.org
+
+Change-Id: Ib9207aaae4e5e7ecdf1a99a0f23a508a53af631d
+Signed-off-by: Igor Chauskin <igorch@amazon.com>
+Reviewed-by: Michal Krawczyk <mk@semihalf.com>
+Reviewed-by: Guy Tzalik <gtzalik@amazon.com>
+---
+ drivers/net/ena/base/ena_com.c       |  2 --
+ drivers/net/ena/base/ena_plat_dpdk.h | 16 ++++++++++++----
+ drivers/net/ena/ena_ethdev.c         |  6 ++++++
+ 3 files changed, 18 insertions(+), 6 deletions(-)
+
+diff --git a/drivers/net/ena/base/ena_com.c b/drivers/net/ena/base/ena_com.c
+index 1c38a1138d..0dbd1b0cd0 100644
+--- a/drivers/net/ena/base/ena_com.c
++++ b/drivers/net/ena/base/ena_com.c
+@@ -62,8 +62,6 @@
+ 
+ #define ENA_MMIO_READ_TIMEOUT 0xFFFFFFFF
+ 
+-static int ena_alloc_cnt;
+-
+ /*****************************************************************************/
+ /*****************************************************************************/
+ /*****************************************************************************/
+diff --git a/drivers/net/ena/base/ena_plat_dpdk.h b/drivers/net/ena/base/ena_plat_dpdk.h
+index 42f454ccd5..324e30875d 100644
+--- a/drivers/net/ena/base/ena_plat_dpdk.h
++++ b/drivers/net/ena/base/ena_plat_dpdk.h
+@@ -1,7 +1,7 @@
+ /*-
+ * BSD LICENSE
+ *
+-* Copyright (c) 2015-2016 Amazon.com, Inc. or its affiliates.
++* Copyright (c) 2015-2020 Amazon.com, Inc. or its affiliates.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+@@ -182,13 +182,20 @@ typedef uint64_t dma_addr_t;
+ #define ena_wait_event_t ena_wait_queue_t
+ #define ENA_MIGHT_SLEEP()
+ 
++/*
++ * Each rte_memzone should have unique name.
++ * To satisfy it, count number of allocations and add it to name.
++ */
++extern rte_atomic32_t ena_alloc_cnt;
++
+ #define ENA_MEM_ALLOC_COHERENT(dmadev, size, virt, phys, handle)	\
+ 	do {								\
+ 		const struct rte_memzone *mz;				\
+ 		char z_name[RTE_MEMZONE_NAMESIZE];			\
+ 		ENA_TOUCH(dmadev); ENA_TOUCH(handle);			\
+ 		snprintf(z_name, sizeof(z_name),			\
+-				"ena_alloc_%d", ena_alloc_cnt++);	\
++			 "ena_alloc_%d",				\
++			 rte_atomic32_add_return(&ena_alloc_cnt, 1));	\
+ 		mz = rte_memzone_reserve(z_name, size, SOCKET_ID_ANY, 0); \
+ 		handle = mz;						\
+ 		if (mz == NULL) {					\
+@@ -212,8 +219,9 @@ typedef uint64_t dma_addr_t;
+ 		char z_name[RTE_MEMZONE_NAMESIZE];			\
+ 		ENA_TOUCH(dmadev); ENA_TOUCH(dev_node);			\
+ 		snprintf(z_name, sizeof(z_name),			\
+-				"ena_alloc_%d", ena_alloc_cnt++);	\
+-		mz = rte_memzone_reserve(z_name, size, node, 0); \
++			 "ena_alloc_%d",				\
++			 rte_atomic32_add_return(&ena_alloc_cnt, 1));	\
++		mz = rte_memzone_reserve(z_name, size, node, 0);	\
+ 		mem_handle = mz;					\
+ 		if (mz == NULL) {					\
+ 			virt = NULL;					\
+diff --git a/drivers/net/ena/ena_ethdev.c b/drivers/net/ena/ena_ethdev.c
+index 26d9e37395..b6c26071af 100644
+--- a/drivers/net/ena/ena_ethdev.c
++++ b/drivers/net/ena/ena_ethdev.c
+@@ -111,6 +111,12 @@ struct ena_stats {
+ #define ENA_STAT_GLOBAL_ENTRY(stat) \
+ 	ENA_STAT_ENTRY(stat, dev)
+ 
++/*
++ * Each rte_memzone should have unique name.
++ * To satisfy it, count number of allocation and add it to name.
++ */
++rte_atomic32_t ena_alloc_cnt;
++
+ static const struct ena_stats ena_stats_global_strings[] = {
+ 	ENA_STAT_GLOBAL_ENTRY(tx_timeout),
+ 	ENA_STAT_GLOBAL_ENTRY(io_suspend),
+-- 
+2.20.1
+

--- a/userspace/dpdk/16.04/0019-net-ena-base-prevent-allocation-of-zero-sized-memory.patch
+++ b/userspace/dpdk/16.04/0019-net-ena-base-prevent-allocation-of-zero-sized-memory.patch
@@ -1,0 +1,74 @@
+From cb3e5a979f34c53a10fbb9f1c890194f2b7fbdb2 Mon Sep 17 00:00:00 2001
+From: Igor Chauskin <igorch@amazon.com>
+Date: Wed, 8 Apr 2020 10:28:54 +0200
+Subject: [PATCH 19/21] net/ena/base: prevent allocation of zero sized memory
+
+[ upstream commit 29dc10d9424ccf26a346387b0a707185e2432400 ]
+
+rte_memzone_reserve() will reserve the biggest contiguous memzone
+available if received 0 as size param.
+
+Fixes: 9ba7981ec992 ("ena: add communication layer for DPDK")
+Cc: stable@dpdk.org
+
+Change-Id: I2f71119e93c5e9addd8c538820093f030066d690
+Signed-off-by: Igor Chauskin <igorch@amazon.com>
+Reviewed-by: Michal Krawczyk <mk@semihalf.com>
+Reviewed-by: Guy Tzalik <gtzalik@amazon.com>
+---
+ drivers/net/ena/base/ena_plat_dpdk.h | 27 ++++++++++++++++-----------
+ 1 file changed, 16 insertions(+), 11 deletions(-)
+
+diff --git a/drivers/net/ena/base/ena_plat_dpdk.h b/drivers/net/ena/base/ena_plat_dpdk.h
+index 324e30875d..e95475362e 100644
+--- a/drivers/net/ena/base/ena_plat_dpdk.h
++++ b/drivers/net/ena/base/ena_plat_dpdk.h
+@@ -190,14 +190,17 @@ extern rte_atomic32_t ena_alloc_cnt;
+ 
+ #define ENA_MEM_ALLOC_COHERENT(dmadev, size, virt, phys, handle)	\
+ 	do {								\
+-		const struct rte_memzone *mz;				\
+-		char z_name[RTE_MEMZONE_NAMESIZE];			\
++		const struct rte_memzone *mz = NULL;			\
+ 		ENA_TOUCH(dmadev); ENA_TOUCH(handle);			\
+-		snprintf(z_name, sizeof(z_name),			\
++		if (size > 0) {						\
++			char z_name[RTE_MEMZONE_NAMESIZE];		\
++			snprintf(z_name, sizeof(z_name),		\
+ 			 "ena_alloc_%d",				\
+ 			 rte_atomic32_add_return(&ena_alloc_cnt, 1));	\
+-		mz = rte_memzone_reserve(z_name, size, SOCKET_ID_ANY, 0); \
+-		handle = mz;						\
++			mz = rte_memzone_reserve(z_name, size,		\
++				SOCKET_ID_ANY, 0);			\
++			handle = mz;					\
++		}							\
+ 		if (mz == NULL) {					\
+ 			virt = NULL;					\
+ 			phys = 0;					\
+@@ -215,14 +218,16 @@ extern rte_atomic32_t ena_alloc_cnt;
+ #define ENA_MEM_ALLOC_COHERENT_NODE(					\
+ 	dmadev, size, virt, phys, mem_handle, node, dev_node)		\
+ 	do {								\
+-		const struct rte_memzone *mz;				\
+-		char z_name[RTE_MEMZONE_NAMESIZE];			\
++		const struct rte_memzone *mz = NULL;			\
+ 		ENA_TOUCH(dmadev); ENA_TOUCH(dev_node);			\
+-		snprintf(z_name, sizeof(z_name),			\
++		if (size > 0) {						\
++			char z_name[RTE_MEMZONE_NAMESIZE];		\
++			snprintf(z_name, sizeof(z_name),		\
+ 			 "ena_alloc_%d",				\
+-			 rte_atomic32_add_return(&ena_alloc_cnt, 1));	\
+-		mz = rte_memzone_reserve(z_name, size, node, 0);	\
+-		mem_handle = mz;					\
++			 rte_atomic32_add_return(&ena_alloc_cnt, 1));   \
++			mz = rte_memzone_reserve(z_name, size, node, 0); \
++			mem_handle = mz;				\
++		}							\
+ 		if (mz == NULL) {					\
+ 			virt = NULL;					\
+ 			phys = 0;					\
+-- 
+2.20.1
+

--- a/userspace/dpdk/16.04/0020-net-ena-set-IO-ring-size-to-valid-value.patch
+++ b/userspace/dpdk/16.04/0020-net-ena-set-IO-ring-size-to-valid-value.patch
@@ -1,0 +1,49 @@
+From ec1ad2227cdcbaad9100cf614d7c12770d0afb0f Mon Sep 17 00:00:00 2001
+From: Michal Krawczyk <mk@semihalf.com>
+Date: Fri, 3 Jul 2020 13:14:58 +0000
+Subject: [PATCH 20/21] net/ena: set IO ring size to valid value
+
+[ upstream commit badc3a6aa133a886a61b9e3ad666e5675f7ec3d3 ]
+
+IO rings were configured with the maximum allowed size for the Tx/Rx
+rings. However, the application could decide to create smaller rings.
+
+This patch is using value stored in the ring instead of the value from
+the adapter which is indicating the maximum allowed value.
+
+Fixes: df238f84c0a2 ("net/ena: recreate HW IO rings on start and stop")
+Cc: stable@dpdk.org
+
+Change-Id: Icf9102e2aa4e7413b6620b36dd232673239b7291
+Signed-off-by: Michal Krawczyk <mk@semihalf.com>
+Reviewed-by: Igor Chauskin <igorch@amazon.com>
+Reviewed-by: Guy Tzalik <gtzalik@amazon.com>
+---
+ drivers/net/ena/ena_ethdev.c | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/drivers/net/ena/ena_ethdev.c b/drivers/net/ena/ena_ethdev.c
+index b6c26071af..1843979daf 100644
+--- a/drivers/net/ena/ena_ethdev.c
++++ b/drivers/net/ena/ena_ethdev.c
+@@ -981,7 +981,7 @@ static int ena_tx_queue_setup(struct rte_eth_dev *dev,
+ 	ctx.qid = ena_qid;
+ 	ctx.msix_vector = -1; /* admin interrupts not used */
+ 	ctx.mem_queue_type = ena_dev->tx_mem_queue_type;
+-	ctx.queue_size = adapter->tx_ring_size;
++	ctx.queue_size = nb_desc;
+ 	ctx.numa_node = socket_id;
+ 
+ 	rc = ena_com_create_io_queue(ena_dev, &ctx);
+@@ -1093,7 +1093,7 @@ static int ena_rx_queue_setup(struct rte_eth_dev *dev,
+ 	ctx.direction = ENA_COM_IO_QUEUE_DIRECTION_RX;
+ 	ctx.mem_queue_type = ENA_ADMIN_PLACEMENT_POLICY_HOST;
+ 	ctx.msix_vector = -1; /* admin interrupts not used */
+-	ctx.queue_size = adapter->rx_ring_size;
++	ctx.queue_size = nb_desc;
+ 	ctx.numa_node = socket_id;
+ 
+ 	rc = ena_com_create_io_queue(ena_dev, &ctx);
+-- 
+2.20.1
+

--- a/userspace/dpdk/16.04/0021-net-ena-limit-refill-threshold-by-fixed-value.patch
+++ b/userspace/dpdk/16.04/0021-net-ena-limit-refill-threshold-by-fixed-value.patch
@@ -1,0 +1,117 @@
+From 3922a585ce43dafb09ab45d8990c553ee161c616 Mon Sep 17 00:00:00 2001
+From: Michal Krawczyk <mk@semihalf.com>
+Date: Wed, 8 Apr 2020 10:29:16 +0200
+Subject: [PATCH 21/21] net/ena: limit refill threshold by fixed value
+
+[ upstream commit 7755060798de9c0146df8809926030ed47fc9086 ]
+
+Divider used for both Tx and Rx cleanup/refill threshold can cause too
+big delay in case of the really big rings - for example if the 8k Rx
+ring will be used, the refill won't trigger unless 1024 threshold will
+be reached. It will also cause driver to try to allocate that much
+descriptors.
+
+Limiting it by fixed value - 256 in that case, would limit maximum
+time spent in repopulate function.
+
+Change-Id: Ia8659e6ddf179ff612a780adc6fe55d13eeac6e9
+Signed-off-by: Michal Krawczyk <mk@semihalf.com>
+Reviewed-by: Igor Chauskin <igorch@amazon.com>
+Reviewed-by: Guy Tzalik <gtzalik@amazon.com>
+---
+ drivers/net/ena/ena_ethdev.c | 26 ++++++++++++++------------
+ drivers/net/ena/ena_ethdev.h | 10 ++++++++++
+ 2 files changed, 24 insertions(+), 12 deletions(-)
+
+diff --git a/drivers/net/ena/ena_ethdev.c b/drivers/net/ena/ena_ethdev.c
+index 1843979daf..061ceb1bbb 100644
+--- a/drivers/net/ena/ena_ethdev.c
++++ b/drivers/net/ena/ena_ethdev.c
+@@ -59,14 +59,6 @@
+ /*reverse version of ENA_IO_RXQ_IDX*/
+ #define ENA_IO_RXQ_IDX_REV(q)	((q - 1) / 2)
+ 
+-/* While processing submitted and completed descriptors (rx and tx path
+- * respectively) in a loop it is desired to:
+- *  - perform batch submissions while populating sumbissmion queue
+- *  - avoid blocking transmission of other packets during cleanup phase
+- * Hence the utilization ratio of 1/8 of a queue size.
+- */
+-#define ENA_RING_DESCS_RATIO(ring_size)	(ring_size / 8)
+-
+ #define __MERGE_64B_H_L(h, l) (((uint64_t)h << 32) | l)
+ #define TEST_BIT(val, bit_shift) (val & (1UL << bit_shift))
+ 
+@@ -1496,6 +1488,8 @@ static uint16_t eth_ena_recv_pkts(void *rx_queue, struct rte_mbuf **rx_pkts,
+ 	struct ena_ring *rx_ring = (struct ena_ring *)(rx_queue);
+ 	unsigned int ring_size = rx_ring->ring_size;
+ 	unsigned int ring_mask = ring_size - 1;
++	unsigned int free_queue_entries;
++	unsigned int refill_threshold;
+ 	uint16_t next_to_clean = rx_ring->next_to_clean;
+ 	uint16_t desc_in_use = 0;
+ 	unsigned int recv_idx = 0;
+@@ -1575,10 +1569,14 @@ static uint16_t eth_ena_recv_pkts(void *rx_queue, struct rte_mbuf **rx_pkts,
+ 
+ 	rx_ring->next_to_clean = next_to_clean;
+ 
+-	desc_in_use = desc_in_use - completed + 1;
++	free_queue_entries = ena_com_sq_empty_space(rx_ring->ena_com_io_sq);
++	refill_threshold =
++		RTE_MIN(ring_size / ENA_REFILL_THRESH_DIVIDER,
++		(unsigned int)ENA_REFILL_THRESH_PACKET);
++
+ 	/* Burst refill to save doorbells, memory barriers, const interval */
+-	if (ring_size - desc_in_use > ENA_RING_DESCS_RATIO(ring_size))
+-		ena_populate_rx_queue(rx_ring, ring_size - desc_in_use);
++	if (free_queue_entries > refill_threshold)
++		ena_populate_rx_queue(rx_ring, free_queue_entries);
+ 
+ 	return recv_idx;
+ }
+@@ -1592,6 +1590,7 @@ static uint16_t eth_ena_xmit_pkts(void *tx_queue, struct rte_mbuf **tx_pkts,
+ 	struct rte_mbuf *mbuf;
+ 	unsigned int ring_size = tx_ring->ring_size;
+ 	unsigned int ring_mask = ring_size - 1;
++	unsigned int cleanup_budget;
+ 	struct ena_com_tx_ctx ena_tx_ctx;
+ 	struct ena_tx_buffer *tx_info;
+ 	struct ena_com_buf *ebuf;
+@@ -1698,9 +1697,12 @@ static uint16_t eth_ena_xmit_pkts(void *tx_queue, struct rte_mbuf **tx_pkts,
+ 		/* Put back descriptor to the ring for reuse */
+ 		tx_ring->empty_tx_reqs[next_to_clean & ring_mask] = req_id;
+ 		next_to_clean++;
++		cleanup_budget =
++			RTE_MIN(ring_size / ENA_REFILL_THRESH_DIVIDER,
++			(unsigned int)ENA_REFILL_THRESH_PACKET);
+ 
+ 		/* If too many descs to clean, leave it for another run */
+-		if (unlikely(total_tx_descs > ENA_RING_DESCS_RATIO(ring_size)))
++		if (unlikely(total_tx_descs > cleanup_budget))
+ 			break;
+ 	}
+ 
+diff --git a/drivers/net/ena/ena_ethdev.h b/drivers/net/ena/ena_ethdev.h
+index d6e5e730e1..2b02806db5 100644
+--- a/drivers/net/ena/ena_ethdev.h
++++ b/drivers/net/ena/ena_ethdev.h
+@@ -50,6 +50,16 @@
+ 
+ #define ENA_MMIO_DISABLE_REG_READ	BIT(0)
+ 
++/* While processing submitted and completed descriptors (rx and tx path
++ * respectively) in a loop it is desired to:
++ *  - perform batch submissions while populating sumbissmion queue
++ *  - avoid blocking transmission of other packets during cleanup phase
++ * Hence the utilization ratio of 1/8 of a queue size or max value if the size
++ * of the ring is very big - like 8k Rx rings.
++ */
++#define ENA_REFILL_THRESH_DIVIDER      8
++#define ENA_REFILL_THRESH_PACKET       256
++
+ struct ena_adapter;
+ 
+ enum ena_ring_type {
+-- 
+2.20.1
+

--- a/userspace/dpdk/16.11/0001-net-ena-cleanup-if-refilling-of-Rx-descriptors-fails.patch
+++ b/userspace/dpdk/16.11/0001-net-ena-cleanup-if-refilling-of-Rx-descriptors-fails.patch
@@ -1,7 +1,7 @@
 From 395ef06d77c3d2d7d1eb9400a3988ec8857fd5d7 Mon Sep 17 00:00:00 2001
 From: Michal Krawczyk <mk@semihalf.com>
 Date: Mon, 10 Apr 2017 16:28:10 +0200
-Subject: [PATCH 01/19] net/ena: cleanup if refilling of Rx descriptors fails
+Subject: [PATCH 01/26] net/ena: cleanup if refilling of Rx descriptors fails
 
 [ upstream commit 2732e07ad1e54c648c8ca5bc6965af5bf607ba10 ]
 
@@ -22,7 +22,7 @@ Acked-by: Jan Medala <jan.medala@outlook.com>
  1 file changed, 2 insertions(+)
 
 diff --git a/drivers/net/ena/ena_ethdev.c b/drivers/net/ena/ena_ethdev.c
-index ab9a178f7..dd53c32d9 100644
+index ab9a178f72..dd53c32d99 100644
 --- a/drivers/net/ena/ena_ethdev.c
 +++ b/drivers/net/ena/ena_ethdev.c
 @@ -1165,6 +1165,8 @@ static int ena_populate_rx_queue(struct ena_ring *rxq, unsigned int count)

--- a/userspace/dpdk/16.11/0002-net-ena-fix-Rx-descriptors-allocation.patch
+++ b/userspace/dpdk/16.11/0002-net-ena-fix-Rx-descriptors-allocation.patch
@@ -1,7 +1,7 @@
 From a8c9bdcc04fddbd930f1856ce7f56dc7b20e4d0b Mon Sep 17 00:00:00 2001
 From: Michal Krawczyk <mk@semihalf.com>
 Date: Thu, 18 May 2017 17:41:50 +0200
-Subject: [PATCH 02/19] net/ena: fix Rx descriptors allocation
+Subject: [PATCH 02/26] net/ena: fix Rx descriptors allocation
 
 [ backported from upstream commit a467e8f37a3eec98210c0c3ec04bf6e9506ddd81 ]
 
@@ -22,7 +22,7 @@ Acked-by: Jan Medala <jan.medala@outlook.com>
  1 file changed, 7 insertions(+), 5 deletions(-)
 
 diff --git a/drivers/net/ena/ena_ethdev.c b/drivers/net/ena/ena_ethdev.c
-index dd53c32d9..2318cf35d 100644
+index dd53c32d99..2318cf35d6 100644
 --- a/drivers/net/ena/ena_ethdev.c
 +++ b/drivers/net/ena/ena_ethdev.c
 @@ -913,7 +913,7 @@ static int ena_start(struct rte_eth_dev *dev)

--- a/userspace/dpdk/16.11/0003-net-ena-fix-delayed-cleanup-of-Rx-descriptors.patch
+++ b/userspace/dpdk/16.11/0003-net-ena-fix-delayed-cleanup-of-Rx-descriptors.patch
@@ -1,7 +1,7 @@
 From 9566e5c1adc033c0a43601def1132a4775522cb0 Mon Sep 17 00:00:00 2001
 From: Michal Krawczyk <mk@semihalf.com>
 Date: Thu, 18 May 2017 17:41:51 +0200
-Subject: [PATCH 03/19] net/ena: fix delayed cleanup of Rx descriptors
+Subject: [PATCH 03/26] net/ena: fix delayed cleanup of Rx descriptors
 
 [ backported from upstream commit ec78af6bc0556cf2a1133185ca33fb835b38afe0 ]
 
@@ -27,7 +27,7 @@ Acked-by: Jan Medala <jan.medala@outlook.com>
  1 file changed, 3 insertions(+), 3 deletions(-)
 
 diff --git a/drivers/net/ena/ena_ethdev.c b/drivers/net/ena/ena_ethdev.c
-index 2318cf35d..8d4898d67 100644
+index 2318cf35d6..8d4898d673 100644
 --- a/drivers/net/ena/ena_ethdev.c
 +++ b/drivers/net/ena/ena_ethdev.c
 @@ -1564,13 +1564,13 @@ static uint16_t eth_ena_recv_pkts(void *rx_queue, struct rte_mbuf **rx_pkts,

--- a/userspace/dpdk/16.11/0004-net-ena-fix-cleanup-of-the-Tx-bufs.patch
+++ b/userspace/dpdk/16.11/0004-net-ena-fix-cleanup-of-the-Tx-bufs.patch
@@ -1,7 +1,7 @@
 From 9457d1b00377ffe171d674a96f8dbe36edc16252 Mon Sep 17 00:00:00 2001
 From: Michal Krawczyk <mk@semihalf.com>
 Date: Fri, 16 Jun 2017 08:19:16 +0000
-Subject: [PATCH 04/19] net/ena: fix cleanup of the Tx bufs
+Subject: [PATCH 04/26] net/ena: fix cleanup of the Tx bufs
 
 [ upstream commit 207a514ce516f8ab3c1ad2b0f930f045b90b773c ]
 
@@ -22,7 +22,7 @@ Signed-off-by: Michal Krawczyk <mk@semihalf.com>
  1 file changed, 4 insertions(+), 4 deletions(-)
 
 diff --git a/drivers/net/ena/ena_ethdev.c b/drivers/net/ena/ena_ethdev.c
-index 8d4898d67..c832d241f 100644
+index 8d4898d673..c832d241f8 100644
 --- a/drivers/net/ena/ena_ethdev.c
 +++ b/drivers/net/ena/ena_ethdev.c
 @@ -682,11 +682,10 @@ static void ena_rx_queue_release_bufs(struct ena_ring *ring)

--- a/userspace/dpdk/16.11/0005-net-ena-base-initialize-memory-in-the-allocation-mac.patch
+++ b/userspace/dpdk/16.11/0005-net-ena-base-initialize-memory-in-the-allocation-mac.patch
@@ -1,7 +1,7 @@
 From 752d24a3c56d0c7bffcba40249912b8fe112af4b Mon Sep 17 00:00:00 2001
 From: Michal Krawczyk <mk@semihalf.com>
 Date: Fri, 16 Jun 2017 09:10:48 +0000
-Subject: [PATCH 05/19] net/ena/base: initialize memory in the allocation
+Subject: [PATCH 05/26] net/ena/base: initialize memory in the allocation
  macros
 
 [ upstream commit 2861ea8df0173f047efe2636ef3b9643d4d989bc ]
@@ -20,7 +20,7 @@ Signed-off-by: Michal Krawczyk <mk@semihalf.com>
  1 file changed, 2 insertions(+)
 
 diff --git a/drivers/net/ena/base/ena_plat_dpdk.h b/drivers/net/ena/base/ena_plat_dpdk.h
-index 87c3bf13b..a812d75e2 100644
+index 87c3bf13b4..a812d75e2c 100644
 --- a/drivers/net/ena/base/ena_plat_dpdk.h
 +++ b/drivers/net/ena/base/ena_plat_dpdk.h
 @@ -206,6 +206,7 @@ typedef uint64_t dma_addr_t;

--- a/userspace/dpdk/16.11/0006-net-ena-do-not-set-Tx-L4-offloads-in-Rx-path.patch
+++ b/userspace/dpdk/16.11/0006-net-ena-do-not-set-Tx-L4-offloads-in-Rx-path.patch
@@ -1,7 +1,7 @@
 From 97f897630d47295ac8b8c3b25724b9beeee8b0b2 Mon Sep 17 00:00:00 2001
 From: Rafal Kozik <rk@semihalf.com>
 Date: Tue, 9 Jan 2018 16:19:08 +0100
-Subject: [PATCH 06/19] net/ena: do not set Tx L4 offloads in Rx path
+Subject: [PATCH 06/26] net/ena: do not set Tx L4 offloads in Rx path
 
 [ upstream commit fd617795679019c7aea5ab1e8c85db02cf53f169 ]
 
@@ -23,7 +23,7 @@ Signed-off-by: Michal Krawczyk <mk@semihalf.com>
  1 file changed, 6 insertions(+), 4 deletions(-)
 
 diff --git a/drivers/net/ena/ena_ethdev.c b/drivers/net/ena/ena_ethdev.c
-index c832d241f..3e73fe1fb 100644
+index c832d241f8..3e73fe1fba 100644
 --- a/drivers/net/ena/ena_ethdev.c
 +++ b/drivers/net/ena/ena_ethdev.c
 @@ -248,16 +248,17 @@ static inline void ena_rx_mbuf_prepare(struct rte_mbuf *mbuf,

--- a/userspace/dpdk/16.11/0007-net-ena-check-pointer-before-memset.patch
+++ b/userspace/dpdk/16.11/0007-net-ena-check-pointer-before-memset.patch
@@ -1,7 +1,7 @@
 From 38a75ccdb2ea650ac7e98b2c3948616cd6fab432 Mon Sep 17 00:00:00 2001
 From: Rafal Kozik <rk@semihalf.com>
 Date: Thu, 7 Jun 2018 11:43:18 +0200
-Subject: [PATCH 07/19] net/ena: check pointer before memset
+Subject: [PATCH 07/26] net/ena: check pointer before memset
 
 [ upstream commit 46916aa17d4b2007df8c0454f99ba0ca8b8cb93b ]
 
@@ -19,7 +19,7 @@ Acked-by: Michal Krawczyk <mk@semihalf.com>
  1 file changed, 16 insertions(+), 6 deletions(-)
 
 diff --git a/drivers/net/ena/base/ena_plat_dpdk.h b/drivers/net/ena/base/ena_plat_dpdk.h
-index a812d75e2..cc69b3372 100644
+index a812d75e2c..cc69b33726 100644
 --- a/drivers/net/ena/base/ena_plat_dpdk.h
 +++ b/drivers/net/ena/base/ena_plat_dpdk.h
 @@ -188,10 +188,15 @@ typedef uint64_t dma_addr_t;

--- a/userspace/dpdk/16.11/0008-net-ena-change-memory-type.patch
+++ b/userspace/dpdk/16.11/0008-net-ena-change-memory-type.patch
@@ -1,7 +1,7 @@
 From 85c0b74c24ab44e78cfdece88993be142fb2ccba Mon Sep 17 00:00:00 2001
 From: Rafal Kozik <rk@semihalf.com>
 Date: Thu, 7 Jun 2018 11:43:19 +0200
-Subject: [PATCH 08/19] net/ena: change memory type
+Subject: [PATCH 08/26] net/ena: change memory type
 
 [ upstream commit 9f32c7e7e6ce58ab772913f54f8328c1c0186a17 ]
 
@@ -22,7 +22,7 @@ Acked-by: Michal Krawczyk <mk@semihalf.com>
  1 file changed, 1 insertion(+), 7 deletions(-)
 
 diff --git a/drivers/net/ena/base/ena_plat_dpdk.h b/drivers/net/ena/base/ena_plat_dpdk.h
-index cc69b3372..ff873e807 100644
+index cc69b33726..ff873e807d 100644
 --- a/drivers/net/ena/base/ena_plat_dpdk.h
 +++ b/drivers/net/ena/base/ena_plat_dpdk.h
 @@ -223,14 +223,8 @@ typedef uint64_t dma_addr_t;

--- a/userspace/dpdk/16.11/0009-net-ena-fix-GENMASK_ULL-macro.patch
+++ b/userspace/dpdk/16.11/0009-net-ena-fix-GENMASK_ULL-macro.patch
@@ -1,7 +1,7 @@
 From 51758b4a25224f10a434c97bd5c46299ea35923f Mon Sep 17 00:00:00 2001
 From: Rafal Kozik <rk@semihalf.com>
 Date: Thu, 7 Jun 2018 11:43:20 +0200
-Subject: [PATCH 09/19] net/ena: fix GENMASK_ULL macro
+Subject: [PATCH 09/26] net/ena: fix GENMASK_ULL macro
 
 [ upstream commit 7544aee8d0b4ae0262b1ba7e1539cf8171664df7 ]
 
@@ -20,7 +20,7 @@ Acked-by: Michal Krawczyk <mk@semihalf.com>
  1 file changed, 3 insertions(+), 1 deletion(-)
 
 diff --git a/drivers/net/ena/base/ena_plat_dpdk.h b/drivers/net/ena/base/ena_plat_dpdk.h
-index ff873e807..791b44ff7 100644
+index ff873e807d..791b44ff72 100644
 --- a/drivers/net/ena/base/ena_plat_dpdk.h
 +++ b/drivers/net/ena/base/ena_plat_dpdk.h
 @@ -115,11 +115,13 @@ typedef uint64_t dma_addr_t;

--- a/userspace/dpdk/16.11/0010-net-ena-set-link-speed-as-none.patch
+++ b/userspace/dpdk/16.11/0010-net-ena-set-link-speed-as-none.patch
@@ -1,7 +1,7 @@
 From c59dd287eb5cf304d48a865b2eea3e014acb7c55 Mon Sep 17 00:00:00 2001
 From: Rafal Kozik <rk@semihalf.com>
 Date: Thu, 7 Jun 2018 11:43:22 +0200
-Subject: [PATCH 10/19] net/ena: set link speed as none
+Subject: [PATCH 10/26] net/ena: set link speed as none
 
 [ upstream commit 41e59028dd8ab2038a7655c6fc3098222661aa53 ]
 
@@ -21,7 +21,7 @@ Acked-by: Michal Krawczyk <mk@semihalf.com>
  1 file changed, 1 insertion(+), 1 deletion(-)
 
 diff --git a/drivers/net/ena/ena_ethdev.c b/drivers/net/ena/ena_ethdev.c
-index 3e73fe1fb..713f5323e 100644
+index 3e73fe1fba..713f5323ee 100644
 --- a/drivers/net/ena/ena_ethdev.c
 +++ b/drivers/net/ena/ena_ethdev.c
 @@ -702,7 +702,7 @@ static int ena_link_update(struct rte_eth_dev *dev,

--- a/userspace/dpdk/16.11/0011-net-ena-fix-SIGFPE-with-0-Rx-queue.patch
+++ b/userspace/dpdk/16.11/0011-net-ena-fix-SIGFPE-with-0-Rx-queue.patch
@@ -1,7 +1,7 @@
 From 65757a0c198c2d99e43b528024b065cfb02b1341 Mon Sep 17 00:00:00 2001
 From: Daria Kolistratova <daria.kolistratova@intel.com>
 Date: Tue, 26 Jun 2018 18:38:56 +0100
-Subject: [PATCH 11/19] net/ena: fix SIGFPE with 0 Rx queue
+Subject: [PATCH 11/26] net/ena: fix SIGFPE with 0 Rx queue
 
 [ upstream commit 361913ad6f8c05fc541fe4bfdae3b0dc095ae3af ]
 
@@ -19,7 +19,7 @@ Acked-by: Michal Krawczyk <mk@semihalf.com>
  1 file changed, 1 insertion(+), 1 deletion(-)
 
 diff --git a/drivers/net/ena/ena_ethdev.c b/drivers/net/ena/ena_ethdev.c
-index 713f5323e..a67065398 100644
+index 713f5323ee..a670653987 100644
 --- a/drivers/net/ena/ena_ethdev.c
 +++ b/drivers/net/ena/ena_ethdev.c
 @@ -899,7 +899,7 @@ static int ena_start(struct rte_eth_dev *dev)

--- a/userspace/dpdk/16.11/0012-net-ena-fix-passing-RSS-hash-to-mbuf.patch
+++ b/userspace/dpdk/16.11/0012-net-ena-fix-passing-RSS-hash-to-mbuf.patch
@@ -1,7 +1,7 @@
 From a8100fd4d73c8abc979e681a8efe16d7628cd558 Mon Sep 17 00:00:00 2001
 From: Stewart Allen <allenste@amazon.com>
 Date: Thu, 25 Oct 2018 19:59:22 +0200
-Subject: [PATCH 12/19] net/ena: fix passing RSS hash to mbuf
+Subject: [PATCH 12/26] net/ena: fix passing RSS hash to mbuf
 
 [ upstream commit e5df9f33db00eb9d322abaefff30da74fd0e625d ]
 
@@ -19,7 +19,7 @@ Acked-by: Michal Krawczyk <mk@semihalf.com>
  1 file changed, 1 insertion(+), 1 deletion(-)
 
 diff --git a/drivers/net/ena/ena_ethdev.c b/drivers/net/ena/ena_ethdev.c
-index a67065398..e38407287 100644
+index a670653987..e38407287e 100644
 --- a/drivers/net/ena/ena_ethdev.c
 +++ b/drivers/net/ena/ena_ethdev.c
 @@ -1558,7 +1558,7 @@ static uint16_t eth_ena_recv_pkts(void *rx_queue, struct rte_mbuf **rx_pkts,

--- a/userspace/dpdk/16.11/0013-net-ena-add-supported-RSS-offloads-types.patch
+++ b/userspace/dpdk/16.11/0013-net-ena-add-supported-RSS-offloads-types.patch
@@ -1,7 +1,7 @@
 From c9469181aa7ff3411f1e090e07f7abc67b62ffe4 Mon Sep 17 00:00:00 2001
 From: Rafal Kozik <rk@semihalf.com>
 Date: Fri, 14 Dec 2018 14:18:38 +0100
-Subject: [PATCH 13/19] net/ena: add supported RSS offloads types
+Subject: [PATCH 13/26] net/ena: add supported RSS offloads types
 
 [ upstream commit b01ead202beb45346d7daeb2f2b1a608006af644 ]
 
@@ -20,7 +20,7 @@ Acked-by: Michal Krawczyk <mk@semihalf.com>
  1 file changed, 3 insertions(+)
 
 diff --git a/drivers/net/ena/ena_ethdev.c b/drivers/net/ena/ena_ethdev.c
-index e38407287..088893230 100644
+index e38407287e..0888932301 100644
 --- a/drivers/net/ena/ena_ethdev.c
 +++ b/drivers/net/ena/ena_ethdev.c
 @@ -1478,6 +1478,9 @@ static void ena_infos_get(struct rte_eth_dev *dev,

--- a/userspace/dpdk/16.11/0014-net-ena-update-completion-queue-after-cleanup.patch
+++ b/userspace/dpdk/16.11/0014-net-ena-update-completion-queue-after-cleanup.patch
@@ -1,7 +1,7 @@
 From f8f96ba4b28049cf514ba8c5ba0324e25c063f2b Mon Sep 17 00:00:00 2001
 From: Rafal Kozik <rk@semihalf.com>
 Date: Fri, 14 Dec 2018 14:18:44 +0100
-Subject: [PATCH 14/19] net/ena: update completion queue after cleanup
+Subject: [PATCH 14/26] net/ena: update completion queue after cleanup
 
 [ upstream commit a45462c507e98b49cb5c2302e0be3c72d2e20a1a ]
 
@@ -19,7 +19,7 @@ Acked-by: Michal Krawczyk <mk@semihalf.com>
  1 file changed, 5 insertions(+), 2 deletions(-)
 
 diff --git a/drivers/net/ena/ena_ethdev.c b/drivers/net/ena/ena_ethdev.c
-index 088893230..9642bdb18 100644
+index 0888932301..9642bdb182 100644
 --- a/drivers/net/ena/ena_ethdev.c
 +++ b/drivers/net/ena/ena_ethdev.c
 @@ -1572,8 +1572,10 @@ static uint16_t eth_ena_recv_pkts(void *rx_queue, struct rte_mbuf **rx_pkts,

--- a/userspace/dpdk/16.11/0015-net-ena-fix-dev-init-with-multi-process.patch
+++ b/userspace/dpdk/16.11/0015-net-ena-fix-dev-init-with-multi-process.patch
@@ -1,7 +1,7 @@
 From 5a56e222261788b4ff1f0a778bad136a8017494c Mon Sep 17 00:00:00 2001
 From: Michal Krawczyk <mk@semihalf.com>
 Date: Fri, 25 Jan 2019 09:10:25 +0100
-Subject: [PATCH 15/19] net/ena: fix dev init with multi-process
+Subject: [PATCH 15/26] net/ena: fix dev init with multi-process
 
 [ upstream commit fd9768905870856a2340266d25f8c0100dfccfff ]
 
@@ -22,7 +22,7 @@ Signed-off-by: Michal Krawczyk <mk@semihalf.com>
  1 file changed, 5 insertions(+), 5 deletions(-)
 
 diff --git a/drivers/net/ena/ena_ethdev.c b/drivers/net/ena/ena_ethdev.c
-index 9642bdb18..5a0d39cb2 100644
+index 9642bdb182..5a0d39cb2a 100644
 --- a/drivers/net/ena/ena_ethdev.c
 +++ b/drivers/net/ena/ena_ethdev.c
 @@ -1270,18 +1270,18 @@ static int eth_ena_dev_init(struct rte_eth_dev *eth_dev)

--- a/userspace/dpdk/16.11/0016-net-ena-get-device-info-statically.patch
+++ b/userspace/dpdk/16.11/0016-net-ena-get-device-info-statically.patch
@@ -1,7 +1,7 @@
 From dcbca00d0c5ed9e68112c3abd4c59dd8a8253214 Mon Sep 17 00:00:00 2001
 From: Michal Krawczyk <mk@semihalf.com>
 Date: Fri, 15 Feb 2019 09:36:39 +0100
-Subject: [PATCH 16/19] net/ena: get device info statically
+Subject: [PATCH 16/26] net/ena: get device info statically
 
 [ upstream commit 117ba4a60488a0f96a5737f38ddba6d0f9a728b6 ]
 
@@ -22,7 +22,7 @@ Signed-off-by: Michal Krawczyk <mk@semihalf.com>
  2 files changed, 19 insertions(+), 15 deletions(-)
 
 diff --git a/drivers/net/ena/ena_ethdev.c b/drivers/net/ena/ena_ethdev.c
-index 5a0d39cb2..4ba2162a7 100644
+index 5a0d39cb2a..4ba2162a70 100644
 --- a/drivers/net/ena/ena_ethdev.c
 +++ b/drivers/net/ena/ena_ethdev.c
 @@ -1352,6 +1352,15 @@ static int eth_ena_dev_init(struct rte_eth_dev *eth_dev)
@@ -82,7 +82,7 @@ index 5a0d39cb2..4ba2162a7 100644
  			DEV_RX_OFFLOAD_UDP_CKSUM  |
  			DEV_RX_OFFLOAD_TCP_CKSUM;
 diff --git a/drivers/net/ena/ena_ethdev.h b/drivers/net/ena/ena_ethdev.h
-index 4c7edbb9e..4791c53b5 100644
+index 4c7edbb9e7..4791c53b5a 100644
 --- a/drivers/net/ena/ena_ethdev.h
 +++ b/drivers/net/ena/ena_ethdev.h
 @@ -143,6 +143,12 @@ struct ena_stats_rx {

--- a/userspace/dpdk/16.11/0017-net-ena-fix-checksum-feature-flag.patch
+++ b/userspace/dpdk/16.11/0017-net-ena-fix-checksum-feature-flag.patch
@@ -1,7 +1,7 @@
 From bcbb265edef2a42fb5af62d2788eb46c30445674 Mon Sep 17 00:00:00 2001
 From: Michal Krawczyk <mk@semihalf.com>
 Date: Mon, 8 Apr 2019 12:27:44 +0200
-Subject: [PATCH 17/19] net/ena: fix checksum feature flag
+Subject: [PATCH 17/26] net/ena: fix checksum feature flag
 
 [ upstream commit ef538c1a7f565c9b58518375a500aa864445fd11 ]
 
@@ -18,7 +18,7 @@ Signed-off-by: Michal Krawczyk <mk@semihalf.com>
  1 file changed, 1 insertion(+), 1 deletion(-)
 
 diff --git a/drivers/net/ena/ena_ethdev.c b/drivers/net/ena/ena_ethdev.c
-index 4ba2162a7..4adeb9728 100644
+index 4ba2162a70..4adeb9728e 100644
 --- a/drivers/net/ena/ena_ethdev.c
 +++ b/drivers/net/ena/ena_ethdev.c
 @@ -1357,7 +1357,7 @@ static int eth_ena_dev_init(struct rte_eth_dev *eth_dev)

--- a/userspace/dpdk/16.11/0018-net-ena-fix-Rx-checksum-errors-statistics.patch
+++ b/userspace/dpdk/16.11/0018-net-ena-fix-Rx-checksum-errors-statistics.patch
@@ -1,7 +1,7 @@
 From 8c2d266436055d21dd239890e7422d97079f2084 Mon Sep 17 00:00:00 2001
 From: Michal Krawczyk <mk@semihalf.com>
 Date: Tue, 28 May 2019 10:28:34 +0200
-Subject: [PATCH 18/19] net/ena: fix Rx checksum errors statistics
+Subject: [PATCH 18/26] net/ena: fix Rx checksum errors statistics
 
 [ upstream commit ef74b5f7b69b9502ddab81121611243efcfe1dde ]
 
@@ -21,7 +21,7 @@ Signed-off-by: Michal Krawczyk <mk@semihalf.com>
  1 file changed, 5 insertions(+), 4 deletions(-)
 
 diff --git a/drivers/net/ena/ena_ethdev.c b/drivers/net/ena/ena_ethdev.c
-index 4adeb9728..7998f4e6a 100644
+index 4adeb9728e..7998f4e6a5 100644
 --- a/drivers/net/ena/ena_ethdev.c
 +++ b/drivers/net/ena/ena_ethdev.c
 @@ -1558,6 +1558,11 @@ static uint16_t eth_ena_recv_pkts(void *rx_queue, struct rte_mbuf **rx_pkts,

--- a/userspace/dpdk/16.11/0019-net-ena-fix-assigning-NUMA-node-to-IO-queue.patch
+++ b/userspace/dpdk/16.11/0019-net-ena-fix-assigning-NUMA-node-to-IO-queue.patch
@@ -1,7 +1,7 @@
 From da602284b0284e7bf3986557aea26a69257d8c32 Mon Sep 17 00:00:00 2001
 From: Michal Krawczyk <mk@semihalf.com>
 Date: Tue, 4 Jun 2019 12:59:36 +0200
-Subject: [PATCH 19/19] net/ena: fix assigning NUMA node to IO queue
+Subject: [PATCH 19/26] net/ena: fix assigning NUMA node to IO queue
 
 [ upstream commit 4217cb0b7d2c5385f06f531af7f14b860927aba7 ]
 
@@ -23,7 +23,7 @@ Reviewed-by: David Marchand <david.marchand@redhat.com>
  2 files changed, 8 insertions(+), 17 deletions(-)
 
 diff --git a/drivers/net/ena/ena_ethdev.c b/drivers/net/ena/ena_ethdev.c
-index 7998f4e6a..97c8046ed 100644
+index 7998f4e6a5..97c8046ed0 100644
 --- a/drivers/net/ena/ena_ethdev.c
 +++ b/drivers/net/ena/ena_ethdev.c
 @@ -38,7 +38,6 @@
@@ -106,7 +106,7 @@ index 7998f4e6a..97c8046ed 100644
  
  	rxq->rx_buffer_info = rte_zmalloc("rxq->buffer_info",
 diff --git a/drivers/net/ena/ena_ethdev.h b/drivers/net/ena/ena_ethdev.h
-index 4791c53b5..8d5eb5a7c 100644
+index 4791c53b5a..8d5eb5a7ca 100644
 --- a/drivers/net/ena/ena_ethdev.h
 +++ b/drivers/net/ena/ena_ethdev.h
 @@ -90,6 +90,8 @@ struct ena_ring {

--- a/userspace/dpdk/16.11/0020-net-ena-base-fix-node-deallocation.patch
+++ b/userspace/dpdk/16.11/0020-net-ena-base-fix-node-deallocation.patch
@@ -1,0 +1,59 @@
+From fbacfc65f254d509bfe622621c83487bafaa2973 Mon Sep 17 00:00:00 2001
+From: Michal Krawczyk <mk@semihalf.com>
+Date: Thu, 2 Jul 2020 10:25:03 +0000
+Subject: [PATCH 20/26] net/ena/base: fix node deallocation
+
+The memzone handle wasn't saved anywhere - it could cause free of the
+invalid memory, as the mem_handle was never holding the right value.
+
+Signed-off-by: Michal Krawczyk <mk@semihalf.com>
+---
+ drivers/net/ena/base/ena_com.c       | 2 ++
+ drivers/net/ena/base/ena_plat_dpdk.h | 4 +++-
+ 2 files changed, 5 insertions(+), 1 deletion(-)
+
+diff --git a/drivers/net/ena/base/ena_com.c b/drivers/net/ena/base/ena_com.c
+index 88053e3360..621a4da5c3 100644
+--- a/drivers/net/ena/base/ena_com.c
++++ b/drivers/net/ena/base/ena_com.c
+@@ -347,6 +347,7 @@ static int ena_com_init_io_sq(struct ena_com_dev *ena_dev,
+ 					    size,
+ 					    io_sq->desc_addr.virt_addr,
+ 					    io_sq->desc_addr.phys_addr,
++					    io_sq->desc_addr.mem_handle,
+ 					    ctx->numa_node,
+ 					    dev_node);
+ 		if (!io_sq->desc_addr.virt_addr)
+@@ -400,6 +401,7 @@ static int ena_com_init_io_cq(struct ena_com_dev *ena_dev,
+ 				    size,
+ 				    io_cq->cdesc_addr.virt_addr,
+ 				    io_cq->cdesc_addr.phys_addr,
++				    io_cq->cdesc_addr.mem_handle,
+ 				    ctx->numa_node,
+ 				    prev_node);
+ 	if (!io_cq->cdesc_addr.virt_addr)
+diff --git a/drivers/net/ena/base/ena_plat_dpdk.h b/drivers/net/ena/base/ena_plat_dpdk.h
+index 791b44ff72..42f454ccd5 100644
+--- a/drivers/net/ena/base/ena_plat_dpdk.h
++++ b/drivers/net/ena/base/ena_plat_dpdk.h
+@@ -205,7 +205,8 @@ typedef uint64_t dma_addr_t;
+ 		   ENA_TOUCH(dmadev);					\
+ 		   rte_memzone_free(handle); })
+ 
+-#define ENA_MEM_ALLOC_COHERENT_NODE(dmadev, size, virt, phys, node, dev_node) \
++#define ENA_MEM_ALLOC_COHERENT_NODE(					\
++	dmadev, size, virt, phys, mem_handle, node, dev_node)		\
+ 	do {								\
+ 		const struct rte_memzone *mz;				\
+ 		char z_name[RTE_MEMZONE_NAMESIZE];			\
+@@ -213,6 +214,7 @@ typedef uint64_t dma_addr_t;
+ 		snprintf(z_name, sizeof(z_name),			\
+ 				"ena_alloc_%d", ena_alloc_cnt++);	\
+ 		mz = rte_memzone_reserve(z_name, size, node, 0); \
++		mem_handle = mz;					\
+ 		if (mz == NULL) {					\
+ 			virt = NULL;					\
+ 			phys = 0;					\
+-- 
+2.20.1
+

--- a/userspace/dpdk/16.11/0021-net-ena-fix-indication-of-bad-L4-Rx-checksums.patch
+++ b/userspace/dpdk/16.11/0021-net-ena-fix-indication-of-bad-L4-Rx-checksums.patch
@@ -1,0 +1,44 @@
+From 6d1196fffb970acf040095f709804ba7bd923327 Mon Sep 17 00:00:00 2001
+From: Igor Chauskin <igorch@amazon.com>
+Date: Mon, 28 Oct 2019 11:23:33 +0100
+Subject: [PATCH 21/26] net/ena: fix indication of bad L4 Rx checksums
+
+[ upstream commit 05817057faba9356900ced61e24a22eef6bc4c87 ]
+
+Add checking of l4_csum_checked and frag flags before checking the
+l4_csum_error flag.
+
+In case of IP fragment/unchecked L4 csum - add PKT_RX_L4_CKSUM_UNKNOWN
+flag to the indicated mbuf.
+
+Fixes: 1173fca25af9 ("ena: add polling-mode driver")
+Cc: stable@dpdk.org
+
+Change-Id: I9f1414741eb44ca289a8bfd11d7e66110c95040e
+Signed-off-by: Igor Chauskin <igorch@amazon.com>
+Reviewed-by: Maciej Bielski <mba@semihalf.com>
+Reviewed-by: Michal Krawczyk <mk@semihalf.com>
+---
+ drivers/net/ena/ena_ethdev.c | 5 ++++-
+ 1 file changed, 4 insertions(+), 1 deletion(-)
+
+diff --git a/drivers/net/ena/ena_ethdev.c b/drivers/net/ena/ena_ethdev.c
+index 97c8046ed0..47cb53f49a 100644
+--- a/drivers/net/ena/ena_ethdev.c
++++ b/drivers/net/ena/ena_ethdev.c
+@@ -247,8 +247,11 @@ static inline void ena_rx_mbuf_prepare(struct rte_mbuf *mbuf,
+ 	else if (ena_rx_ctx->l3_proto == ENA_ETH_IO_L3_PROTO_IPV6)
+ 		packet_type |= RTE_PTYPE_L3_IPV6;
+ 
+-	if (unlikely(ena_rx_ctx->l4_csum_err))
++	if (unlikely(ena_rx_ctx->l4_csum_err) && !ena_rx_ctx->frag)
+ 		ol_flags |= PKT_RX_L4_CKSUM_BAD;
++	else
++		ol_flags |= PKT_RX_L4_CKSUM_UNKNOWN;
++
+ 	if (unlikely(ena_rx_ctx->l3_csum_err))
+ 		ol_flags |= PKT_RX_IP_CKSUM_BAD;
+ 
+-- 
+2.20.1
+

--- a/userspace/dpdk/16.11/0022-net-ena-ensure-Rx-buffer-size-is-at-least-1400B.patch
+++ b/userspace/dpdk/16.11/0022-net-ena-ensure-Rx-buffer-size-is-at-least-1400B.patch
@@ -1,0 +1,84 @@
+From 836a09ebf16c2afc43dce29117321fb9c4b2092d Mon Sep 17 00:00:00 2001
+From: Michal Krawczyk <mk@semihalf.com>
+Date: Wed, 8 Apr 2020 10:28:52 +0200
+Subject: [PATCH 22/26] net/ena: ensure Rx buffer size is at least 1400B
+
+[ upstream commit 38364c2687ead97b99402310087c27131a97748c ]
+
+Some of the ENA devices can't handle buffers which are smaller than a
+1400B. Because of this limitation, size of the buffer is being checked
+and limited during the Rx queue setup.
+
+If it's below the allowed value, PMD won't finish it's configuration
+successfully..
+
+Change-Id: Ib402d3bfad98a3fc4f91095d5c6f90c6069da021
+Signed-off-by: Michal Krawczyk <mk@semihalf.com>
+Reviewed-by: Igor Chauskin <igorch@amazon.com>
+Reviewed-by: Guy Tzalik <gtzalik@amazon.com>
+---
+ drivers/net/ena/ena_ethdev.c | 12 +++++++++++-
+ drivers/net/ena/ena_ethdev.h |  3 ++-
+ 2 files changed, 13 insertions(+), 2 deletions(-)
+
+diff --git a/drivers/net/ena/ena_ethdev.c b/drivers/net/ena/ena_ethdev.c
+index 47cb53f49a..6e2dbc9d09 100644
+--- a/drivers/net/ena/ena_ethdev.c
++++ b/drivers/net/ena/ena_ethdev.c
+@@ -1,7 +1,7 @@
+ /*-
+ * BSD LICENSE
+ *
+-* Copyright (c) 2015-2016 Amazon.com, Inc. or its affiliates.
++* Copyright (c) 2015-2020 Amazon.com, Inc. or its affiliates.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+@@ -1042,6 +1042,7 @@ static int ena_rx_queue_setup(struct rte_eth_dev *dev,
+ 	struct ena_adapter *adapter =
+ 		(struct ena_adapter *)(dev->data->dev_private);
+ 	struct ena_ring *rxq = NULL;
++	size_t buffer_size;
+ 	uint16_t ena_qid = 0;
+ 	int rc = 0;
+ 	struct ena_com_dev *ena_dev = &adapter->ena_dev;
+@@ -1068,6 +1069,15 @@ static int ena_rx_queue_setup(struct rte_eth_dev *dev,
+ 		return -EINVAL;
+ 	}
+ 
++	/* ENA isn't supporting buffers smaller than 1400 bytes */
++	buffer_size = rte_pktmbuf_data_room_size(mp) - RTE_PKTMBUF_HEADROOM;
++	if (buffer_size < ENA_RX_BUF_MIN_SIZE) {
++		PMD_DRV_LOG(ERR,
++			"Unsupported size of RX buffer: %zu (min size: %d)\n",
++			buffer_size, ENA_RX_BUF_MIN_SIZE);
++		return -EINVAL;
++	}
++
+ 	ena_qid = ENA_IO_RXQ_IDX(queue_idx);
+ 
+ 	ctx.qid = ena_qid;
+diff --git a/drivers/net/ena/ena_ethdev.h b/drivers/net/ena/ena_ethdev.h
+index 8d5eb5a7ca..d6e5e730e1 100644
+--- a/drivers/net/ena/ena_ethdev.h
++++ b/drivers/net/ena/ena_ethdev.h
+@@ -1,7 +1,7 @@
+ /*-
+ * BSD LICENSE
+ *
+-* Copyright (c) 2015-2016 Amazon.com, Inc. or its affiliates.
++* Copyright (c) 2015-2020 Amazon.com, Inc. or its affiliates.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+@@ -46,6 +46,7 @@
+ #define ENA_MIN_FRAME_LEN	64
+ #define ENA_NAME_MAX_LEN	20
+ #define ENA_PKT_MAX_BUFS	17
++#define ENA_RX_BUF_MIN_SIZE	1400
+ 
+ #define ENA_MMIO_DISABLE_REG_READ	BIT(0)
+ 
+-- 
+2.20.1
+

--- a/userspace/dpdk/16.11/0023-net-ena-base-make-allocation-macros-thread-safe.patch
+++ b/userspace/dpdk/16.11/0023-net-ena-base-make-allocation-macros-thread-safe.patch
@@ -1,0 +1,103 @@
+From cec3004fa53d6300fd6f967fca00ad6931c17427 Mon Sep 17 00:00:00 2001
+From: Igor Chauskin <igorch@amazon.com>
+Date: Wed, 8 Apr 2020 10:28:53 +0200
+Subject: [PATCH 23/26] net/ena/base: make allocation macros thread-safe
+
+[ upstream commit b14fcac035fd8514851c9140a4e26d765b61c532 ]
+
+Memory allocation region id could possibly be non-unique
+due to non-atomic increment, causing allocation failure.
+
+Fixes: 9ba7981ec992 ("ena: add communication layer for DPDK")
+Cc: stable@dpdk.org
+
+Change-Id: Ib9207aaae4e5e7ecdf1a99a0f23a508a53af631d
+Signed-off-by: Igor Chauskin <igorch@amazon.com>
+Reviewed-by: Michal Krawczyk <mk@semihalf.com>
+Reviewed-by: Guy Tzalik <gtzalik@amazon.com>
+---
+ drivers/net/ena/base/ena_com.c       |  2 --
+ drivers/net/ena/base/ena_plat_dpdk.h | 16 ++++++++++++----
+ drivers/net/ena/ena_ethdev.c         |  6 ++++++
+ 3 files changed, 18 insertions(+), 6 deletions(-)
+
+diff --git a/drivers/net/ena/base/ena_com.c b/drivers/net/ena/base/ena_com.c
+index 621a4da5c3..bae7d1212b 100644
+--- a/drivers/net/ena/base/ena_com.c
++++ b/drivers/net/ena/base/ena_com.c
+@@ -62,8 +62,6 @@
+ 
+ #define ENA_MMIO_READ_TIMEOUT 0xFFFFFFFF
+ 
+-static int ena_alloc_cnt;
+-
+ /*****************************************************************************/
+ /*****************************************************************************/
+ /*****************************************************************************/
+diff --git a/drivers/net/ena/base/ena_plat_dpdk.h b/drivers/net/ena/base/ena_plat_dpdk.h
+index 42f454ccd5..324e30875d 100644
+--- a/drivers/net/ena/base/ena_plat_dpdk.h
++++ b/drivers/net/ena/base/ena_plat_dpdk.h
+@@ -1,7 +1,7 @@
+ /*-
+ * BSD LICENSE
+ *
+-* Copyright (c) 2015-2016 Amazon.com, Inc. or its affiliates.
++* Copyright (c) 2015-2020 Amazon.com, Inc. or its affiliates.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+@@ -182,13 +182,20 @@ typedef uint64_t dma_addr_t;
+ #define ena_wait_event_t ena_wait_queue_t
+ #define ENA_MIGHT_SLEEP()
+ 
++/*
++ * Each rte_memzone should have unique name.
++ * To satisfy it, count number of allocations and add it to name.
++ */
++extern rte_atomic32_t ena_alloc_cnt;
++
+ #define ENA_MEM_ALLOC_COHERENT(dmadev, size, virt, phys, handle)	\
+ 	do {								\
+ 		const struct rte_memzone *mz;				\
+ 		char z_name[RTE_MEMZONE_NAMESIZE];			\
+ 		ENA_TOUCH(dmadev); ENA_TOUCH(handle);			\
+ 		snprintf(z_name, sizeof(z_name),			\
+-				"ena_alloc_%d", ena_alloc_cnt++);	\
++			 "ena_alloc_%d",				\
++			 rte_atomic32_add_return(&ena_alloc_cnt, 1));	\
+ 		mz = rte_memzone_reserve(z_name, size, SOCKET_ID_ANY, 0); \
+ 		handle = mz;						\
+ 		if (mz == NULL) {					\
+@@ -212,8 +219,9 @@ typedef uint64_t dma_addr_t;
+ 		char z_name[RTE_MEMZONE_NAMESIZE];			\
+ 		ENA_TOUCH(dmadev); ENA_TOUCH(dev_node);			\
+ 		snprintf(z_name, sizeof(z_name),			\
+-				"ena_alloc_%d", ena_alloc_cnt++);	\
+-		mz = rte_memzone_reserve(z_name, size, node, 0); \
++			 "ena_alloc_%d",				\
++			 rte_atomic32_add_return(&ena_alloc_cnt, 1));	\
++		mz = rte_memzone_reserve(z_name, size, node, 0);	\
+ 		mem_handle = mz;					\
+ 		if (mz == NULL) {					\
+ 			virt = NULL;					\
+diff --git a/drivers/net/ena/ena_ethdev.c b/drivers/net/ena/ena_ethdev.c
+index 6e2dbc9d09..888559a159 100644
+--- a/drivers/net/ena/ena_ethdev.c
++++ b/drivers/net/ena/ena_ethdev.c
+@@ -111,6 +111,12 @@ struct ena_stats {
+ #define ENA_STAT_GLOBAL_ENTRY(stat) \
+ 	ENA_STAT_ENTRY(stat, dev)
+ 
++/*
++ * Each rte_memzone should have unique name.
++ * To satisfy it, count number of allocation and add it to name.
++ */
++rte_atomic32_t ena_alloc_cnt;
++
+ static const struct ena_stats ena_stats_global_strings[] = {
+ 	ENA_STAT_GLOBAL_ENTRY(tx_timeout),
+ 	ENA_STAT_GLOBAL_ENTRY(io_suspend),
+-- 
+2.20.1
+

--- a/userspace/dpdk/16.11/0024-net-ena-base-prevent-allocation-of-zero-sized-memory.patch
+++ b/userspace/dpdk/16.11/0024-net-ena-base-prevent-allocation-of-zero-sized-memory.patch
@@ -1,0 +1,74 @@
+From 57865ace2bab7133f28ec02e8952fca2d2bd3d51 Mon Sep 17 00:00:00 2001
+From: Igor Chauskin <igorch@amazon.com>
+Date: Wed, 8 Apr 2020 10:28:54 +0200
+Subject: [PATCH 24/26] net/ena/base: prevent allocation of zero sized memory
+
+[ upstream commit 29dc10d9424ccf26a346387b0a707185e2432400 ]
+
+rte_memzone_reserve() will reserve the biggest contiguous memzone
+available if received 0 as size param.
+
+Fixes: 9ba7981ec992 ("ena: add communication layer for DPDK")
+Cc: stable@dpdk.org
+
+Change-Id: I2f71119e93c5e9addd8c538820093f030066d690
+Signed-off-by: Igor Chauskin <igorch@amazon.com>
+Reviewed-by: Michal Krawczyk <mk@semihalf.com>
+Reviewed-by: Guy Tzalik <gtzalik@amazon.com>
+---
+ drivers/net/ena/base/ena_plat_dpdk.h | 27 ++++++++++++++++-----------
+ 1 file changed, 16 insertions(+), 11 deletions(-)
+
+diff --git a/drivers/net/ena/base/ena_plat_dpdk.h b/drivers/net/ena/base/ena_plat_dpdk.h
+index 324e30875d..e95475362e 100644
+--- a/drivers/net/ena/base/ena_plat_dpdk.h
++++ b/drivers/net/ena/base/ena_plat_dpdk.h
+@@ -190,14 +190,17 @@ extern rte_atomic32_t ena_alloc_cnt;
+ 
+ #define ENA_MEM_ALLOC_COHERENT(dmadev, size, virt, phys, handle)	\
+ 	do {								\
+-		const struct rte_memzone *mz;				\
+-		char z_name[RTE_MEMZONE_NAMESIZE];			\
++		const struct rte_memzone *mz = NULL;			\
+ 		ENA_TOUCH(dmadev); ENA_TOUCH(handle);			\
+-		snprintf(z_name, sizeof(z_name),			\
++		if (size > 0) {						\
++			char z_name[RTE_MEMZONE_NAMESIZE];		\
++			snprintf(z_name, sizeof(z_name),		\
+ 			 "ena_alloc_%d",				\
+ 			 rte_atomic32_add_return(&ena_alloc_cnt, 1));	\
+-		mz = rte_memzone_reserve(z_name, size, SOCKET_ID_ANY, 0); \
+-		handle = mz;						\
++			mz = rte_memzone_reserve(z_name, size,		\
++				SOCKET_ID_ANY, 0);			\
++			handle = mz;					\
++		}							\
+ 		if (mz == NULL) {					\
+ 			virt = NULL;					\
+ 			phys = 0;					\
+@@ -215,14 +218,16 @@ extern rte_atomic32_t ena_alloc_cnt;
+ #define ENA_MEM_ALLOC_COHERENT_NODE(					\
+ 	dmadev, size, virt, phys, mem_handle, node, dev_node)		\
+ 	do {								\
+-		const struct rte_memzone *mz;				\
+-		char z_name[RTE_MEMZONE_NAMESIZE];			\
++		const struct rte_memzone *mz = NULL;			\
+ 		ENA_TOUCH(dmadev); ENA_TOUCH(dev_node);			\
+-		snprintf(z_name, sizeof(z_name),			\
++		if (size > 0) {						\
++			char z_name[RTE_MEMZONE_NAMESIZE];		\
++			snprintf(z_name, sizeof(z_name),		\
+ 			 "ena_alloc_%d",				\
+-			 rte_atomic32_add_return(&ena_alloc_cnt, 1));	\
+-		mz = rte_memzone_reserve(z_name, size, node, 0);	\
+-		mem_handle = mz;					\
++			 rte_atomic32_add_return(&ena_alloc_cnt, 1));   \
++			mz = rte_memzone_reserve(z_name, size, node, 0); \
++			mem_handle = mz;				\
++		}							\
+ 		if (mz == NULL) {					\
+ 			virt = NULL;					\
+ 			phys = 0;					\
+-- 
+2.20.1
+

--- a/userspace/dpdk/16.11/0025-net-ena-set-IO-ring-size-to-valid-value.patch
+++ b/userspace/dpdk/16.11/0025-net-ena-set-IO-ring-size-to-valid-value.patch
@@ -1,0 +1,49 @@
+From d9a3e22e34495e7f8efbd8c3bb765792336642ca Mon Sep 17 00:00:00 2001
+From: Michal Krawczyk <mk@semihalf.com>
+Date: Fri, 3 Jul 2020 13:14:58 +0000
+Subject: [PATCH 25/26] net/ena: set IO ring size to valid value
+
+[ upstream commit badc3a6aa133a886a61b9e3ad666e5675f7ec3d3 ]
+
+IO rings were configured with the maximum allowed size for the Tx/Rx
+rings. However, the application could decide to create smaller rings.
+
+This patch is using value stored in the ring instead of the value from
+the adapter which is indicating the maximum allowed value.
+
+Fixes: df238f84c0a2 ("net/ena: recreate HW IO rings on start and stop")
+Cc: stable@dpdk.org
+
+Change-Id: Icf9102e2aa4e7413b6620b36dd232673239b7291
+Signed-off-by: Michal Krawczyk <mk@semihalf.com>
+Reviewed-by: Igor Chauskin <igorch@amazon.com>
+Reviewed-by: Guy Tzalik <gtzalik@amazon.com>
+---
+ drivers/net/ena/ena_ethdev.c | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/drivers/net/ena/ena_ethdev.c b/drivers/net/ena/ena_ethdev.c
+index 888559a159..0a97c67815 100644
+--- a/drivers/net/ena/ena_ethdev.c
++++ b/drivers/net/ena/ena_ethdev.c
+@@ -978,7 +978,7 @@ static int ena_tx_queue_setup(struct rte_eth_dev *dev,
+ 	ctx.qid = ena_qid;
+ 	ctx.msix_vector = -1; /* admin interrupts not used */
+ 	ctx.mem_queue_type = ena_dev->tx_mem_queue_type;
+-	ctx.queue_size = adapter->tx_ring_size;
++	ctx.queue_size = nb_desc;
+ 	ctx.numa_node = socket_id;
+ 
+ 	rc = ena_com_create_io_queue(ena_dev, &ctx);
+@@ -1090,7 +1090,7 @@ static int ena_rx_queue_setup(struct rte_eth_dev *dev,
+ 	ctx.direction = ENA_COM_IO_QUEUE_DIRECTION_RX;
+ 	ctx.mem_queue_type = ENA_ADMIN_PLACEMENT_POLICY_HOST;
+ 	ctx.msix_vector = -1; /* admin interrupts not used */
+-	ctx.queue_size = adapter->rx_ring_size;
++	ctx.queue_size = nb_desc;
+ 	ctx.numa_node = socket_id;
+ 
+ 	rc = ena_com_create_io_queue(ena_dev, &ctx);
+-- 
+2.20.1
+

--- a/userspace/dpdk/16.11/0026-net-ena-limit-refill-threshold-by-fixed-value.patch
+++ b/userspace/dpdk/16.11/0026-net-ena-limit-refill-threshold-by-fixed-value.patch
@@ -1,0 +1,118 @@
+From 5d9c030d80ec3d1c9fb73a5c64bb9be7d81eb829 Mon Sep 17 00:00:00 2001
+From: Michal Krawczyk <mk@semihalf.com>
+Date: Wed, 8 Apr 2020 10:29:16 +0200
+Subject: [PATCH 26/26] net/ena: limit refill threshold by fixed value
+
+[ upstream commit 7755060798de9c0146df8809926030ed47fc9086 ]
+
+Divider used for both Tx and Rx cleanup/refill threshold can cause too
+big delay in case of the really big rings - for example if the 8k Rx
+ring will be used, the refill won't trigger unless 1024 threshold will
+be reached. It will also cause driver to try to allocate that much
+descriptors.
+
+Limiting it by fixed value - 256 in that case, would limit maximum
+time spent in repopulate function.
+
+Change-Id: Ia8659e6ddf179ff612a780adc6fe55d13eeac6e9
+Signed-off-by: Michal Krawczyk <mk@semihalf.com>
+Reviewed-by: Igor Chauskin <igorch@amazon.com>
+Reviewed-by: Guy Tzalik <gtzalik@amazon.com>
+---
+ drivers/net/ena/ena_ethdev.c | 26 ++++++++++++++------------
+ drivers/net/ena/ena_ethdev.h | 10 ++++++++++
+ 2 files changed, 24 insertions(+), 12 deletions(-)
+
+diff --git a/drivers/net/ena/ena_ethdev.c b/drivers/net/ena/ena_ethdev.c
+index 0a97c67815..f3dda8f7d0 100644
+--- a/drivers/net/ena/ena_ethdev.c
++++ b/drivers/net/ena/ena_ethdev.c
+@@ -59,14 +59,6 @@
+ /*reverse version of ENA_IO_RXQ_IDX*/
+ #define ENA_IO_RXQ_IDX_REV(q)	((q - 1) / 2)
+ 
+-/* While processing submitted and completed descriptors (rx and tx path
+- * respectively) in a loop it is desired to:
+- *  - perform batch submissions while populating sumbissmion queue
+- *  - avoid blocking transmission of other packets during cleanup phase
+- * Hence the utilization ratio of 1/8 of a queue size.
+- */
+-#define ENA_RING_DESCS_RATIO(ring_size)	(ring_size / 8)
+-
+ #define __MERGE_64B_H_L(h, l) (((uint64_t)h << 32) | l)
+ #define TEST_BIT(val, bit_shift) (val & (1UL << bit_shift))
+ 
+@@ -1501,6 +1493,8 @@ static uint16_t eth_ena_recv_pkts(void *rx_queue, struct rte_mbuf **rx_pkts,
+ 	struct ena_ring *rx_ring = (struct ena_ring *)(rx_queue);
+ 	unsigned int ring_size = rx_ring->ring_size;
+ 	unsigned int ring_mask = ring_size - 1;
++	unsigned int free_queue_entries;
++	unsigned int refill_threshold;
+ 	uint16_t next_to_clean = rx_ring->next_to_clean;
+ 	uint16_t desc_in_use = 0;
+ 	unsigned int recv_idx = 0;
+@@ -1580,11 +1574,15 @@ static uint16_t eth_ena_recv_pkts(void *rx_queue, struct rte_mbuf **rx_pkts,
+ 
+ 	rx_ring->next_to_clean = next_to_clean;
+ 
+-	desc_in_use = desc_in_use - completed + 1;
++	free_queue_entries = ena_com_sq_empty_space(rx_ring->ena_com_io_sq);
++	refill_threshold =
++		RTE_MIN(ring_size / ENA_REFILL_THRESH_DIVIDER,
++		(unsigned int)ENA_REFILL_THRESH_PACKET);
++
+ 	/* Burst refill to save doorbells, memory barriers, const interval */
+-	if (ring_size - desc_in_use > ENA_RING_DESCS_RATIO(ring_size)) {
++	if (free_queue_entries > refill_threshold) {
+ 		ena_com_update_dev_comp_head(rx_ring->ena_com_io_cq);
+-		ena_populate_rx_queue(rx_ring, ring_size - desc_in_use);
++		ena_populate_rx_queue(rx_ring, free_queue_entries);
+ 	}
+ 
+ 	return recv_idx;
+@@ -1599,6 +1597,7 @@ static uint16_t eth_ena_xmit_pkts(void *tx_queue, struct rte_mbuf **tx_pkts,
+ 	struct rte_mbuf *mbuf;
+ 	unsigned int ring_size = tx_ring->ring_size;
+ 	unsigned int ring_mask = ring_size - 1;
++	unsigned int cleanup_budget;
+ 	struct ena_com_tx_ctx ena_tx_ctx;
+ 	struct ena_tx_buffer *tx_info;
+ 	struct ena_com_buf *ebuf;
+@@ -1705,9 +1704,12 @@ static uint16_t eth_ena_xmit_pkts(void *tx_queue, struct rte_mbuf **tx_pkts,
+ 		/* Put back descriptor to the ring for reuse */
+ 		tx_ring->empty_tx_reqs[next_to_clean & ring_mask] = req_id;
+ 		next_to_clean++;
++		cleanup_budget =
++			RTE_MIN(ring_size / ENA_REFILL_THRESH_DIVIDER,
++			(unsigned int)ENA_REFILL_THRESH_PACKET);
+ 
+ 		/* If too many descs to clean, leave it for another run */
+-		if (unlikely(total_tx_descs > ENA_RING_DESCS_RATIO(ring_size)))
++		if (unlikely(total_tx_descs > cleanup_budget))
+ 			break;
+ 	}
+ 
+diff --git a/drivers/net/ena/ena_ethdev.h b/drivers/net/ena/ena_ethdev.h
+index d6e5e730e1..2b02806db5 100644
+--- a/drivers/net/ena/ena_ethdev.h
++++ b/drivers/net/ena/ena_ethdev.h
+@@ -50,6 +50,16 @@
+ 
+ #define ENA_MMIO_DISABLE_REG_READ	BIT(0)
+ 
++/* While processing submitted and completed descriptors (rx and tx path
++ * respectively) in a loop it is desired to:
++ *  - perform batch submissions while populating sumbissmion queue
++ *  - avoid blocking transmission of other packets during cleanup phase
++ * Hence the utilization ratio of 1/8 of a queue size or max value if the size
++ * of the ring is very big - like 8k Rx rings.
++ */
++#define ENA_REFILL_THRESH_DIVIDER      8
++#define ENA_REFILL_THRESH_PACKET       256
++
+ struct ena_adapter;
+ 
+ enum ena_ring_type {
+-- 
+2.20.1
+

--- a/userspace/dpdk/17.02/0001-net-ena-fix-Rx-descriptors-allocation.patch
+++ b/userspace/dpdk/17.02/0001-net-ena-fix-Rx-descriptors-allocation.patch
@@ -1,7 +1,7 @@
 From ad5f91443d2f6596268e7a0619c9509e00ba3b12 Mon Sep 17 00:00:00 2001
 From: Michal Krawczyk <mk@semihalf.com>
 Date: Mon, 10 Apr 2017 16:28:08 +0200
-Subject: [PATCH 01/21] net/ena: fix Rx descriptors allocation
+Subject: [PATCH 01/28] net/ena: fix Rx descriptors allocation
 
 [ upstream commit a467e8f37a3eec98210c0c3ec04bf6e9506ddd81 ]
 
@@ -22,7 +22,7 @@ Acked-by: Jan Medala <jan.medala@outlook.com>
  1 file changed, 6 insertions(+), 4 deletions(-)
 
 diff --git a/drivers/net/ena/ena_ethdev.c b/drivers/net/ena/ena_ethdev.c
-index b5e6db624..90cf2ad3c 100644
+index b5e6db6245..90cf2ad3c3 100644
 --- a/drivers/net/ena/ena_ethdev.c
 +++ b/drivers/net/ena/ena_ethdev.c
 @@ -919,7 +919,7 @@ static int ena_start(struct rte_eth_dev *dev)

--- a/userspace/dpdk/17.02/0002-net-ena-fix-delayed-cleanup-of-Rx-descriptors.patch
+++ b/userspace/dpdk/17.02/0002-net-ena-fix-delayed-cleanup-of-Rx-descriptors.patch
@@ -1,7 +1,7 @@
 From 1e449ffd3b2d11d7d296222fce58de4a12b769c6 Mon Sep 17 00:00:00 2001
 From: Michal Krawczyk <mk@semihalf.com>
 Date: Mon, 10 Apr 2017 16:28:09 +0200
-Subject: [PATCH 02/21] net/ena: fix delayed cleanup of Rx descriptors
+Subject: [PATCH 02/28] net/ena: fix delayed cleanup of Rx descriptors
 
 [ upstream commit ec78af6bc0556cf2a1133185ca33fb835b38afe0 ]
 
@@ -26,7 +26,7 @@ Acked-by: Jan Medala <jan.medala@outlook.com>
  1 file changed, 3 insertions(+), 3 deletions(-)
 
 diff --git a/drivers/net/ena/ena_ethdev.c b/drivers/net/ena/ena_ethdev.c
-index 90cf2ad3c..b4c713f94 100644
+index 90cf2ad3c3..b4c713f943 100644
 --- a/drivers/net/ena/ena_ethdev.c
 +++ b/drivers/net/ena/ena_ethdev.c
 @@ -1575,13 +1575,13 @@ static uint16_t eth_ena_recv_pkts(void *rx_queue, struct rte_mbuf **rx_pkts,

--- a/userspace/dpdk/17.02/0003-net-ena-cleanup-if-refilling-of-Rx-descriptors-fails.patch
+++ b/userspace/dpdk/17.02/0003-net-ena-cleanup-if-refilling-of-Rx-descriptors-fails.patch
@@ -1,7 +1,7 @@
 From 1b794e3d217507604a567ba692121ccfff415dd7 Mon Sep 17 00:00:00 2001
 From: Michal Krawczyk <mk@semihalf.com>
 Date: Mon, 10 Apr 2017 16:28:10 +0200
-Subject: [PATCH 03/21] net/ena: cleanup if refilling of Rx descriptors fails
+Subject: [PATCH 03/28] net/ena: cleanup if refilling of Rx descriptors fails
 
 [ upstream commit 2732e07ad1e54c648c8ca5bc6965af5bf607ba10 ]
 
@@ -22,7 +22,7 @@ Acked-by: Jan Medala <jan.medala@outlook.com>
  1 file changed, 2 insertions(+)
 
 diff --git a/drivers/net/ena/ena_ethdev.c b/drivers/net/ena/ena_ethdev.c
-index b4c713f94..e6e889bdd 100644
+index b4c713f943..e6e889bdd1 100644
 --- a/drivers/net/ena/ena_ethdev.c
 +++ b/drivers/net/ena/ena_ethdev.c
 @@ -1172,6 +1172,8 @@ static int ena_populate_rx_queue(struct ena_ring *rxq, unsigned int count)

--- a/userspace/dpdk/17.02/0004-net-ena-calculate-partial-checksum-if-DF-bit-is-disa.patch
+++ b/userspace/dpdk/17.02/0004-net-ena-calculate-partial-checksum-if-DF-bit-is-disa.patch
@@ -1,7 +1,7 @@
 From 931953ad093d51d077a787d5901a33863f33e040 Mon Sep 17 00:00:00 2001
 From: Michal Krawczyk <mk@semihalf.com>
 Date: Mon, 10 Apr 2017 16:28:11 +0200
-Subject: [PATCH 04/21] net/ena: calculate partial checksum if DF bit is
+Subject: [PATCH 04/28] net/ena: calculate partial checksum if DF bit is
  disabled
 
 [ upstream commit bc5ef57d43c5f4ea423734b2aeae070ae19dd91f ]
@@ -27,7 +27,7 @@ Acked-by: Jan Medala <jan.medala@outlook.com>
  1 file changed, 23 insertions(+), 13 deletions(-)
 
 diff --git a/drivers/net/ena/ena_ethdev.c b/drivers/net/ena/ena_ethdev.c
-index e6e889bdd..3ba990142 100644
+index e6e889bdd1..3ba990142e 100644
 --- a/drivers/net/ena/ena_ethdev.c
 +++ b/drivers/net/ena/ena_ethdev.c
 @@ -1599,14 +1599,33 @@ eth_ena_prep_pkts(void *tx_queue, struct rte_mbuf **tx_pkts,

--- a/userspace/dpdk/17.02/0005-net-ena-fix-cleanup-of-the-Tx-bufs.patch
+++ b/userspace/dpdk/17.02/0005-net-ena-fix-cleanup-of-the-Tx-bufs.patch
@@ -1,7 +1,7 @@
 From c5b08a137d41947130192010b99829b84cfdf43c Mon Sep 17 00:00:00 2001
 From: Michal Krawczyk <mk@semihalf.com>
 Date: Fri, 16 Jun 2017 08:19:16 +0000
-Subject: [PATCH 05/21] net/ena: fix cleanup of the Tx bufs
+Subject: [PATCH 05/28] net/ena: fix cleanup of the Tx bufs
 
 [ upstream commit 207a514ce516f8ab3c1ad2b0f930f045b90b773c ]
 
@@ -22,7 +22,7 @@ Signed-off-by: Michal Krawczyk <mk@semihalf.com>
  1 file changed, 4 insertions(+), 4 deletions(-)
 
 diff --git a/drivers/net/ena/ena_ethdev.c b/drivers/net/ena/ena_ethdev.c
-index 3ba990142..7fca0278d 100644
+index 3ba990142e..7fca0278d8 100644
 --- a/drivers/net/ena/ena_ethdev.c
 +++ b/drivers/net/ena/ena_ethdev.c
 @@ -688,11 +688,10 @@ static void ena_rx_queue_release_bufs(struct ena_ring *ring)

--- a/userspace/dpdk/17.02/0006-net-ena-add-memory-initialization-for-the-allocation.patch
+++ b/userspace/dpdk/17.02/0006-net-ena-add-memory-initialization-for-the-allocation.patch
@@ -1,7 +1,7 @@
 From 3384e8610b2227a436057d385fce01660b9f9afc Mon Sep 17 00:00:00 2001
 From: Michal Krawczyk <mk@semihalf.com>
 Date: Fri, 16 Jun 2017 09:10:48 +0000
-Subject: [PATCH 06/21] net/ena: add memory initialization for the allocation
+Subject: [PATCH 06/28] net/ena: add memory initialization for the allocation
  macros
 
 [ upstream commit 2861ea8df0173f047efe2636ef3b9643d4d989bc ]
@@ -20,7 +20,7 @@ Signed-off-by: Michal Krawczyk <mk@semihalf.com>
  1 file changed, 2 insertions(+)
 
 diff --git a/drivers/net/ena/base/ena_plat_dpdk.h b/drivers/net/ena/base/ena_plat_dpdk.h
-index 7eaebf40f..71a8c1e22 100644
+index 7eaebf40f4..71a8c1e220 100644
 --- a/drivers/net/ena/base/ena_plat_dpdk.h
 +++ b/drivers/net/ena/base/ena_plat_dpdk.h
 @@ -207,6 +207,7 @@ typedef uint64_t dma_addr_t;

--- a/userspace/dpdk/17.02/0007-net-ena-do-not-set-Tx-L4-offloads-in-Rx-path.patch
+++ b/userspace/dpdk/17.02/0007-net-ena-do-not-set-Tx-L4-offloads-in-Rx-path.patch
@@ -1,7 +1,7 @@
 From e25e5ab7245cd9893f1ede458c35d59685533324 Mon Sep 17 00:00:00 2001
 From: Rafal Kozik <rk@semihalf.com>
 Date: Tue, 9 Jan 2018 16:19:08 +0100
-Subject: [PATCH 07/21] net/ena: do not set Tx L4 offloads in Rx path
+Subject: [PATCH 07/28] net/ena: do not set Tx L4 offloads in Rx path
 
 [ upstream commit fd617795679019c7aea5ab1e8c85db02cf53f169 ]
 
@@ -23,7 +23,7 @@ Signed-off-by: Michal Krawczyk <mk@semihalf.com>
  1 file changed, 6 insertions(+), 4 deletions(-)
 
 diff --git a/drivers/net/ena/ena_ethdev.c b/drivers/net/ena/ena_ethdev.c
-index 7fca0278d..b7812c62b 100644
+index 7fca0278d8..b7812c62b8 100644
 --- a/drivers/net/ena/ena_ethdev.c
 +++ b/drivers/net/ena/ena_ethdev.c
 @@ -259,16 +259,17 @@ static inline void ena_rx_mbuf_prepare(struct rte_mbuf *mbuf,

--- a/userspace/dpdk/17.02/0008-net-ena-check-pointer-before-memset.patch
+++ b/userspace/dpdk/17.02/0008-net-ena-check-pointer-before-memset.patch
@@ -1,7 +1,7 @@
 From 268c0b4c464a91261fdd006d2865e514bf0471b3 Mon Sep 17 00:00:00 2001
 From: Rafal Kozik <rk@semihalf.com>
 Date: Thu, 7 Jun 2018 11:43:18 +0200
-Subject: [PATCH 08/21] net/ena: check pointer before memset
+Subject: [PATCH 08/28] net/ena: check pointer before memset
 
 [ upstream commit 46916aa17d4b2007df8c0454f99ba0ca8b8cb93b ]
 
@@ -19,7 +19,7 @@ Acked-by: Michal Krawczyk <mk@semihalf.com>
  1 file changed, 16 insertions(+), 6 deletions(-)
 
 diff --git a/drivers/net/ena/base/ena_plat_dpdk.h b/drivers/net/ena/base/ena_plat_dpdk.h
-index 71a8c1e22..955d6302d 100644
+index 71a8c1e220..955d6302dc 100644
 --- a/drivers/net/ena/base/ena_plat_dpdk.h
 +++ b/drivers/net/ena/base/ena_plat_dpdk.h
 @@ -189,10 +189,15 @@ typedef uint64_t dma_addr_t;

--- a/userspace/dpdk/17.02/0009-net-ena-change-memory-type.patch
+++ b/userspace/dpdk/17.02/0009-net-ena-change-memory-type.patch
@@ -1,7 +1,7 @@
 From 4e5f623eff43540c140ae98df593163a6b516d23 Mon Sep 17 00:00:00 2001
 From: Rafal Kozik <rk@semihalf.com>
 Date: Thu, 7 Jun 2018 11:43:19 +0200
-Subject: [PATCH 09/21] net/ena: change memory type
+Subject: [PATCH 09/28] net/ena: change memory type
 
 [ upstream commit 9f32c7e7e6ce58ab772913f54f8328c1c0186a17 ]
 
@@ -22,7 +22,7 @@ Acked-by: Michal Krawczyk <mk@semihalf.com>
  1 file changed, 1 insertion(+), 7 deletions(-)
 
 diff --git a/drivers/net/ena/base/ena_plat_dpdk.h b/drivers/net/ena/base/ena_plat_dpdk.h
-index 955d6302d..977bee49f 100644
+index 955d6302dc..977bee49ff 100644
 --- a/drivers/net/ena/base/ena_plat_dpdk.h
 +++ b/drivers/net/ena/base/ena_plat_dpdk.h
 @@ -224,14 +224,8 @@ typedef uint64_t dma_addr_t;

--- a/userspace/dpdk/17.02/0010-net-ena-fix-GENMASK_ULL-macro.patch
+++ b/userspace/dpdk/17.02/0010-net-ena-fix-GENMASK_ULL-macro.patch
@@ -1,7 +1,7 @@
 From aad5c2696533c1d07b2eaba8fec10f45fa5caf6d Mon Sep 17 00:00:00 2001
 From: Rafal Kozik <rk@semihalf.com>
 Date: Thu, 7 Jun 2018 11:43:20 +0200
-Subject: [PATCH 10/21] net/ena: fix GENMASK_ULL macro
+Subject: [PATCH 10/28] net/ena: fix GENMASK_ULL macro
 
 [ upstream commit 7544aee8d0b4ae0262b1ba7e1539cf8171664df7 ]
 
@@ -20,7 +20,7 @@ Acked-by: Michal Krawczyk <mk@semihalf.com>
  1 file changed, 3 insertions(+), 1 deletion(-)
 
 diff --git a/drivers/net/ena/base/ena_plat_dpdk.h b/drivers/net/ena/base/ena_plat_dpdk.h
-index 977bee49f..06b637870 100644
+index 977bee49ff..06b6378708 100644
 --- a/drivers/net/ena/base/ena_plat_dpdk.h
 +++ b/drivers/net/ena/base/ena_plat_dpdk.h
 @@ -116,11 +116,13 @@ typedef uint64_t dma_addr_t;

--- a/userspace/dpdk/17.02/0011-net-ena-set-link-speed-as-none.patch
+++ b/userspace/dpdk/17.02/0011-net-ena-set-link-speed-as-none.patch
@@ -1,7 +1,7 @@
 From 80d00b05a0978bc71fb656ae421e7e5443310e2e Mon Sep 17 00:00:00 2001
 From: Rafal Kozik <rk@semihalf.com>
 Date: Thu, 7 Jun 2018 11:43:22 +0200
-Subject: [PATCH 11/21] net/ena: set link speed as none
+Subject: [PATCH 11/28] net/ena: set link speed as none
 
 [ upstream commit 41e59028dd8ab2038a7655c6fc3098222661aa53 ]
 
@@ -21,7 +21,7 @@ Acked-by: Michal Krawczyk <mk@semihalf.com>
  1 file changed, 1 insertion(+), 1 deletion(-)
 
 diff --git a/drivers/net/ena/ena_ethdev.c b/drivers/net/ena/ena_ethdev.c
-index b7812c62b..13eeb6b7b 100644
+index b7812c62b8..13eeb6b7bd 100644
 --- a/drivers/net/ena/ena_ethdev.c
 +++ b/drivers/net/ena/ena_ethdev.c
 @@ -708,7 +708,7 @@ static int ena_link_update(struct rte_eth_dev *dev,

--- a/userspace/dpdk/17.02/0012-net-ena-fix-SIGFPE-with-0-Rx-queue.patch
+++ b/userspace/dpdk/17.02/0012-net-ena-fix-SIGFPE-with-0-Rx-queue.patch
@@ -1,7 +1,7 @@
 From 3288b6f499b06608b5b506a0e67536a1cf5376be Mon Sep 17 00:00:00 2001
 From: Daria Kolistratova <daria.kolistratova@intel.com>
 Date: Tue, 26 Jun 2018 18:38:56 +0100
-Subject: [PATCH 12/21] net/ena: fix SIGFPE with 0 Rx queue
+Subject: [PATCH 12/28] net/ena: fix SIGFPE with 0 Rx queue
 
 [ upstream commit 361913ad6f8c05fc541fe4bfdae3b0dc095ae3af ]
 
@@ -19,7 +19,7 @@ Acked-by: Michal Krawczyk <mk@semihalf.com>
  1 file changed, 1 insertion(+), 1 deletion(-)
 
 diff --git a/drivers/net/ena/ena_ethdev.c b/drivers/net/ena/ena_ethdev.c
-index 13eeb6b7b..72473e06a 100644
+index 13eeb6b7bd..72473e06a9 100644
 --- a/drivers/net/ena/ena_ethdev.c
 +++ b/drivers/net/ena/ena_ethdev.c
 @@ -905,7 +905,7 @@ static int ena_start(struct rte_eth_dev *dev)

--- a/userspace/dpdk/17.02/0013-net-ena-fix-passing-RSS-hash-to-mbuf.patch
+++ b/userspace/dpdk/17.02/0013-net-ena-fix-passing-RSS-hash-to-mbuf.patch
@@ -1,7 +1,7 @@
 From bbff4cdbd2b5a9e2d32843e9314252a25bebd70e Mon Sep 17 00:00:00 2001
 From: Stewart Allen <allenste@amazon.com>
 Date: Thu, 25 Oct 2018 19:59:22 +0200
-Subject: [PATCH 13/21] net/ena: fix passing RSS hash to mbuf
+Subject: [PATCH 13/28] net/ena: fix passing RSS hash to mbuf
 
 [ upstream commit e5df9f33db00eb9d322abaefff30da74fd0e625d ]
 
@@ -19,7 +19,7 @@ Acked-by: Michal Krawczyk <mk@semihalf.com>
  1 file changed, 1 insertion(+), 1 deletion(-)
 
 diff --git a/drivers/net/ena/ena_ethdev.c b/drivers/net/ena/ena_ethdev.c
-index 72473e06a..837ab468c 100644
+index 72473e06a9..837ab468cb 100644
 --- a/drivers/net/ena/ena_ethdev.c
 +++ b/drivers/net/ena/ena_ethdev.c
 @@ -1571,7 +1571,7 @@ static uint16_t eth_ena_recv_pkts(void *rx_queue, struct rte_mbuf **rx_pkts,

--- a/userspace/dpdk/17.02/0014-net-ena-add-supported-RSS-offloads-types.patch
+++ b/userspace/dpdk/17.02/0014-net-ena-add-supported-RSS-offloads-types.patch
@@ -1,7 +1,7 @@
 From 69a5de44b392f04c27822cc5086bb89926eae1bf Mon Sep 17 00:00:00 2001
 From: Rafal Kozik <rk@semihalf.com>
 Date: Fri, 14 Dec 2018 14:18:38 +0100
-Subject: [PATCH 14/21] net/ena: add supported RSS offloads types
+Subject: [PATCH 14/28] net/ena: add supported RSS offloads types
 
 [ upstream commit b01ead202beb45346d7daeb2f2b1a608006af644 ]
 
@@ -20,7 +20,7 @@ Acked-by: Michal Krawczyk <mk@semihalf.com>
  1 file changed, 3 insertions(+)
 
 diff --git a/drivers/net/ena/ena_ethdev.c b/drivers/net/ena/ena_ethdev.c
-index 837ab468c..7c9ec59f8 100644
+index 837ab468cb..7c9ec59f8e 100644
 --- a/drivers/net/ena/ena_ethdev.c
 +++ b/drivers/net/ena/ena_ethdev.c
 @@ -1491,6 +1491,9 @@ static void ena_infos_get(struct rte_eth_dev *dev,

--- a/userspace/dpdk/17.02/0015-net-ena-update-completion-queue-after-cleanup.patch
+++ b/userspace/dpdk/17.02/0015-net-ena-update-completion-queue-after-cleanup.patch
@@ -1,7 +1,7 @@
 From 70b364b1f505d3328719e72db955569b39c5049b Mon Sep 17 00:00:00 2001
 From: Rafal Kozik <rk@semihalf.com>
 Date: Fri, 14 Dec 2018 14:18:44 +0100
-Subject: [PATCH 15/21] net/ena: update completion queue after cleanup
+Subject: [PATCH 15/28] net/ena: update completion queue after cleanup
 
 [ upstream commit a45462c507e98b49cb5c2302e0be3c72d2e20a1a ]
 
@@ -19,7 +19,7 @@ Acked-by: Michal Krawczyk <mk@semihalf.com>
  1 file changed, 5 insertions(+), 2 deletions(-)
 
 diff --git a/drivers/net/ena/ena_ethdev.c b/drivers/net/ena/ena_ethdev.c
-index 7c9ec59f8..932f711c2 100644
+index 7c9ec59f8e..932f711c26 100644
 --- a/drivers/net/ena/ena_ethdev.c
 +++ b/drivers/net/ena/ena_ethdev.c
 @@ -1585,8 +1585,10 @@ static uint16_t eth_ena_recv_pkts(void *rx_queue, struct rte_mbuf **rx_pkts,

--- a/userspace/dpdk/17.02/0016-net-ena-fix-dev-init-with-multi-process.patch
+++ b/userspace/dpdk/17.02/0016-net-ena-fix-dev-init-with-multi-process.patch
@@ -1,7 +1,7 @@
 From 47327061cdf32a07923a985a9142bd3a079ec890 Mon Sep 17 00:00:00 2001
 From: Michal Krawczyk <mk@semihalf.com>
 Date: Fri, 25 Jan 2019 09:10:25 +0100
-Subject: [PATCH 16/21] net/ena: fix dev init with multi-process
+Subject: [PATCH 16/28] net/ena: fix dev init with multi-process
 
 [ upstream commit fd9768905870856a2340266d25f8c0100dfccfff ]
 
@@ -22,7 +22,7 @@ Signed-off-by: Michal Krawczyk <mk@semihalf.com>
  1 file changed, 6 insertions(+), 5 deletions(-)
 
 diff --git a/drivers/net/ena/ena_ethdev.c b/drivers/net/ena/ena_ethdev.c
-index 932f711c2..aad3ab458 100644
+index 932f711c26..aad3ab458a 100644
 --- a/drivers/net/ena/ena_ethdev.c
 +++ b/drivers/net/ena/ena_ethdev.c
 @@ -1276,19 +1276,20 @@ static int eth_ena_dev_init(struct rte_eth_dev *eth_dev)

--- a/userspace/dpdk/17.02/0017-net-ena-fix-errno-to-positive-value.patch
+++ b/userspace/dpdk/17.02/0017-net-ena-fix-errno-to-positive-value.patch
@@ -1,7 +1,7 @@
 From 0040e38ff046ca7029dbd53705224dcb745c6d19 Mon Sep 17 00:00:00 2001
 From: Michal Krawczyk <mk@semihalf.com>
 Date: Fri, 25 Jan 2019 09:10:26 +0100
-Subject: [PATCH 17/21] net/ena: fix errno to positive value
+Subject: [PATCH 17/28] net/ena: fix errno to positive value
 
 [ upstream commit baeed5f404dd1b049118cfec26a2fd3203671572 ]
 
@@ -18,7 +18,7 @@ Signed-off-by: Michal Krawczyk <mk@semihalf.com>
  1 file changed, 3 insertions(+), 3 deletions(-)
 
 diff --git a/drivers/net/ena/ena_ethdev.c b/drivers/net/ena/ena_ethdev.c
-index aad3ab458..6c791f2a9 100644
+index aad3ab458a..6c791f2a9b 100644
 --- a/drivers/net/ena/ena_ethdev.c
 +++ b/drivers/net/ena/ena_ethdev.c
 @@ -1636,14 +1636,14 @@ eth_ena_prep_pkts(void *tx_queue, struct rte_mbuf **tx_pkts,

--- a/userspace/dpdk/17.02/0018-net-ena-get-device-info-statically.patch
+++ b/userspace/dpdk/17.02/0018-net-ena-get-device-info-statically.patch
@@ -1,7 +1,7 @@
 From 61a20a71541a8e3a20f74a02296fd8d26a71cc6b Mon Sep 17 00:00:00 2001
 From: Michal Krawczyk <mk@semihalf.com>
 Date: Fri, 15 Feb 2019 09:36:39 +0100
-Subject: [PATCH 18/21] net/ena: get device info statically
+Subject: [PATCH 18/28] net/ena: get device info statically
 
 [ upstream commit 117ba4a60488a0f96a5737f38ddba6d0f9a728b6 ]
 
@@ -22,7 +22,7 @@ Signed-off-by: Michal Krawczyk <mk@semihalf.com>
  2 files changed, 19 insertions(+), 20 deletions(-)
 
 diff --git a/drivers/net/ena/ena_ethdev.c b/drivers/net/ena/ena_ethdev.c
-index 6c791f2a9..c3c655dd8 100644
+index 6c791f2a9b..c3c655dd8c 100644
 --- a/drivers/net/ena/ena_ethdev.c
 +++ b/drivers/net/ena/ena_ethdev.c
 @@ -1360,9 +1360,14 @@ static int eth_ena_dev_init(struct rte_eth_dev *eth_dev)
@@ -93,7 +93,7 @@ index 6c791f2a9..c3c655dd8 100644
  		}
  
 diff --git a/drivers/net/ena/ena_ethdev.h b/drivers/net/ena/ena_ethdev.h
-index dc3080ffd..4791c53b5 100644
+index dc3080ffd3..4791c53b5a 100644
 --- a/drivers/net/ena/ena_ethdev.h
 +++ b/drivers/net/ena/ena_ethdev.h
 @@ -143,6 +143,12 @@ struct ena_stats_rx {

--- a/userspace/dpdk/17.02/0019-net-ena-fix-checksum-feature-flag.patch
+++ b/userspace/dpdk/17.02/0019-net-ena-fix-checksum-feature-flag.patch
@@ -1,7 +1,7 @@
 From 92e3acef5333b7b45928bd79f7fa137939b5c612 Mon Sep 17 00:00:00 2001
 From: Michal Krawczyk <mk@semihalf.com>
 Date: Mon, 8 Apr 2019 12:27:44 +0200
-Subject: [PATCH 19/21] net/ena: fix checksum feature flag
+Subject: [PATCH 19/28] net/ena: fix checksum feature flag
 
 [ upstream commit ef538c1a7f565c9b58518375a500aa864445fd11 ]
 
@@ -18,7 +18,7 @@ Signed-off-by: Michal Krawczyk <mk@semihalf.com>
  1 file changed, 1 insertion(+), 1 deletion(-)
 
 diff --git a/drivers/net/ena/ena_ethdev.c b/drivers/net/ena/ena_ethdev.c
-index c3c655dd8..c011e9382 100644
+index c3c655dd8c..c011e9382e 100644
 --- a/drivers/net/ena/ena_ethdev.c
 +++ b/drivers/net/ena/ena_ethdev.c
 @@ -1365,7 +1365,7 @@ static int eth_ena_dev_init(struct rte_eth_dev *eth_dev)

--- a/userspace/dpdk/17.02/0020-net-ena-fix-Rx-checksum-errors-statistics.patch
+++ b/userspace/dpdk/17.02/0020-net-ena-fix-Rx-checksum-errors-statistics.patch
@@ -1,7 +1,7 @@
 From 75fb64525968b152921a89eee76ae51884e13831 Mon Sep 17 00:00:00 2001
 From: Michal Krawczyk <mk@semihalf.com>
 Date: Tue, 28 May 2019 10:28:34 +0200
-Subject: [PATCH 20/21] net/ena: fix Rx checksum errors statistics
+Subject: [PATCH 20/28] net/ena: fix Rx checksum errors statistics
 
 [ upstream commit ef74b5f7b69b9502ddab81121611243efcfe1dde ]
 
@@ -21,7 +21,7 @@ Signed-off-by: Michal Krawczyk <mk@semihalf.com>
  1 file changed, 5 insertions(+), 4 deletions(-)
 
 diff --git a/drivers/net/ena/ena_ethdev.c b/drivers/net/ena/ena_ethdev.c
-index c011e9382..eeb85cbe4 100644
+index c011e9382e..eeb85cbe4e 100644
 --- a/drivers/net/ena/ena_ethdev.c
 +++ b/drivers/net/ena/ena_ethdev.c
 @@ -1568,6 +1568,11 @@ static uint16_t eth_ena_recv_pkts(void *rx_queue, struct rte_mbuf **rx_pkts,

--- a/userspace/dpdk/17.02/0021-net-ena-fix-assigning-NUMA-node-to-IO-queue.patch
+++ b/userspace/dpdk/17.02/0021-net-ena-fix-assigning-NUMA-node-to-IO-queue.patch
@@ -1,7 +1,7 @@
 From de5f761f4c19ea0b848c82119497f5d903ce8fb0 Mon Sep 17 00:00:00 2001
 From: Michal Krawczyk <mk@semihalf.com>
 Date: Tue, 4 Jun 2019 12:59:36 +0200
-Subject: [PATCH 21/21] net/ena: fix assigning NUMA node to IO queue
+Subject: [PATCH 21/28] net/ena: fix assigning NUMA node to IO queue
 
 [ upstream commit 4217cb0b7d2c5385f06f531af7f14b860927aba7 ]
 
@@ -23,7 +23,7 @@ Reviewed-by: David Marchand <david.marchand@redhat.com>
  2 files changed, 8 insertions(+), 17 deletions(-)
 
 diff --git a/drivers/net/ena/ena_ethdev.c b/drivers/net/ena/ena_ethdev.c
-index eeb85cbe4..cc0e50e93 100644
+index eeb85cbe4e..cc0e50e939 100644
 --- a/drivers/net/ena/ena_ethdev.c
 +++ b/drivers/net/ena/ena_ethdev.c
 @@ -38,7 +38,6 @@
@@ -106,7 +106,7 @@ index eeb85cbe4..cc0e50e93 100644
  
  	rxq->rx_buffer_info = rte_zmalloc("rxq->buffer_info",
 diff --git a/drivers/net/ena/ena_ethdev.h b/drivers/net/ena/ena_ethdev.h
-index 4791c53b5..8d5eb5a7c 100644
+index 4791c53b5a..8d5eb5a7ca 100644
 --- a/drivers/net/ena/ena_ethdev.h
 +++ b/drivers/net/ena/ena_ethdev.h
 @@ -90,6 +90,8 @@ struct ena_ring {

--- a/userspace/dpdk/17.02/0022-net-ena-base-fix-node-deallocation.patch
+++ b/userspace/dpdk/17.02/0022-net-ena-base-fix-node-deallocation.patch
@@ -1,0 +1,59 @@
+From b2bb1041cb4d398912b4f33a3e7cce4a0a3cab19 Mon Sep 17 00:00:00 2001
+From: Michal Krawczyk <mk@semihalf.com>
+Date: Thu, 2 Jul 2020 10:25:03 +0000
+Subject: [PATCH 22/28] net/ena/base: fix node deallocation
+
+The memzone handle wasn't saved anywhere - it could cause free of the
+invalid memory, as the mem_handle was never holding the right value.
+
+Signed-off-by: Michal Krawczyk <mk@semihalf.com>
+---
+ drivers/net/ena/base/ena_com.c       | 2 ++
+ drivers/net/ena/base/ena_plat_dpdk.h | 4 +++-
+ 2 files changed, 5 insertions(+), 1 deletion(-)
+
+diff --git a/drivers/net/ena/base/ena_com.c b/drivers/net/ena/base/ena_com.c
+index bd6f3c6b12..08c498c877 100644
+--- a/drivers/net/ena/base/ena_com.c
++++ b/drivers/net/ena/base/ena_com.c
+@@ -347,6 +347,7 @@ static int ena_com_init_io_sq(struct ena_com_dev *ena_dev,
+ 					    size,
+ 					    io_sq->desc_addr.virt_addr,
+ 					    io_sq->desc_addr.phys_addr,
++					    io_sq->desc_addr.mem_handle,
+ 					    ctx->numa_node,
+ 					    dev_node);
+ 		if (!io_sq->desc_addr.virt_addr)
+@@ -400,6 +401,7 @@ static int ena_com_init_io_cq(struct ena_com_dev *ena_dev,
+ 				    size,
+ 				    io_cq->cdesc_addr.virt_addr,
+ 				    io_cq->cdesc_addr.phys_addr,
++				    io_cq->cdesc_addr.mem_handle,
+ 				    ctx->numa_node,
+ 				    prev_node);
+ 	if (!io_cq->cdesc_addr.virt_addr)
+diff --git a/drivers/net/ena/base/ena_plat_dpdk.h b/drivers/net/ena/base/ena_plat_dpdk.h
+index 06b6378708..2c7887c190 100644
+--- a/drivers/net/ena/base/ena_plat_dpdk.h
++++ b/drivers/net/ena/base/ena_plat_dpdk.h
+@@ -206,7 +206,8 @@ typedef uint64_t dma_addr_t;
+ 		   ENA_TOUCH(dmadev);					\
+ 		   rte_memzone_free(handle); })
+ 
+-#define ENA_MEM_ALLOC_COHERENT_NODE(dmadev, size, virt, phys, node, dev_node) \
++#define ENA_MEM_ALLOC_COHERENT_NODE(					\
++	dmadev, size, virt, phys, mem_handle, node, dev_node)		\
+ 	do {								\
+ 		const struct rte_memzone *mz;				\
+ 		char z_name[RTE_MEMZONE_NAMESIZE];			\
+@@ -214,6 +215,7 @@ typedef uint64_t dma_addr_t;
+ 		snprintf(z_name, sizeof(z_name),			\
+ 				"ena_alloc_%d", ena_alloc_cnt++);	\
+ 		mz = rte_memzone_reserve(z_name, size, node, 0); \
++		mem_handle = mz;					\
+ 		if (mz == NULL) {					\
+ 			virt = NULL;					\
+ 			phys = 0;					\
+-- 
+2.20.1
+

--- a/userspace/dpdk/17.02/0023-net-ena-fix-indication-of-bad-L4-Rx-checksums.patch
+++ b/userspace/dpdk/17.02/0023-net-ena-fix-indication-of-bad-L4-Rx-checksums.patch
@@ -1,0 +1,44 @@
+From 919f7cad7bda5bb917e95ae158c466b33195196b Mon Sep 17 00:00:00 2001
+From: Igor Chauskin <igorch@amazon.com>
+Date: Mon, 28 Oct 2019 11:23:33 +0100
+Subject: [PATCH 23/28] net/ena: fix indication of bad L4 Rx checksums
+
+[ upstream commit 05817057faba9356900ced61e24a22eef6bc4c87 ]
+
+Add checking of l4_csum_checked and frag flags before checking the
+l4_csum_error flag.
+
+In case of IP fragment/unchecked L4 csum - add PKT_RX_L4_CKSUM_UNKNOWN
+flag to the indicated mbuf.
+
+Fixes: 1173fca25af9 ("ena: add polling-mode driver")
+Cc: stable@dpdk.org
+
+Change-Id: I9f1414741eb44ca289a8bfd11d7e66110c95040e
+Signed-off-by: Igor Chauskin <igorch@amazon.com>
+Reviewed-by: Maciej Bielski <mba@semihalf.com>
+Reviewed-by: Michal Krawczyk <mk@semihalf.com>
+---
+ drivers/net/ena/ena_ethdev.c | 5 ++++-
+ 1 file changed, 4 insertions(+), 1 deletion(-)
+
+diff --git a/drivers/net/ena/ena_ethdev.c b/drivers/net/ena/ena_ethdev.c
+index cc0e50e939..cf517356dc 100644
+--- a/drivers/net/ena/ena_ethdev.c
++++ b/drivers/net/ena/ena_ethdev.c
+@@ -258,8 +258,11 @@ static inline void ena_rx_mbuf_prepare(struct rte_mbuf *mbuf,
+ 	else if (ena_rx_ctx->l3_proto == ENA_ETH_IO_L3_PROTO_IPV6)
+ 		packet_type |= RTE_PTYPE_L3_IPV6;
+ 
+-	if (unlikely(ena_rx_ctx->l4_csum_err))
++	if (unlikely(ena_rx_ctx->l4_csum_err) && !ena_rx_ctx->frag)
+ 		ol_flags |= PKT_RX_L4_CKSUM_BAD;
++	else
++		ol_flags |= PKT_RX_L4_CKSUM_UNKNOWN;
++
+ 	if (unlikely(ena_rx_ctx->l3_csum_err))
+ 		ol_flags |= PKT_RX_IP_CKSUM_BAD;
+ 
+-- 
+2.20.1
+

--- a/userspace/dpdk/17.02/0024-net-ena-ensure-Rx-buffer-size-is-at-least-1400B.patch
+++ b/userspace/dpdk/17.02/0024-net-ena-ensure-Rx-buffer-size-is-at-least-1400B.patch
@@ -1,0 +1,84 @@
+From 56471af399aac91b8d758a6f4a98210e16a4c8fb Mon Sep 17 00:00:00 2001
+From: Michal Krawczyk <mk@semihalf.com>
+Date: Wed, 8 Apr 2020 10:28:52 +0200
+Subject: [PATCH 24/28] net/ena: ensure Rx buffer size is at least 1400B
+
+[ upstream commit 38364c2687ead97b99402310087c27131a97748c ]
+
+Some of the ENA devices can't handle buffers which are smaller than a
+1400B. Because of this limitation, size of the buffer is being checked
+and limited during the Rx queue setup.
+
+If it's below the allowed value, PMD won't finish it's configuration
+successfully..
+
+Change-Id: Ib402d3bfad98a3fc4f91095d5c6f90c6069da021
+Signed-off-by: Michal Krawczyk <mk@semihalf.com>
+Reviewed-by: Igor Chauskin <igorch@amazon.com>
+Reviewed-by: Guy Tzalik <gtzalik@amazon.com>
+---
+ drivers/net/ena/ena_ethdev.c | 12 +++++++++++-
+ drivers/net/ena/ena_ethdev.h |  3 ++-
+ 2 files changed, 13 insertions(+), 2 deletions(-)
+
+diff --git a/drivers/net/ena/ena_ethdev.c b/drivers/net/ena/ena_ethdev.c
+index cf517356dc..c6b7152289 100644
+--- a/drivers/net/ena/ena_ethdev.c
++++ b/drivers/net/ena/ena_ethdev.c
+@@ -1,7 +1,7 @@
+ /*-
+ * BSD LICENSE
+ *
+-* Copyright (c) 2015-2016 Amazon.com, Inc. or its affiliates.
++* Copyright (c) 2015-2020 Amazon.com, Inc. or its affiliates.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+@@ -1048,6 +1048,7 @@ static int ena_rx_queue_setup(struct rte_eth_dev *dev,
+ 	struct ena_adapter *adapter =
+ 		(struct ena_adapter *)(dev->data->dev_private);
+ 	struct ena_ring *rxq = NULL;
++	size_t buffer_size;
+ 	uint16_t ena_qid = 0;
+ 	int rc = 0;
+ 	struct ena_com_dev *ena_dev = &adapter->ena_dev;
+@@ -1074,6 +1075,15 @@ static int ena_rx_queue_setup(struct rte_eth_dev *dev,
+ 		return -EINVAL;
+ 	}
+ 
++	/* ENA isn't supporting buffers smaller than 1400 bytes */
++	buffer_size = rte_pktmbuf_data_room_size(mp) - RTE_PKTMBUF_HEADROOM;
++	if (buffer_size < ENA_RX_BUF_MIN_SIZE) {
++		PMD_DRV_LOG(ERR,
++			"Unsupported size of RX buffer: %zu (min size: %d)\n",
++			buffer_size, ENA_RX_BUF_MIN_SIZE);
++		return -EINVAL;
++	}
++
+ 	ena_qid = ENA_IO_RXQ_IDX(queue_idx);
+ 
+ 	ctx.qid = ena_qid;
+diff --git a/drivers/net/ena/ena_ethdev.h b/drivers/net/ena/ena_ethdev.h
+index 8d5eb5a7ca..d6e5e730e1 100644
+--- a/drivers/net/ena/ena_ethdev.h
++++ b/drivers/net/ena/ena_ethdev.h
+@@ -1,7 +1,7 @@
+ /*-
+ * BSD LICENSE
+ *
+-* Copyright (c) 2015-2016 Amazon.com, Inc. or its affiliates.
++* Copyright (c) 2015-2020 Amazon.com, Inc. or its affiliates.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+@@ -46,6 +46,7 @@
+ #define ENA_MIN_FRAME_LEN	64
+ #define ENA_NAME_MAX_LEN	20
+ #define ENA_PKT_MAX_BUFS	17
++#define ENA_RX_BUF_MIN_SIZE	1400
+ 
+ #define ENA_MMIO_DISABLE_REG_READ	BIT(0)
+ 
+-- 
+2.20.1
+

--- a/userspace/dpdk/17.02/0025-net-ena-base-make-allocation-macros-thread-safe.patch
+++ b/userspace/dpdk/17.02/0025-net-ena-base-make-allocation-macros-thread-safe.patch
@@ -1,0 +1,103 @@
+From d7d4610e022f5fcded2379bdc75b861e76d23d61 Mon Sep 17 00:00:00 2001
+From: Igor Chauskin <igorch@amazon.com>
+Date: Wed, 8 Apr 2020 10:28:53 +0200
+Subject: [PATCH 25/28] net/ena/base: make allocation macros thread-safe
+
+[ upstream commit b14fcac035fd8514851c9140a4e26d765b61c532 ]
+
+Memory allocation region id could possibly be non-unique
+due to non-atomic increment, causing allocation failure.
+
+Fixes: 9ba7981ec992 ("ena: add communication layer for DPDK")
+Cc: stable@dpdk.org
+
+Change-Id: Ib9207aaae4e5e7ecdf1a99a0f23a508a53af631d
+Signed-off-by: Igor Chauskin <igorch@amazon.com>
+Reviewed-by: Michal Krawczyk <mk@semihalf.com>
+Reviewed-by: Guy Tzalik <gtzalik@amazon.com>
+---
+ drivers/net/ena/base/ena_com.c       |  2 --
+ drivers/net/ena/base/ena_plat_dpdk.h | 16 ++++++++++++----
+ drivers/net/ena/ena_ethdev.c         |  6 ++++++
+ 3 files changed, 18 insertions(+), 6 deletions(-)
+
+diff --git a/drivers/net/ena/base/ena_com.c b/drivers/net/ena/base/ena_com.c
+index 08c498c877..07accacf96 100644
+--- a/drivers/net/ena/base/ena_com.c
++++ b/drivers/net/ena/base/ena_com.c
+@@ -62,8 +62,6 @@
+ 
+ #define ENA_MMIO_READ_TIMEOUT 0xFFFFFFFF
+ 
+-static int ena_alloc_cnt;
+-
+ /*****************************************************************************/
+ /*****************************************************************************/
+ /*****************************************************************************/
+diff --git a/drivers/net/ena/base/ena_plat_dpdk.h b/drivers/net/ena/base/ena_plat_dpdk.h
+index 2c7887c190..791471adbd 100644
+--- a/drivers/net/ena/base/ena_plat_dpdk.h
++++ b/drivers/net/ena/base/ena_plat_dpdk.h
+@@ -1,7 +1,7 @@
+ /*-
+ * BSD LICENSE
+ *
+-* Copyright (c) 2015-2016 Amazon.com, Inc. or its affiliates.
++* Copyright (c) 2015-2020 Amazon.com, Inc. or its affiliates.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+@@ -183,13 +183,20 @@ typedef uint64_t dma_addr_t;
+ #define ena_wait_event_t ena_wait_queue_t
+ #define ENA_MIGHT_SLEEP()
+ 
++/*
++ * Each rte_memzone should have unique name.
++ * To satisfy it, count number of allocations and add it to name.
++ */
++extern rte_atomic32_t ena_alloc_cnt;
++
+ #define ENA_MEM_ALLOC_COHERENT(dmadev, size, virt, phys, handle)	\
+ 	do {								\
+ 		const struct rte_memzone *mz;				\
+ 		char z_name[RTE_MEMZONE_NAMESIZE];			\
+ 		ENA_TOUCH(dmadev); ENA_TOUCH(handle);			\
+ 		snprintf(z_name, sizeof(z_name),			\
+-				"ena_alloc_%d", ena_alloc_cnt++);	\
++			 "ena_alloc_%d",				\
++			 rte_atomic32_add_return(&ena_alloc_cnt, 1));	\
+ 		mz = rte_memzone_reserve(z_name, size, SOCKET_ID_ANY, 0); \
+ 		handle = mz;						\
+ 		if (mz == NULL) {					\
+@@ -213,8 +220,9 @@ typedef uint64_t dma_addr_t;
+ 		char z_name[RTE_MEMZONE_NAMESIZE];			\
+ 		ENA_TOUCH(dmadev); ENA_TOUCH(dev_node);			\
+ 		snprintf(z_name, sizeof(z_name),			\
+-				"ena_alloc_%d", ena_alloc_cnt++);	\
+-		mz = rte_memzone_reserve(z_name, size, node, 0); \
++			 "ena_alloc_%d",				\
++			 rte_atomic32_add_return(&ena_alloc_cnt, 1));	\
++		mz = rte_memzone_reserve(z_name, size, node, 0);	\
+ 		mem_handle = mz;					\
+ 		if (mz == NULL) {					\
+ 			virt = NULL;					\
+diff --git a/drivers/net/ena/ena_ethdev.c b/drivers/net/ena/ena_ethdev.c
+index c6b7152289..4202d51458 100644
+--- a/drivers/net/ena/ena_ethdev.c
++++ b/drivers/net/ena/ena_ethdev.c
+@@ -112,6 +112,12 @@ struct ena_stats {
+ #define ENA_STAT_GLOBAL_ENTRY(stat) \
+ 	ENA_STAT_ENTRY(stat, dev)
+ 
++/*
++ * Each rte_memzone should have unique name.
++ * To satisfy it, count number of allocation and add it to name.
++ */
++rte_atomic32_t ena_alloc_cnt;
++
+ static const struct ena_stats ena_stats_global_strings[] = {
+ 	ENA_STAT_GLOBAL_ENTRY(tx_timeout),
+ 	ENA_STAT_GLOBAL_ENTRY(io_suspend),
+-- 
+2.20.1
+

--- a/userspace/dpdk/17.02/0026-net-ena-base-prevent-allocation-of-zero-sized-memory.patch
+++ b/userspace/dpdk/17.02/0026-net-ena-base-prevent-allocation-of-zero-sized-memory.patch
@@ -1,0 +1,74 @@
+From 21b671c8680a24ce2799113dfe1404bd76537f26 Mon Sep 17 00:00:00 2001
+From: Igor Chauskin <igorch@amazon.com>
+Date: Wed, 8 Apr 2020 10:28:54 +0200
+Subject: [PATCH 26/28] net/ena/base: prevent allocation of zero sized memory
+
+[ upstream commit 29dc10d9424ccf26a346387b0a707185e2432400 ]
+
+rte_memzone_reserve() will reserve the biggest contiguous memzone
+available if received 0 as size param.
+
+Fixes: 9ba7981ec992 ("ena: add communication layer for DPDK")
+Cc: stable@dpdk.org
+
+Change-Id: I2f71119e93c5e9addd8c538820093f030066d690
+Signed-off-by: Igor Chauskin <igorch@amazon.com>
+Reviewed-by: Michal Krawczyk <mk@semihalf.com>
+Reviewed-by: Guy Tzalik <gtzalik@amazon.com>
+---
+ drivers/net/ena/base/ena_plat_dpdk.h | 27 ++++++++++++++++-----------
+ 1 file changed, 16 insertions(+), 11 deletions(-)
+
+diff --git a/drivers/net/ena/base/ena_plat_dpdk.h b/drivers/net/ena/base/ena_plat_dpdk.h
+index 791471adbd..f3820d5ebd 100644
+--- a/drivers/net/ena/base/ena_plat_dpdk.h
++++ b/drivers/net/ena/base/ena_plat_dpdk.h
+@@ -191,14 +191,17 @@ extern rte_atomic32_t ena_alloc_cnt;
+ 
+ #define ENA_MEM_ALLOC_COHERENT(dmadev, size, virt, phys, handle)	\
+ 	do {								\
+-		const struct rte_memzone *mz;				\
+-		char z_name[RTE_MEMZONE_NAMESIZE];			\
++		const struct rte_memzone *mz = NULL;			\
+ 		ENA_TOUCH(dmadev); ENA_TOUCH(handle);			\
+-		snprintf(z_name, sizeof(z_name),			\
++		if (size > 0) {						\
++			char z_name[RTE_MEMZONE_NAMESIZE];		\
++			snprintf(z_name, sizeof(z_name),		\
+ 			 "ena_alloc_%d",				\
+ 			 rte_atomic32_add_return(&ena_alloc_cnt, 1));	\
+-		mz = rte_memzone_reserve(z_name, size, SOCKET_ID_ANY, 0); \
+-		handle = mz;						\
++			mz = rte_memzone_reserve(z_name, size,		\
++				SOCKET_ID_ANY, 0);			\
++			handle = mz;					\
++		}							\
+ 		if (mz == NULL) {					\
+ 			virt = NULL;					\
+ 			phys = 0;					\
+@@ -216,14 +219,16 @@ extern rte_atomic32_t ena_alloc_cnt;
+ #define ENA_MEM_ALLOC_COHERENT_NODE(					\
+ 	dmadev, size, virt, phys, mem_handle, node, dev_node)		\
+ 	do {								\
+-		const struct rte_memzone *mz;				\
+-		char z_name[RTE_MEMZONE_NAMESIZE];			\
++		const struct rte_memzone *mz = NULL;			\
+ 		ENA_TOUCH(dmadev); ENA_TOUCH(dev_node);			\
+-		snprintf(z_name, sizeof(z_name),			\
++		if (size > 0) {						\
++			char z_name[RTE_MEMZONE_NAMESIZE];		\
++			snprintf(z_name, sizeof(z_name),		\
+ 			 "ena_alloc_%d",				\
+-			 rte_atomic32_add_return(&ena_alloc_cnt, 1));	\
+-		mz = rte_memzone_reserve(z_name, size, node, 0);	\
+-		mem_handle = mz;					\
++			 rte_atomic32_add_return(&ena_alloc_cnt, 1));   \
++			mz = rte_memzone_reserve(z_name, size, node, 0); \
++			mem_handle = mz;				\
++		}							\
+ 		if (mz == NULL) {					\
+ 			virt = NULL;					\
+ 			phys = 0;					\
+-- 
+2.20.1
+

--- a/userspace/dpdk/17.02/0027-net-ena-set-IO-ring-size-to-valid-value.patch
+++ b/userspace/dpdk/17.02/0027-net-ena-set-IO-ring-size-to-valid-value.patch
@@ -1,0 +1,49 @@
+From f486231708fc2a53078a49126adae59311fc52d1 Mon Sep 17 00:00:00 2001
+From: Michal Krawczyk <mk@semihalf.com>
+Date: Fri, 3 Jul 2020 13:14:58 +0000
+Subject: [PATCH 27/28] net/ena: set IO ring size to valid value
+
+[ upstream commit badc3a6aa133a886a61b9e3ad666e5675f7ec3d3 ]
+
+IO rings were configured with the maximum allowed size for the Tx/Rx
+rings. However, the application could decide to create smaller rings.
+
+This patch is using value stored in the ring instead of the value from
+the adapter which is indicating the maximum allowed value.
+
+Fixes: df238f84c0a2 ("net/ena: recreate HW IO rings on start and stop")
+Cc: stable@dpdk.org
+
+Change-Id: Icf9102e2aa4e7413b6620b36dd232673239b7291
+Signed-off-by: Michal Krawczyk <mk@semihalf.com>
+Reviewed-by: Igor Chauskin <igorch@amazon.com>
+Reviewed-by: Guy Tzalik <gtzalik@amazon.com>
+---
+ drivers/net/ena/ena_ethdev.c | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/drivers/net/ena/ena_ethdev.c b/drivers/net/ena/ena_ethdev.c
+index 4202d51458..2e687e6ca7 100644
+--- a/drivers/net/ena/ena_ethdev.c
++++ b/drivers/net/ena/ena_ethdev.c
+@@ -984,7 +984,7 @@ static int ena_tx_queue_setup(struct rte_eth_dev *dev,
+ 	ctx.qid = ena_qid;
+ 	ctx.msix_vector = -1; /* admin interrupts not used */
+ 	ctx.mem_queue_type = ena_dev->tx_mem_queue_type;
+-	ctx.queue_size = adapter->tx_ring_size;
++	ctx.queue_size = nb_desc;
+ 	ctx.numa_node = socket_id;
+ 
+ 	rc = ena_com_create_io_queue(ena_dev, &ctx);
+@@ -1096,7 +1096,7 @@ static int ena_rx_queue_setup(struct rte_eth_dev *dev,
+ 	ctx.direction = ENA_COM_IO_QUEUE_DIRECTION_RX;
+ 	ctx.mem_queue_type = ENA_ADMIN_PLACEMENT_POLICY_HOST;
+ 	ctx.msix_vector = -1; /* admin interrupts not used */
+-	ctx.queue_size = adapter->rx_ring_size;
++	ctx.queue_size = nb_desc;
+ 	ctx.numa_node = socket_id;
+ 
+ 	rc = ena_com_create_io_queue(ena_dev, &ctx);
+-- 
+2.20.1
+

--- a/userspace/dpdk/17.02/0028-net-ena-limit-refill-threshold-by-fixed-value.patch
+++ b/userspace/dpdk/17.02/0028-net-ena-limit-refill-threshold-by-fixed-value.patch
@@ -1,0 +1,118 @@
+From e97634db60605dcb75e7cb773f28d67d59e4e169 Mon Sep 17 00:00:00 2001
+From: Michal Krawczyk <mk@semihalf.com>
+Date: Wed, 8 Apr 2020 10:29:16 +0200
+Subject: [PATCH 28/28] net/ena: limit refill threshold by fixed value
+
+[ upstream commit 7755060798de9c0146df8809926030ed47fc9086 ]
+
+Divider used for both Tx and Rx cleanup/refill threshold can cause too
+big delay in case of the really big rings - for example if the 8k Rx
+ring will be used, the refill won't trigger unless 1024 threshold will
+be reached. It will also cause driver to try to allocate that much
+descriptors.
+
+Limiting it by fixed value - 256 in that case, would limit maximum
+time spent in repopulate function.
+
+Change-Id: Ia8659e6ddf179ff612a780adc6fe55d13eeac6e9
+Signed-off-by: Michal Krawczyk <mk@semihalf.com>
+Reviewed-by: Igor Chauskin <igorch@amazon.com>
+Reviewed-by: Guy Tzalik <gtzalik@amazon.com>
+---
+ drivers/net/ena/ena_ethdev.c | 26 ++++++++++++++------------
+ drivers/net/ena/ena_ethdev.h | 10 ++++++++++
+ 2 files changed, 24 insertions(+), 12 deletions(-)
+
+diff --git a/drivers/net/ena/ena_ethdev.c b/drivers/net/ena/ena_ethdev.c
+index 2e687e6ca7..fbc54db59b 100644
+--- a/drivers/net/ena/ena_ethdev.c
++++ b/drivers/net/ena/ena_ethdev.c
+@@ -60,14 +60,6 @@
+ /*reverse version of ENA_IO_RXQ_IDX*/
+ #define ENA_IO_RXQ_IDX_REV(q)	((q - 1) / 2)
+ 
+-/* While processing submitted and completed descriptors (rx and tx path
+- * respectively) in a loop it is desired to:
+- *  - perform batch submissions while populating sumbissmion queue
+- *  - avoid blocking transmission of other packets during cleanup phase
+- * Hence the utilization ratio of 1/8 of a queue size.
+- */
+-#define ENA_RING_DESCS_RATIO(ring_size)	(ring_size / 8)
+-
+ #define __MERGE_64B_H_L(h, l) (((uint64_t)h << 32) | l)
+ #define TEST_BIT(val, bit_shift) (val & (1UL << bit_shift))
+ 
+@@ -1511,6 +1503,8 @@ static uint16_t eth_ena_recv_pkts(void *rx_queue, struct rte_mbuf **rx_pkts,
+ 	struct ena_ring *rx_ring = (struct ena_ring *)(rx_queue);
+ 	unsigned int ring_size = rx_ring->ring_size;
+ 	unsigned int ring_mask = ring_size - 1;
++	unsigned int free_queue_entries;
++	unsigned int refill_threshold;
+ 	uint16_t next_to_clean = rx_ring->next_to_clean;
+ 	uint16_t desc_in_use = 0;
+ 	unsigned int recv_idx = 0;
+@@ -1590,11 +1584,15 @@ static uint16_t eth_ena_recv_pkts(void *rx_queue, struct rte_mbuf **rx_pkts,
+ 
+ 	rx_ring->next_to_clean = next_to_clean;
+ 
+-	desc_in_use = desc_in_use - completed + 1;
++	free_queue_entries = ena_com_sq_empty_space(rx_ring->ena_com_io_sq);
++	refill_threshold =
++		RTE_MIN(ring_size / ENA_REFILL_THRESH_DIVIDER,
++		(unsigned int)ENA_REFILL_THRESH_PACKET);
++
+ 	/* Burst refill to save doorbells, memory barriers, const interval */
+-	if (ring_size - desc_in_use > ENA_RING_DESCS_RATIO(ring_size)) {
++	if (free_queue_entries > refill_threshold) {
+ 		ena_com_update_dev_comp_head(rx_ring->ena_com_io_cq);
+-		ena_populate_rx_queue(rx_ring, ring_size - desc_in_use);
++		ena_populate_rx_queue(rx_ring, free_queue_entries);
+ 	}
+ 
+ 	return recv_idx;
+@@ -1679,6 +1677,7 @@ static uint16_t eth_ena_xmit_pkts(void *tx_queue, struct rte_mbuf **tx_pkts,
+ 	struct rte_mbuf *mbuf;
+ 	unsigned int ring_size = tx_ring->ring_size;
+ 	unsigned int ring_mask = ring_size - 1;
++	unsigned int cleanup_budget;
+ 	struct ena_com_tx_ctx ena_tx_ctx;
+ 	struct ena_tx_buffer *tx_info;
+ 	struct ena_com_buf *ebuf;
+@@ -1785,9 +1784,12 @@ static uint16_t eth_ena_xmit_pkts(void *tx_queue, struct rte_mbuf **tx_pkts,
+ 		/* Put back descriptor to the ring for reuse */
+ 		tx_ring->empty_tx_reqs[next_to_clean & ring_mask] = req_id;
+ 		next_to_clean++;
++		cleanup_budget =
++			RTE_MIN(ring_size / ENA_REFILL_THRESH_DIVIDER,
++			(unsigned int)ENA_REFILL_THRESH_PACKET);
+ 
+ 		/* If too many descs to clean, leave it for another run */
+-		if (unlikely(total_tx_descs > ENA_RING_DESCS_RATIO(ring_size)))
++		if (unlikely(total_tx_descs > cleanup_budget))
+ 			break;
+ 	}
+ 
+diff --git a/drivers/net/ena/ena_ethdev.h b/drivers/net/ena/ena_ethdev.h
+index d6e5e730e1..2b02806db5 100644
+--- a/drivers/net/ena/ena_ethdev.h
++++ b/drivers/net/ena/ena_ethdev.h
+@@ -50,6 +50,16 @@
+ 
+ #define ENA_MMIO_DISABLE_REG_READ	BIT(0)
+ 
++/* While processing submitted and completed descriptors (rx and tx path
++ * respectively) in a loop it is desired to:
++ *  - perform batch submissions while populating sumbissmion queue
++ *  - avoid blocking transmission of other packets during cleanup phase
++ * Hence the utilization ratio of 1/8 of a queue size or max value if the size
++ * of the ring is very big - like 8k Rx rings.
++ */
++#define ENA_REFILL_THRESH_DIVIDER      8
++#define ENA_REFILL_THRESH_PACKET       256
++
+ struct ena_adapter;
+ 
+ enum ena_ring_type {
+-- 
+2.20.1
+

--- a/userspace/dpdk/17.05/0001-net-ena-fix-cleanup-of-the-Tx-bufs.patch
+++ b/userspace/dpdk/17.05/0001-net-ena-fix-cleanup-of-the-Tx-bufs.patch
@@ -1,7 +1,7 @@
 From c9a25c151987fb41fe6cd2dd036caef5fbf275c5 Mon Sep 17 00:00:00 2001
 From: Michal Krawczyk <mk@semihalf.com>
 Date: Fri, 16 Jun 2017 08:19:16 +0000
-Subject: [PATCH 01/17] net/ena: fix cleanup of the Tx bufs
+Subject: [PATCH 01/24] net/ena: fix cleanup of the Tx bufs
 
 [ upstream commit 207a514ce516f8ab3c1ad2b0f930f045b90b773c ]
 
@@ -22,7 +22,7 @@ Signed-off-by: Michal Krawczyk <mk@semihalf.com>
  1 file changed, 4 insertions(+), 4 deletions(-)
 
 diff --git a/drivers/net/ena/ena_ethdev.c b/drivers/net/ena/ena_ethdev.c
-index 64fee05d3..ce07a26d0 100644
+index 64fee05d30..ce07a26d00 100644
 --- a/drivers/net/ena/ena_ethdev.c
 +++ b/drivers/net/ena/ena_ethdev.c
 @@ -689,11 +689,10 @@ static void ena_rx_queue_release_bufs(struct ena_ring *ring)

--- a/userspace/dpdk/17.05/0002-net-ena-add-memory-initialization-for-the-allocation.patch
+++ b/userspace/dpdk/17.05/0002-net-ena-add-memory-initialization-for-the-allocation.patch
@@ -1,7 +1,7 @@
 From ed58565307ee85a621183c98c95fd69099a9017c Mon Sep 17 00:00:00 2001
 From: Michal Krawczyk <mk@semihalf.com>
 Date: Fri, 16 Jun 2017 09:10:48 +0000
-Subject: [PATCH 02/17] net/ena: add memory initialization for the allocation
+Subject: [PATCH 02/24] net/ena: add memory initialization for the allocation
  macros
 
 [ upstream commit 2861ea8df0173f047efe2636ef3b9643d4d989bc ]
@@ -20,7 +20,7 @@ Signed-off-by: Michal Krawczyk <mk@semihalf.com>
  1 file changed, 2 insertions(+)
 
 diff --git a/drivers/net/ena/base/ena_plat_dpdk.h b/drivers/net/ena/base/ena_plat_dpdk.h
-index 7eaebf40f..71a8c1e22 100644
+index 7eaebf40f4..71a8c1e220 100644
 --- a/drivers/net/ena/base/ena_plat_dpdk.h
 +++ b/drivers/net/ena/base/ena_plat_dpdk.h
 @@ -207,6 +207,7 @@ typedef uint64_t dma_addr_t;

--- a/userspace/dpdk/17.05/0003-net-ena-do-not-set-Tx-L4-offloads-in-Rx-path.patch
+++ b/userspace/dpdk/17.05/0003-net-ena-do-not-set-Tx-L4-offloads-in-Rx-path.patch
@@ -1,7 +1,7 @@
 From cb942c4ed75cafaae651588248cda7ec94afd99c Mon Sep 17 00:00:00 2001
 From: Rafal Kozik <rk@semihalf.com>
 Date: Tue, 9 Jan 2018 16:19:08 +0100
-Subject: [PATCH 03/17] net/ena: do not set Tx L4 offloads in Rx path
+Subject: [PATCH 03/24] net/ena: do not set Tx L4 offloads in Rx path
 
 [ upstream commit fd617795679019c7aea5ab1e8c85db02cf53f169 ]
 
@@ -23,7 +23,7 @@ Signed-off-by: Michal Krawczyk <mk@semihalf.com>
  1 file changed, 6 insertions(+), 4 deletions(-)
 
 diff --git a/drivers/net/ena/ena_ethdev.c b/drivers/net/ena/ena_ethdev.c
-index ce07a26d0..58b0b6355 100644
+index ce07a26d00..58b0b63552 100644
 --- a/drivers/net/ena/ena_ethdev.c
 +++ b/drivers/net/ena/ena_ethdev.c
 @@ -260,16 +260,17 @@ static inline void ena_rx_mbuf_prepare(struct rte_mbuf *mbuf,

--- a/userspace/dpdk/17.05/0004-net-ena-check-pointer-before-memset.patch
+++ b/userspace/dpdk/17.05/0004-net-ena-check-pointer-before-memset.patch
@@ -1,7 +1,7 @@
 From d69ed2f5bb0a6fd916cfa13ea866ff3ad50ea567 Mon Sep 17 00:00:00 2001
 From: Rafal Kozik <rk@semihalf.com>
 Date: Thu, 7 Jun 2018 11:43:18 +0200
-Subject: [PATCH 04/17] net/ena: check pointer before memset
+Subject: [PATCH 04/24] net/ena: check pointer before memset
 
 [ upstream commit 46916aa17d4b2007df8c0454f99ba0ca8b8cb93b ]
 
@@ -19,7 +19,7 @@ Acked-by: Michal Krawczyk <mk@semihalf.com>
  1 file changed, 16 insertions(+), 6 deletions(-)
 
 diff --git a/drivers/net/ena/base/ena_plat_dpdk.h b/drivers/net/ena/base/ena_plat_dpdk.h
-index 71a8c1e22..955d6302d 100644
+index 71a8c1e220..955d6302dc 100644
 --- a/drivers/net/ena/base/ena_plat_dpdk.h
 +++ b/drivers/net/ena/base/ena_plat_dpdk.h
 @@ -189,10 +189,15 @@ typedef uint64_t dma_addr_t;

--- a/userspace/dpdk/17.05/0005-net-ena-change-memory-type.patch
+++ b/userspace/dpdk/17.05/0005-net-ena-change-memory-type.patch
@@ -1,7 +1,7 @@
 From 6d7dde897ae61bd65ee1aa834af478a51d30ac39 Mon Sep 17 00:00:00 2001
 From: Rafal Kozik <rk@semihalf.com>
 Date: Thu, 7 Jun 2018 11:43:19 +0200
-Subject: [PATCH 05/17] net/ena: change memory type
+Subject: [PATCH 05/24] net/ena: change memory type
 
 [ upstream commit 9f32c7e7e6ce58ab772913f54f8328c1c0186a17 ]
 
@@ -22,7 +22,7 @@ Acked-by: Michal Krawczyk <mk@semihalf.com>
  1 file changed, 1 insertion(+), 7 deletions(-)
 
 diff --git a/drivers/net/ena/base/ena_plat_dpdk.h b/drivers/net/ena/base/ena_plat_dpdk.h
-index 955d6302d..977bee49f 100644
+index 955d6302dc..977bee49ff 100644
 --- a/drivers/net/ena/base/ena_plat_dpdk.h
 +++ b/drivers/net/ena/base/ena_plat_dpdk.h
 @@ -224,14 +224,8 @@ typedef uint64_t dma_addr_t;

--- a/userspace/dpdk/17.05/0006-net-ena-fix-GENMASK_ULL-macro.patch
+++ b/userspace/dpdk/17.05/0006-net-ena-fix-GENMASK_ULL-macro.patch
@@ -1,7 +1,7 @@
 From a1f3aa39b175e931705981c4dc608b7b7c7f8fc8 Mon Sep 17 00:00:00 2001
 From: Rafal Kozik <rk@semihalf.com>
 Date: Thu, 7 Jun 2018 11:43:20 +0200
-Subject: [PATCH 06/17] net/ena: fix GENMASK_ULL macro
+Subject: [PATCH 06/24] net/ena: fix GENMASK_ULL macro
 
 [ upstream commit 7544aee8d0b4ae0262b1ba7e1539cf8171664df7 ]
 
@@ -20,7 +20,7 @@ Acked-by: Michal Krawczyk <mk@semihalf.com>
  1 file changed, 3 insertions(+), 1 deletion(-)
 
 diff --git a/drivers/net/ena/base/ena_plat_dpdk.h b/drivers/net/ena/base/ena_plat_dpdk.h
-index 977bee49f..06b637870 100644
+index 977bee49ff..06b6378708 100644
 --- a/drivers/net/ena/base/ena_plat_dpdk.h
 +++ b/drivers/net/ena/base/ena_plat_dpdk.h
 @@ -116,11 +116,13 @@ typedef uint64_t dma_addr_t;

--- a/userspace/dpdk/17.05/0007-net-ena-set-link-speed-as-none.patch
+++ b/userspace/dpdk/17.05/0007-net-ena-set-link-speed-as-none.patch
@@ -1,7 +1,7 @@
 From 5f2238d1a6c1986f0b301c9b77232ca6cef0ef70 Mon Sep 17 00:00:00 2001
 From: Rafal Kozik <rk@semihalf.com>
 Date: Thu, 7 Jun 2018 11:43:22 +0200
-Subject: [PATCH 07/17] net/ena: set link speed as none
+Subject: [PATCH 07/24] net/ena: set link speed as none
 
 [ upstream commit 41e59028dd8ab2038a7655c6fc3098222661aa53 ]
 
@@ -21,7 +21,7 @@ Acked-by: Michal Krawczyk <mk@semihalf.com>
  1 file changed, 1 insertion(+), 1 deletion(-)
 
 diff --git a/drivers/net/ena/ena_ethdev.c b/drivers/net/ena/ena_ethdev.c
-index 58b0b6355..185fc6fca 100644
+index 58b0b63552..185fc6fcaf 100644
 --- a/drivers/net/ena/ena_ethdev.c
 +++ b/drivers/net/ena/ena_ethdev.c
 @@ -709,7 +709,7 @@ static int ena_link_update(struct rte_eth_dev *dev,

--- a/userspace/dpdk/17.05/0008-net-ena-fix-SIGFPE-with-0-Rx-queue.patch
+++ b/userspace/dpdk/17.05/0008-net-ena-fix-SIGFPE-with-0-Rx-queue.patch
@@ -1,7 +1,7 @@
 From 57d442274cdb3150da5449c92a1100a29a8ffdec Mon Sep 17 00:00:00 2001
 From: Daria Kolistratova <daria.kolistratova@intel.com>
 Date: Tue, 26 Jun 2018 18:38:56 +0100
-Subject: [PATCH 08/17] net/ena: fix SIGFPE with 0 Rx queue
+Subject: [PATCH 08/24] net/ena: fix SIGFPE with 0 Rx queue
 
 [ upstream commit 361913ad6f8c05fc541fe4bfdae3b0dc095ae3af ]
 
@@ -19,7 +19,7 @@ Acked-by: Michal Krawczyk <mk@semihalf.com>
  1 file changed, 1 insertion(+), 1 deletion(-)
 
 diff --git a/drivers/net/ena/ena_ethdev.c b/drivers/net/ena/ena_ethdev.c
-index 185fc6fca..52e353c2d 100644
+index 185fc6fcaf..52e353c2d9 100644
 --- a/drivers/net/ena/ena_ethdev.c
 +++ b/drivers/net/ena/ena_ethdev.c
 @@ -906,7 +906,7 @@ static int ena_start(struct rte_eth_dev *dev)

--- a/userspace/dpdk/17.05/0009-net-ena-fix-passing-RSS-hash-to-mbuf.patch
+++ b/userspace/dpdk/17.05/0009-net-ena-fix-passing-RSS-hash-to-mbuf.patch
@@ -1,7 +1,7 @@
 From 0cb97dd4d90c398607395939f3a0e3d4fdedfa35 Mon Sep 17 00:00:00 2001
 From: Stewart Allen <allenste@amazon.com>
 Date: Thu, 25 Oct 2018 19:59:22 +0200
-Subject: [PATCH 09/17] net/ena: fix passing RSS hash to mbuf
+Subject: [PATCH 09/24] net/ena: fix passing RSS hash to mbuf
 
 [ upstream commit e5df9f33db00eb9d322abaefff30da74fd0e625d ]
 
@@ -19,7 +19,7 @@ Acked-by: Michal Krawczyk <mk@semihalf.com>
  1 file changed, 1 insertion(+), 1 deletion(-)
 
 diff --git a/drivers/net/ena/ena_ethdev.c b/drivers/net/ena/ena_ethdev.c
-index 52e353c2d..aa88309f2 100644
+index 52e353c2d9..aa88309f25 100644
 --- a/drivers/net/ena/ena_ethdev.c
 +++ b/drivers/net/ena/ena_ethdev.c
 @@ -1572,7 +1572,7 @@ static uint16_t eth_ena_recv_pkts(void *rx_queue, struct rte_mbuf **rx_pkts,

--- a/userspace/dpdk/17.05/0010-net-ena-add-supported-RSS-offloads-types.patch
+++ b/userspace/dpdk/17.05/0010-net-ena-add-supported-RSS-offloads-types.patch
@@ -1,7 +1,7 @@
 From 5962c19d83add68482fa1735a3d2d51ab2174a5d Mon Sep 17 00:00:00 2001
 From: Rafal Kozik <rk@semihalf.com>
 Date: Fri, 14 Dec 2018 14:18:38 +0100
-Subject: [PATCH 10/17] net/ena: add supported RSS offloads types
+Subject: [PATCH 10/24] net/ena: add supported RSS offloads types
 
 [ upstream commit b01ead202beb45346d7daeb2f2b1a608006af644 ]
 
@@ -20,7 +20,7 @@ Acked-by: Michal Krawczyk <mk@semihalf.com>
  1 file changed, 3 insertions(+)
 
 diff --git a/drivers/net/ena/ena_ethdev.c b/drivers/net/ena/ena_ethdev.c
-index aa88309f2..fdc0e525e 100644
+index aa88309f25..fdc0e525ea 100644
 --- a/drivers/net/ena/ena_ethdev.c
 +++ b/drivers/net/ena/ena_ethdev.c
 @@ -1492,6 +1492,9 @@ static void ena_infos_get(struct rte_eth_dev *dev,

--- a/userspace/dpdk/17.05/0011-net-ena-update-completion-queue-after-cleanup.patch
+++ b/userspace/dpdk/17.05/0011-net-ena-update-completion-queue-after-cleanup.patch
@@ -1,7 +1,7 @@
 From 2b29031c93eadc01443c37e4fb83c1397804a36e Mon Sep 17 00:00:00 2001
 From: Rafal Kozik <rk@semihalf.com>
 Date: Fri, 14 Dec 2018 14:18:44 +0100
-Subject: [PATCH 11/17] net/ena: update completion queue after cleanup
+Subject: [PATCH 11/24] net/ena: update completion queue after cleanup
 
 [ upstream commit a45462c507e98b49cb5c2302e0be3c72d2e20a1a ]
 
@@ -19,7 +19,7 @@ Acked-by: Michal Krawczyk <mk@semihalf.com>
  1 file changed, 5 insertions(+), 2 deletions(-)
 
 diff --git a/drivers/net/ena/ena_ethdev.c b/drivers/net/ena/ena_ethdev.c
-index fdc0e525e..80b54bc94 100644
+index fdc0e525ea..80b54bc949 100644
 --- a/drivers/net/ena/ena_ethdev.c
 +++ b/drivers/net/ena/ena_ethdev.c
 @@ -1586,8 +1586,10 @@ static uint16_t eth_ena_recv_pkts(void *rx_queue, struct rte_mbuf **rx_pkts,

--- a/userspace/dpdk/17.05/0012-net-ena-fix-dev-init-with-multi-process.patch
+++ b/userspace/dpdk/17.05/0012-net-ena-fix-dev-init-with-multi-process.patch
@@ -1,7 +1,7 @@
 From 6a16460d6e2f5dba53f21638ea0363f2c7a1d1ff Mon Sep 17 00:00:00 2001
 From: Michal Krawczyk <mk@semihalf.com>
 Date: Fri, 25 Jan 2019 09:10:25 +0100
-Subject: [PATCH 12/17] net/ena: fix dev init with multi-process
+Subject: [PATCH 12/24] net/ena: fix dev init with multi-process
 
 [ upstream commit fd9768905870856a2340266d25f8c0100dfccfff ]
 
@@ -22,7 +22,7 @@ Signed-off-by: Michal Krawczyk <mk@semihalf.com>
  1 file changed, 6 insertions(+), 5 deletions(-)
 
 diff --git a/drivers/net/ena/ena_ethdev.c b/drivers/net/ena/ena_ethdev.c
-index 80b54bc94..35e293486 100644
+index 80b54bc949..35e293486b 100644
 --- a/drivers/net/ena/ena_ethdev.c
 +++ b/drivers/net/ena/ena_ethdev.c
 @@ -1277,19 +1277,20 @@ static int eth_ena_dev_init(struct rte_eth_dev *eth_dev)

--- a/userspace/dpdk/17.05/0013-net-ena-fix-errno-to-positive-value.patch
+++ b/userspace/dpdk/17.05/0013-net-ena-fix-errno-to-positive-value.patch
@@ -1,7 +1,7 @@
 From 1259ac4f7ddb3f3c439800a77610e49bb35cb3a0 Mon Sep 17 00:00:00 2001
 From: Michal Krawczyk <mk@semihalf.com>
 Date: Fri, 25 Jan 2019 09:10:26 +0100
-Subject: [PATCH 13/17] net/ena: fix errno to positive value
+Subject: [PATCH 13/24] net/ena: fix errno to positive value
 
 [ upstream commit baeed5f404dd1b049118cfec26a2fd3203671572 ]
 
@@ -18,7 +18,7 @@ Signed-off-by: Michal Krawczyk <mk@semihalf.com>
  1 file changed, 3 insertions(+), 3 deletions(-)
 
 diff --git a/drivers/net/ena/ena_ethdev.c b/drivers/net/ena/ena_ethdev.c
-index 35e293486..652156930 100644
+index 35e293486b..652156930b 100644
 --- a/drivers/net/ena/ena_ethdev.c
 +++ b/drivers/net/ena/ena_ethdev.c
 @@ -1637,14 +1637,14 @@ eth_ena_prep_pkts(void *tx_queue, struct rte_mbuf **tx_pkts,

--- a/userspace/dpdk/17.05/0014-net-ena-get-device-info-statically.patch
+++ b/userspace/dpdk/17.05/0014-net-ena-get-device-info-statically.patch
@@ -1,7 +1,7 @@
 From 5dda01af7a1f89d33a71b96ecc5c06fbc6b211e4 Mon Sep 17 00:00:00 2001
 From: Michal Krawczyk <mk@semihalf.com>
 Date: Fri, 15 Feb 2019 09:36:39 +0100
-Subject: [PATCH 14/17] net/ena: get device info statically
+Subject: [PATCH 14/24] net/ena: get device info statically
 
 [ upstream commit 117ba4a60488a0f96a5737f38ddba6d0f9a728b6 ]
 
@@ -22,7 +22,7 @@ Signed-off-by: Michal Krawczyk <mk@semihalf.com>
  2 files changed, 19 insertions(+), 20 deletions(-)
 
 diff --git a/drivers/net/ena/ena_ethdev.c b/drivers/net/ena/ena_ethdev.c
-index 652156930..9dd57c906 100644
+index 652156930b..9dd57c9065 100644
 --- a/drivers/net/ena/ena_ethdev.c
 +++ b/drivers/net/ena/ena_ethdev.c
 @@ -1361,9 +1361,14 @@ static int eth_ena_dev_init(struct rte_eth_dev *eth_dev)
@@ -93,7 +93,7 @@ index 652156930..9dd57c906 100644
  		}
  
 diff --git a/drivers/net/ena/ena_ethdev.h b/drivers/net/ena/ena_ethdev.h
-index dc3080ffd..4791c53b5 100644
+index dc3080ffd3..4791c53b5a 100644
 --- a/drivers/net/ena/ena_ethdev.h
 +++ b/drivers/net/ena/ena_ethdev.h
 @@ -143,6 +143,12 @@ struct ena_stats_rx {

--- a/userspace/dpdk/17.05/0015-net-ena-fix-checksum-feature-flag.patch
+++ b/userspace/dpdk/17.05/0015-net-ena-fix-checksum-feature-flag.patch
@@ -1,7 +1,7 @@
 From c9582d1ba1ba3b63b5700dd6d9a1a30c4b707d0c Mon Sep 17 00:00:00 2001
 From: Michal Krawczyk <mk@semihalf.com>
 Date: Mon, 8 Apr 2019 12:27:44 +0200
-Subject: [PATCH 15/17] net/ena: fix checksum feature flag
+Subject: [PATCH 15/24] net/ena: fix checksum feature flag
 
 [ upstream commit ef538c1a7f565c9b58518375a500aa864445fd11 ]
 
@@ -18,7 +18,7 @@ Signed-off-by: Michal Krawczyk <mk@semihalf.com>
  1 file changed, 1 insertion(+), 1 deletion(-)
 
 diff --git a/drivers/net/ena/ena_ethdev.c b/drivers/net/ena/ena_ethdev.c
-index 9dd57c906..d8406d6ff 100644
+index 9dd57c9065..d8406d6ffb 100644
 --- a/drivers/net/ena/ena_ethdev.c
 +++ b/drivers/net/ena/ena_ethdev.c
 @@ -1366,7 +1366,7 @@ static int eth_ena_dev_init(struct rte_eth_dev *eth_dev)

--- a/userspace/dpdk/17.05/0016-net-ena-fix-Rx-checksum-errors-statistics.patch
+++ b/userspace/dpdk/17.05/0016-net-ena-fix-Rx-checksum-errors-statistics.patch
@@ -1,7 +1,7 @@
 From 88dce76726ea60a3df37b7858308322d8e7c18af Mon Sep 17 00:00:00 2001
 From: Michal Krawczyk <mk@semihalf.com>
 Date: Tue, 28 May 2019 10:28:34 +0200
-Subject: [PATCH 16/17] net/ena: fix Rx checksum errors statistics
+Subject: [PATCH 16/24] net/ena: fix Rx checksum errors statistics
 
 [ upstream commit ef74b5f7b69b9502ddab81121611243efcfe1dde ]
 
@@ -21,7 +21,7 @@ Signed-off-by: Michal Krawczyk <mk@semihalf.com>
  1 file changed, 5 insertions(+), 4 deletions(-)
 
 diff --git a/drivers/net/ena/ena_ethdev.c b/drivers/net/ena/ena_ethdev.c
-index d8406d6ff..c5b2ed730 100644
+index d8406d6ffb..c5b2ed7307 100644
 --- a/drivers/net/ena/ena_ethdev.c
 +++ b/drivers/net/ena/ena_ethdev.c
 @@ -1569,6 +1569,11 @@ static uint16_t eth_ena_recv_pkts(void *rx_queue, struct rte_mbuf **rx_pkts,

--- a/userspace/dpdk/17.05/0017-net-ena-fix-assigning-NUMA-node-to-IO-queue.patch
+++ b/userspace/dpdk/17.05/0017-net-ena-fix-assigning-NUMA-node-to-IO-queue.patch
@@ -1,7 +1,7 @@
 From 357a5c1638730c4f897f29db81726d0e7e4f54ea Mon Sep 17 00:00:00 2001
 From: Michal Krawczyk <mk@semihalf.com>
 Date: Tue, 4 Jun 2019 12:59:36 +0200
-Subject: [PATCH 17/17] net/ena: fix assigning NUMA node to IO queue
+Subject: [PATCH 17/24] net/ena: fix assigning NUMA node to IO queue
 
 [ upstream commit 4217cb0b7d2c5385f06f531af7f14b860927aba7 ]
 
@@ -23,7 +23,7 @@ Reviewed-by: David Marchand <david.marchand@redhat.com>
  2 files changed, 8 insertions(+), 17 deletions(-)
 
 diff --git a/drivers/net/ena/ena_ethdev.c b/drivers/net/ena/ena_ethdev.c
-index c5b2ed730..24fc032e1 100644
+index c5b2ed7307..24fc032e19 100644
 --- a/drivers/net/ena/ena_ethdev.c
 +++ b/drivers/net/ena/ena_ethdev.c
 @@ -39,7 +39,6 @@
@@ -106,7 +106,7 @@ index c5b2ed730..24fc032e1 100644
  
  	rxq->rx_buffer_info = rte_zmalloc("rxq->buffer_info",
 diff --git a/drivers/net/ena/ena_ethdev.h b/drivers/net/ena/ena_ethdev.h
-index 4791c53b5..8d5eb5a7c 100644
+index 4791c53b5a..8d5eb5a7ca 100644
 --- a/drivers/net/ena/ena_ethdev.h
 +++ b/drivers/net/ena/ena_ethdev.h
 @@ -90,6 +90,8 @@ struct ena_ring {

--- a/userspace/dpdk/17.05/0018-net-ena-base-fix-node-deallocation.patch
+++ b/userspace/dpdk/17.05/0018-net-ena-base-fix-node-deallocation.patch
@@ -1,0 +1,59 @@
+From f1a08ab436fba10bddc458dd79bacf33f0a041bb Mon Sep 17 00:00:00 2001
+From: Michal Krawczyk <mk@semihalf.com>
+Date: Thu, 2 Jul 2020 10:25:03 +0000
+Subject: [PATCH 18/24] net/ena/base: fix node deallocation
+
+The memzone handle wasn't saved anywhere - it could cause free of the
+invalid memory, as the mem_handle was never holding the right value.
+
+Signed-off-by: Michal Krawczyk <mk@semihalf.com>
+---
+ drivers/net/ena/base/ena_com.c       | 2 ++
+ drivers/net/ena/base/ena_plat_dpdk.h | 4 +++-
+ 2 files changed, 5 insertions(+), 1 deletion(-)
+
+diff --git a/drivers/net/ena/base/ena_com.c b/drivers/net/ena/base/ena_com.c
+index 38a0587754..1c38a1138d 100644
+--- a/drivers/net/ena/base/ena_com.c
++++ b/drivers/net/ena/base/ena_com.c
+@@ -347,6 +347,7 @@ static int ena_com_init_io_sq(struct ena_com_dev *ena_dev,
+ 					    size,
+ 					    io_sq->desc_addr.virt_addr,
+ 					    io_sq->desc_addr.phys_addr,
++					    io_sq->desc_addr.mem_handle,
+ 					    ctx->numa_node,
+ 					    dev_node);
+ 		if (!io_sq->desc_addr.virt_addr)
+@@ -400,6 +401,7 @@ static int ena_com_init_io_cq(struct ena_com_dev *ena_dev,
+ 				    size,
+ 				    io_cq->cdesc_addr.virt_addr,
+ 				    io_cq->cdesc_addr.phys_addr,
++				    io_cq->cdesc_addr.mem_handle,
+ 				    ctx->numa_node,
+ 				    prev_node);
+ 	if (!io_cq->cdesc_addr.virt_addr)
+diff --git a/drivers/net/ena/base/ena_plat_dpdk.h b/drivers/net/ena/base/ena_plat_dpdk.h
+index 06b6378708..2c7887c190 100644
+--- a/drivers/net/ena/base/ena_plat_dpdk.h
++++ b/drivers/net/ena/base/ena_plat_dpdk.h
+@@ -206,7 +206,8 @@ typedef uint64_t dma_addr_t;
+ 		   ENA_TOUCH(dmadev);					\
+ 		   rte_memzone_free(handle); })
+ 
+-#define ENA_MEM_ALLOC_COHERENT_NODE(dmadev, size, virt, phys, node, dev_node) \
++#define ENA_MEM_ALLOC_COHERENT_NODE(					\
++	dmadev, size, virt, phys, mem_handle, node, dev_node)		\
+ 	do {								\
+ 		const struct rte_memzone *mz;				\
+ 		char z_name[RTE_MEMZONE_NAMESIZE];			\
+@@ -214,6 +215,7 @@ typedef uint64_t dma_addr_t;
+ 		snprintf(z_name, sizeof(z_name),			\
+ 				"ena_alloc_%d", ena_alloc_cnt++);	\
+ 		mz = rte_memzone_reserve(z_name, size, node, 0); \
++		mem_handle = mz;					\
+ 		if (mz == NULL) {					\
+ 			virt = NULL;					\
+ 			phys = 0;					\
+-- 
+2.20.1
+

--- a/userspace/dpdk/17.05/0019-net-ena-fix-indication-of-bad-L4-Rx-checksums.patch
+++ b/userspace/dpdk/17.05/0019-net-ena-fix-indication-of-bad-L4-Rx-checksums.patch
@@ -1,0 +1,44 @@
+From 2fb7358b5ced5dbb733233824fac486f21d6e310 Mon Sep 17 00:00:00 2001
+From: Igor Chauskin <igorch@amazon.com>
+Date: Mon, 28 Oct 2019 11:23:33 +0100
+Subject: [PATCH 19/24] net/ena: fix indication of bad L4 Rx checksums
+
+[ upstream commit 05817057faba9356900ced61e24a22eef6bc4c87 ]
+
+Add checking of l4_csum_checked and frag flags before checking the
+l4_csum_error flag.
+
+In case of IP fragment/unchecked L4 csum - add PKT_RX_L4_CKSUM_UNKNOWN
+flag to the indicated mbuf.
+
+Fixes: 1173fca25af9 ("ena: add polling-mode driver")
+Cc: stable@dpdk.org
+
+Change-Id: I9f1414741eb44ca289a8bfd11d7e66110c95040e
+Signed-off-by: Igor Chauskin <igorch@amazon.com>
+Reviewed-by: Maciej Bielski <mba@semihalf.com>
+Reviewed-by: Michal Krawczyk <mk@semihalf.com>
+---
+ drivers/net/ena/ena_ethdev.c | 5 ++++-
+ 1 file changed, 4 insertions(+), 1 deletion(-)
+
+diff --git a/drivers/net/ena/ena_ethdev.c b/drivers/net/ena/ena_ethdev.c
+index 24fc032e19..89f2e59332 100644
+--- a/drivers/net/ena/ena_ethdev.c
++++ b/drivers/net/ena/ena_ethdev.c
+@@ -259,8 +259,11 @@ static inline void ena_rx_mbuf_prepare(struct rte_mbuf *mbuf,
+ 	else if (ena_rx_ctx->l3_proto == ENA_ETH_IO_L3_PROTO_IPV6)
+ 		packet_type |= RTE_PTYPE_L3_IPV6;
+ 
+-	if (unlikely(ena_rx_ctx->l4_csum_err))
++	if (unlikely(ena_rx_ctx->l4_csum_err) && !ena_rx_ctx->frag)
+ 		ol_flags |= PKT_RX_L4_CKSUM_BAD;
++	else
++		ol_flags |= PKT_RX_L4_CKSUM_UNKNOWN;
++
+ 	if (unlikely(ena_rx_ctx->l3_csum_err))
+ 		ol_flags |= PKT_RX_IP_CKSUM_BAD;
+ 
+-- 
+2.20.1
+

--- a/userspace/dpdk/17.05/0020-net-ena-ensure-Rx-buffer-size-is-at-least-1400B.patch
+++ b/userspace/dpdk/17.05/0020-net-ena-ensure-Rx-buffer-size-is-at-least-1400B.patch
@@ -1,0 +1,84 @@
+From 50033f04e2ca86e7e5bd56ea65b1c5034b033d6d Mon Sep 17 00:00:00 2001
+From: Michal Krawczyk <mk@semihalf.com>
+Date: Wed, 8 Apr 2020 10:28:52 +0200
+Subject: [PATCH 20/24] net/ena: ensure Rx buffer size is at least 1400B
+
+[ upstream commit 38364c2687ead97b99402310087c27131a97748c ]
+
+Some of the ENA devices can't handle buffers which are smaller than a
+1400B. Because of this limitation, size of the buffer is being checked
+and limited during the Rx queue setup.
+
+If it's below the allowed value, PMD won't finish it's configuration
+successfully..
+
+Change-Id: Ib402d3bfad98a3fc4f91095d5c6f90c6069da021
+Signed-off-by: Michal Krawczyk <mk@semihalf.com>
+Reviewed-by: Igor Chauskin <igorch@amazon.com>
+Reviewed-by: Guy Tzalik <gtzalik@amazon.com>
+---
+ drivers/net/ena/ena_ethdev.c | 12 +++++++++++-
+ drivers/net/ena/ena_ethdev.h |  3 ++-
+ 2 files changed, 13 insertions(+), 2 deletions(-)
+
+diff --git a/drivers/net/ena/ena_ethdev.c b/drivers/net/ena/ena_ethdev.c
+index 89f2e59332..5e0f1f4c17 100644
+--- a/drivers/net/ena/ena_ethdev.c
++++ b/drivers/net/ena/ena_ethdev.c
+@@ -1,7 +1,7 @@
+ /*-
+ * BSD LICENSE
+ *
+-* Copyright (c) 2015-2016 Amazon.com, Inc. or its affiliates.
++* Copyright (c) 2015-2020 Amazon.com, Inc. or its affiliates.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+@@ -1049,6 +1049,7 @@ static int ena_rx_queue_setup(struct rte_eth_dev *dev,
+ 	struct ena_adapter *adapter =
+ 		(struct ena_adapter *)(dev->data->dev_private);
+ 	struct ena_ring *rxq = NULL;
++	size_t buffer_size;
+ 	uint16_t ena_qid = 0;
+ 	int rc = 0;
+ 	struct ena_com_dev *ena_dev = &adapter->ena_dev;
+@@ -1075,6 +1076,15 @@ static int ena_rx_queue_setup(struct rte_eth_dev *dev,
+ 		return -EINVAL;
+ 	}
+ 
++	/* ENA isn't supporting buffers smaller than 1400 bytes */
++	buffer_size = rte_pktmbuf_data_room_size(mp) - RTE_PKTMBUF_HEADROOM;
++	if (buffer_size < ENA_RX_BUF_MIN_SIZE) {
++		PMD_DRV_LOG(ERR,
++			"Unsupported size of RX buffer: %zu (min size: %d)\n",
++			buffer_size, ENA_RX_BUF_MIN_SIZE);
++		return -EINVAL;
++	}
++
+ 	ena_qid = ENA_IO_RXQ_IDX(queue_idx);
+ 
+ 	ctx.qid = ena_qid;
+diff --git a/drivers/net/ena/ena_ethdev.h b/drivers/net/ena/ena_ethdev.h
+index 8d5eb5a7ca..d6e5e730e1 100644
+--- a/drivers/net/ena/ena_ethdev.h
++++ b/drivers/net/ena/ena_ethdev.h
+@@ -1,7 +1,7 @@
+ /*-
+ * BSD LICENSE
+ *
+-* Copyright (c) 2015-2016 Amazon.com, Inc. or its affiliates.
++* Copyright (c) 2015-2020 Amazon.com, Inc. or its affiliates.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+@@ -46,6 +46,7 @@
+ #define ENA_MIN_FRAME_LEN	64
+ #define ENA_NAME_MAX_LEN	20
+ #define ENA_PKT_MAX_BUFS	17
++#define ENA_RX_BUF_MIN_SIZE	1400
+ 
+ #define ENA_MMIO_DISABLE_REG_READ	BIT(0)
+ 
+-- 
+2.20.1
+

--- a/userspace/dpdk/17.05/0021-net-ena-base-make-allocation-macros-thread-safe.patch
+++ b/userspace/dpdk/17.05/0021-net-ena-base-make-allocation-macros-thread-safe.patch
@@ -1,0 +1,103 @@
+From 8345a840fff692fabf0afe33e31118fdc257e9fe Mon Sep 17 00:00:00 2001
+From: Igor Chauskin <igorch@amazon.com>
+Date: Wed, 8 Apr 2020 10:28:53 +0200
+Subject: [PATCH 21/24] net/ena/base: make allocation macros thread-safe
+
+[ upstream commit b14fcac035fd8514851c9140a4e26d765b61c532 ]
+
+Memory allocation region id could possibly be non-unique
+due to non-atomic increment, causing allocation failure.
+
+Fixes: 9ba7981ec992 ("ena: add communication layer for DPDK")
+Cc: stable@dpdk.org
+
+Change-Id: Ib9207aaae4e5e7ecdf1a99a0f23a508a53af631d
+Signed-off-by: Igor Chauskin <igorch@amazon.com>
+Reviewed-by: Michal Krawczyk <mk@semihalf.com>
+Reviewed-by: Guy Tzalik <gtzalik@amazon.com>
+---
+ drivers/net/ena/base/ena_com.c       |  2 --
+ drivers/net/ena/base/ena_plat_dpdk.h | 16 ++++++++++++----
+ drivers/net/ena/ena_ethdev.c         |  6 ++++++
+ 3 files changed, 18 insertions(+), 6 deletions(-)
+
+diff --git a/drivers/net/ena/base/ena_com.c b/drivers/net/ena/base/ena_com.c
+index 1c38a1138d..0dbd1b0cd0 100644
+--- a/drivers/net/ena/base/ena_com.c
++++ b/drivers/net/ena/base/ena_com.c
+@@ -62,8 +62,6 @@
+ 
+ #define ENA_MMIO_READ_TIMEOUT 0xFFFFFFFF
+ 
+-static int ena_alloc_cnt;
+-
+ /*****************************************************************************/
+ /*****************************************************************************/
+ /*****************************************************************************/
+diff --git a/drivers/net/ena/base/ena_plat_dpdk.h b/drivers/net/ena/base/ena_plat_dpdk.h
+index 2c7887c190..791471adbd 100644
+--- a/drivers/net/ena/base/ena_plat_dpdk.h
++++ b/drivers/net/ena/base/ena_plat_dpdk.h
+@@ -1,7 +1,7 @@
+ /*-
+ * BSD LICENSE
+ *
+-* Copyright (c) 2015-2016 Amazon.com, Inc. or its affiliates.
++* Copyright (c) 2015-2020 Amazon.com, Inc. or its affiliates.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+@@ -183,13 +183,20 @@ typedef uint64_t dma_addr_t;
+ #define ena_wait_event_t ena_wait_queue_t
+ #define ENA_MIGHT_SLEEP()
+ 
++/*
++ * Each rte_memzone should have unique name.
++ * To satisfy it, count number of allocations and add it to name.
++ */
++extern rte_atomic32_t ena_alloc_cnt;
++
+ #define ENA_MEM_ALLOC_COHERENT(dmadev, size, virt, phys, handle)	\
+ 	do {								\
+ 		const struct rte_memzone *mz;				\
+ 		char z_name[RTE_MEMZONE_NAMESIZE];			\
+ 		ENA_TOUCH(dmadev); ENA_TOUCH(handle);			\
+ 		snprintf(z_name, sizeof(z_name),			\
+-				"ena_alloc_%d", ena_alloc_cnt++);	\
++			 "ena_alloc_%d",				\
++			 rte_atomic32_add_return(&ena_alloc_cnt, 1));	\
+ 		mz = rte_memzone_reserve(z_name, size, SOCKET_ID_ANY, 0); \
+ 		handle = mz;						\
+ 		if (mz == NULL) {					\
+@@ -213,8 +220,9 @@ typedef uint64_t dma_addr_t;
+ 		char z_name[RTE_MEMZONE_NAMESIZE];			\
+ 		ENA_TOUCH(dmadev); ENA_TOUCH(dev_node);			\
+ 		snprintf(z_name, sizeof(z_name),			\
+-				"ena_alloc_%d", ena_alloc_cnt++);	\
+-		mz = rte_memzone_reserve(z_name, size, node, 0); \
++			 "ena_alloc_%d",				\
++			 rte_atomic32_add_return(&ena_alloc_cnt, 1));	\
++		mz = rte_memzone_reserve(z_name, size, node, 0);	\
+ 		mem_handle = mz;					\
+ 		if (mz == NULL) {					\
+ 			virt = NULL;					\
+diff --git a/drivers/net/ena/ena_ethdev.c b/drivers/net/ena/ena_ethdev.c
+index 5e0f1f4c17..9ac90a967f 100644
+--- a/drivers/net/ena/ena_ethdev.c
++++ b/drivers/net/ena/ena_ethdev.c
+@@ -113,6 +113,12 @@ struct ena_stats {
+ #define ENA_STAT_GLOBAL_ENTRY(stat) \
+ 	ENA_STAT_ENTRY(stat, dev)
+ 
++/*
++ * Each rte_memzone should have unique name.
++ * To satisfy it, count number of allocation and add it to name.
++ */
++rte_atomic32_t ena_alloc_cnt;
++
+ static const struct ena_stats ena_stats_global_strings[] = {
+ 	ENA_STAT_GLOBAL_ENTRY(tx_timeout),
+ 	ENA_STAT_GLOBAL_ENTRY(io_suspend),
+-- 
+2.20.1
+

--- a/userspace/dpdk/17.05/0022-net-ena-base-prevent-allocation-of-zero-sized-memory.patch
+++ b/userspace/dpdk/17.05/0022-net-ena-base-prevent-allocation-of-zero-sized-memory.patch
@@ -1,0 +1,74 @@
+From c75d1cdc64f544125489008eb4883d3aac099de2 Mon Sep 17 00:00:00 2001
+From: Igor Chauskin <igorch@amazon.com>
+Date: Wed, 8 Apr 2020 10:28:54 +0200
+Subject: [PATCH 22/24] net/ena/base: prevent allocation of zero sized memory
+
+[ upstream commit 29dc10d9424ccf26a346387b0a707185e2432400 ]
+
+rte_memzone_reserve() will reserve the biggest contiguous memzone
+available if received 0 as size param.
+
+Fixes: 9ba7981ec992 ("ena: add communication layer for DPDK")
+Cc: stable@dpdk.org
+
+Change-Id: I2f71119e93c5e9addd8c538820093f030066d690
+Signed-off-by: Igor Chauskin <igorch@amazon.com>
+Reviewed-by: Michal Krawczyk <mk@semihalf.com>
+Reviewed-by: Guy Tzalik <gtzalik@amazon.com>
+---
+ drivers/net/ena/base/ena_plat_dpdk.h | 27 ++++++++++++++++-----------
+ 1 file changed, 16 insertions(+), 11 deletions(-)
+
+diff --git a/drivers/net/ena/base/ena_plat_dpdk.h b/drivers/net/ena/base/ena_plat_dpdk.h
+index 791471adbd..f3820d5ebd 100644
+--- a/drivers/net/ena/base/ena_plat_dpdk.h
++++ b/drivers/net/ena/base/ena_plat_dpdk.h
+@@ -191,14 +191,17 @@ extern rte_atomic32_t ena_alloc_cnt;
+ 
+ #define ENA_MEM_ALLOC_COHERENT(dmadev, size, virt, phys, handle)	\
+ 	do {								\
+-		const struct rte_memzone *mz;				\
+-		char z_name[RTE_MEMZONE_NAMESIZE];			\
++		const struct rte_memzone *mz = NULL;			\
+ 		ENA_TOUCH(dmadev); ENA_TOUCH(handle);			\
+-		snprintf(z_name, sizeof(z_name),			\
++		if (size > 0) {						\
++			char z_name[RTE_MEMZONE_NAMESIZE];		\
++			snprintf(z_name, sizeof(z_name),		\
+ 			 "ena_alloc_%d",				\
+ 			 rte_atomic32_add_return(&ena_alloc_cnt, 1));	\
+-		mz = rte_memzone_reserve(z_name, size, SOCKET_ID_ANY, 0); \
+-		handle = mz;						\
++			mz = rte_memzone_reserve(z_name, size,		\
++				SOCKET_ID_ANY, 0);			\
++			handle = mz;					\
++		}							\
+ 		if (mz == NULL) {					\
+ 			virt = NULL;					\
+ 			phys = 0;					\
+@@ -216,14 +219,16 @@ extern rte_atomic32_t ena_alloc_cnt;
+ #define ENA_MEM_ALLOC_COHERENT_NODE(					\
+ 	dmadev, size, virt, phys, mem_handle, node, dev_node)		\
+ 	do {								\
+-		const struct rte_memzone *mz;				\
+-		char z_name[RTE_MEMZONE_NAMESIZE];			\
++		const struct rte_memzone *mz = NULL;			\
+ 		ENA_TOUCH(dmadev); ENA_TOUCH(dev_node);			\
+-		snprintf(z_name, sizeof(z_name),			\
++		if (size > 0) {						\
++			char z_name[RTE_MEMZONE_NAMESIZE];		\
++			snprintf(z_name, sizeof(z_name),		\
+ 			 "ena_alloc_%d",				\
+-			 rte_atomic32_add_return(&ena_alloc_cnt, 1));	\
+-		mz = rte_memzone_reserve(z_name, size, node, 0);	\
+-		mem_handle = mz;					\
++			 rte_atomic32_add_return(&ena_alloc_cnt, 1));   \
++			mz = rte_memzone_reserve(z_name, size, node, 0); \
++			mem_handle = mz;				\
++		}							\
+ 		if (mz == NULL) {					\
+ 			virt = NULL;					\
+ 			phys = 0;					\
+-- 
+2.20.1
+

--- a/userspace/dpdk/17.05/0023-net-ena-set-IO-ring-size-to-valid-value.patch
+++ b/userspace/dpdk/17.05/0023-net-ena-set-IO-ring-size-to-valid-value.patch
@@ -1,0 +1,49 @@
+From 1cd03c2f81209dcc5e5cb313f49e208193f1ebb1 Mon Sep 17 00:00:00 2001
+From: Michal Krawczyk <mk@semihalf.com>
+Date: Fri, 3 Jul 2020 13:14:58 +0000
+Subject: [PATCH 23/24] net/ena: set IO ring size to valid value
+
+[ upstream commit badc3a6aa133a886a61b9e3ad666e5675f7ec3d3 ]
+
+IO rings were configured with the maximum allowed size for the Tx/Rx
+rings. However, the application could decide to create smaller rings.
+
+This patch is using value stored in the ring instead of the value from
+the adapter which is indicating the maximum allowed value.
+
+Fixes: df238f84c0a2 ("net/ena: recreate HW IO rings on start and stop")
+Cc: stable@dpdk.org
+
+Change-Id: Icf9102e2aa4e7413b6620b36dd232673239b7291
+Signed-off-by: Michal Krawczyk <mk@semihalf.com>
+Reviewed-by: Igor Chauskin <igorch@amazon.com>
+Reviewed-by: Guy Tzalik <gtzalik@amazon.com>
+---
+ drivers/net/ena/ena_ethdev.c | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/drivers/net/ena/ena_ethdev.c b/drivers/net/ena/ena_ethdev.c
+index 9ac90a967f..4437098db5 100644
+--- a/drivers/net/ena/ena_ethdev.c
++++ b/drivers/net/ena/ena_ethdev.c
+@@ -985,7 +985,7 @@ static int ena_tx_queue_setup(struct rte_eth_dev *dev,
+ 	ctx.qid = ena_qid;
+ 	ctx.msix_vector = -1; /* admin interrupts not used */
+ 	ctx.mem_queue_type = ena_dev->tx_mem_queue_type;
+-	ctx.queue_size = adapter->tx_ring_size;
++	ctx.queue_size = nb_desc;
+ 	ctx.numa_node = socket_id;
+ 
+ 	rc = ena_com_create_io_queue(ena_dev, &ctx);
+@@ -1097,7 +1097,7 @@ static int ena_rx_queue_setup(struct rte_eth_dev *dev,
+ 	ctx.direction = ENA_COM_IO_QUEUE_DIRECTION_RX;
+ 	ctx.mem_queue_type = ENA_ADMIN_PLACEMENT_POLICY_HOST;
+ 	ctx.msix_vector = -1; /* admin interrupts not used */
+-	ctx.queue_size = adapter->rx_ring_size;
++	ctx.queue_size = nb_desc;
+ 	ctx.numa_node = socket_id;
+ 
+ 	rc = ena_com_create_io_queue(ena_dev, &ctx);
+-- 
+2.20.1
+

--- a/userspace/dpdk/17.05/0024-net-ena-limit-refill-threshold-by-fixed-value.patch
+++ b/userspace/dpdk/17.05/0024-net-ena-limit-refill-threshold-by-fixed-value.patch
@@ -1,0 +1,118 @@
+From a16955aa7cfeccfbd3c84959469407f07223e0c5 Mon Sep 17 00:00:00 2001
+From: Michal Krawczyk <mk@semihalf.com>
+Date: Wed, 8 Apr 2020 10:29:16 +0200
+Subject: [PATCH 24/24] net/ena: limit refill threshold by fixed value
+
+[ upstream commit 7755060798de9c0146df8809926030ed47fc9086 ]
+
+Divider used for both Tx and Rx cleanup/refill threshold can cause too
+big delay in case of the really big rings - for example if the 8k Rx
+ring will be used, the refill won't trigger unless 1024 threshold will
+be reached. It will also cause driver to try to allocate that much
+descriptors.
+
+Limiting it by fixed value - 256 in that case, would limit maximum
+time spent in repopulate function.
+
+Change-Id: Ia8659e6ddf179ff612a780adc6fe55d13eeac6e9
+Signed-off-by: Michal Krawczyk <mk@semihalf.com>
+Reviewed-by: Igor Chauskin <igorch@amazon.com>
+Reviewed-by: Guy Tzalik <gtzalik@amazon.com>
+---
+ drivers/net/ena/ena_ethdev.c | 26 ++++++++++++++------------
+ drivers/net/ena/ena_ethdev.h | 10 ++++++++++
+ 2 files changed, 24 insertions(+), 12 deletions(-)
+
+diff --git a/drivers/net/ena/ena_ethdev.c b/drivers/net/ena/ena_ethdev.c
+index 4437098db5..2c6115f297 100644
+--- a/drivers/net/ena/ena_ethdev.c
++++ b/drivers/net/ena/ena_ethdev.c
+@@ -61,14 +61,6 @@
+ /*reverse version of ENA_IO_RXQ_IDX*/
+ #define ENA_IO_RXQ_IDX_REV(q)	((q - 1) / 2)
+ 
+-/* While processing submitted and completed descriptors (rx and tx path
+- * respectively) in a loop it is desired to:
+- *  - perform batch submissions while populating sumbissmion queue
+- *  - avoid blocking transmission of other packets during cleanup phase
+- * Hence the utilization ratio of 1/8 of a queue size.
+- */
+-#define ENA_RING_DESCS_RATIO(ring_size)	(ring_size / 8)
+-
+ #define __MERGE_64B_H_L(h, l) (((uint64_t)h << 32) | l)
+ #define TEST_BIT(val, bit_shift) (val & (1UL << bit_shift))
+ 
+@@ -1512,6 +1504,8 @@ static uint16_t eth_ena_recv_pkts(void *rx_queue, struct rte_mbuf **rx_pkts,
+ 	struct ena_ring *rx_ring = (struct ena_ring *)(rx_queue);
+ 	unsigned int ring_size = rx_ring->ring_size;
+ 	unsigned int ring_mask = ring_size - 1;
++	unsigned int free_queue_entries;
++	unsigned int refill_threshold;
+ 	uint16_t next_to_clean = rx_ring->next_to_clean;
+ 	uint16_t desc_in_use = 0;
+ 	unsigned int recv_idx = 0;
+@@ -1591,11 +1585,15 @@ static uint16_t eth_ena_recv_pkts(void *rx_queue, struct rte_mbuf **rx_pkts,
+ 
+ 	rx_ring->next_to_clean = next_to_clean;
+ 
+-	desc_in_use = desc_in_use - completed + 1;
++	free_queue_entries = ena_com_sq_empty_space(rx_ring->ena_com_io_sq);
++	refill_threshold =
++		RTE_MIN(ring_size / ENA_REFILL_THRESH_DIVIDER,
++		(unsigned int)ENA_REFILL_THRESH_PACKET);
++
+ 	/* Burst refill to save doorbells, memory barriers, const interval */
+-	if (ring_size - desc_in_use > ENA_RING_DESCS_RATIO(ring_size)) {
++	if (free_queue_entries > refill_threshold) {
+ 		ena_com_update_dev_comp_head(rx_ring->ena_com_io_cq);
+-		ena_populate_rx_queue(rx_ring, ring_size - desc_in_use);
++		ena_populate_rx_queue(rx_ring, free_queue_entries);
+ 	}
+ 
+ 	return recv_idx;
+@@ -1680,6 +1678,7 @@ static uint16_t eth_ena_xmit_pkts(void *tx_queue, struct rte_mbuf **tx_pkts,
+ 	struct rte_mbuf *mbuf;
+ 	unsigned int ring_size = tx_ring->ring_size;
+ 	unsigned int ring_mask = ring_size - 1;
++	unsigned int cleanup_budget;
+ 	struct ena_com_tx_ctx ena_tx_ctx;
+ 	struct ena_tx_buffer *tx_info;
+ 	struct ena_com_buf *ebuf;
+@@ -1786,9 +1785,12 @@ static uint16_t eth_ena_xmit_pkts(void *tx_queue, struct rte_mbuf **tx_pkts,
+ 		/* Put back descriptor to the ring for reuse */
+ 		tx_ring->empty_tx_reqs[next_to_clean & ring_mask] = req_id;
+ 		next_to_clean++;
++		cleanup_budget =
++			RTE_MIN(ring_size / ENA_REFILL_THRESH_DIVIDER,
++			(unsigned int)ENA_REFILL_THRESH_PACKET);
+ 
+ 		/* If too many descs to clean, leave it for another run */
+-		if (unlikely(total_tx_descs > ENA_RING_DESCS_RATIO(ring_size)))
++		if (unlikely(total_tx_descs > cleanup_budget))
+ 			break;
+ 	}
+ 
+diff --git a/drivers/net/ena/ena_ethdev.h b/drivers/net/ena/ena_ethdev.h
+index d6e5e730e1..2b02806db5 100644
+--- a/drivers/net/ena/ena_ethdev.h
++++ b/drivers/net/ena/ena_ethdev.h
+@@ -50,6 +50,16 @@
+ 
+ #define ENA_MMIO_DISABLE_REG_READ	BIT(0)
+ 
++/* While processing submitted and completed descriptors (rx and tx path
++ * respectively) in a loop it is desired to:
++ *  - perform batch submissions while populating sumbissmion queue
++ *  - avoid blocking transmission of other packets during cleanup phase
++ * Hence the utilization ratio of 1/8 of a queue size or max value if the size
++ * of the ring is very big - like 8k Rx rings.
++ */
++#define ENA_REFILL_THRESH_DIVIDER      8
++#define ENA_REFILL_THRESH_PACKET       256
++
+ struct ena_adapter;
+ 
+ enum ena_ring_type {
+-- 
+2.20.1
+

--- a/userspace/dpdk/17.08/0001-net-ena-do-not-set-Tx-L4-offloads-in-Rx-path.patch
+++ b/userspace/dpdk/17.08/0001-net-ena-do-not-set-Tx-L4-offloads-in-Rx-path.patch
@@ -1,7 +1,7 @@
 From 530e6d44c051f63b96100079d1a6f5af2d75c325 Mon Sep 17 00:00:00 2001
 From: Rafal Kozik <rk@semihalf.com>
 Date: Tue, 9 Jan 2018 16:19:08 +0100
-Subject: [PATCH 01/15] net/ena: do not set Tx L4 offloads in Rx path
+Subject: [PATCH 01/22] net/ena: do not set Tx L4 offloads in Rx path
 
 [ upstream commit fd617795679019c7aea5ab1e8c85db02cf53f169 ]
 
@@ -23,7 +23,7 @@ Signed-off-by: Michal Krawczyk <mk@semihalf.com>
  1 file changed, 6 insertions(+), 4 deletions(-)
 
 diff --git a/drivers/net/ena/ena_ethdev.c b/drivers/net/ena/ena_ethdev.c
-index 80ce1f353..16a648206 100644
+index 80ce1f3532..16a648206a 100644
 --- a/drivers/net/ena/ena_ethdev.c
 +++ b/drivers/net/ena/ena_ethdev.c
 @@ -260,16 +260,17 @@ static inline void ena_rx_mbuf_prepare(struct rte_mbuf *mbuf,

--- a/userspace/dpdk/17.08/0002-net-ena-check-pointer-before-memset.patch
+++ b/userspace/dpdk/17.08/0002-net-ena-check-pointer-before-memset.patch
@@ -1,7 +1,7 @@
 From 64807cc751f5c59db091b4a4bbcd884225be1701 Mon Sep 17 00:00:00 2001
 From: Rafal Kozik <rk@semihalf.com>
 Date: Thu, 7 Jun 2018 11:43:18 +0200
-Subject: [PATCH 02/15] net/ena: check pointer before memset
+Subject: [PATCH 02/22] net/ena: check pointer before memset
 
 [ upstream commit 46916aa17d4b2007df8c0454f99ba0ca8b8cb93b ]
 
@@ -19,7 +19,7 @@ Acked-by: Michal Krawczyk <mk@semihalf.com>
  1 file changed, 16 insertions(+), 6 deletions(-)
 
 diff --git a/drivers/net/ena/base/ena_plat_dpdk.h b/drivers/net/ena/base/ena_plat_dpdk.h
-index 71a8c1e22..955d6302d 100644
+index 71a8c1e220..955d6302dc 100644
 --- a/drivers/net/ena/base/ena_plat_dpdk.h
 +++ b/drivers/net/ena/base/ena_plat_dpdk.h
 @@ -189,10 +189,15 @@ typedef uint64_t dma_addr_t;

--- a/userspace/dpdk/17.08/0003-net-ena-change-memory-type.patch
+++ b/userspace/dpdk/17.08/0003-net-ena-change-memory-type.patch
@@ -1,7 +1,7 @@
 From 9fb11622486a3ce3012f63f30edfd005cfa20735 Mon Sep 17 00:00:00 2001
 From: Rafal Kozik <rk@semihalf.com>
 Date: Thu, 7 Jun 2018 11:43:19 +0200
-Subject: [PATCH 03/15] net/ena: change memory type
+Subject: [PATCH 03/22] net/ena: change memory type
 
 [ upstream commit 9f32c7e7e6ce58ab772913f54f8328c1c0186a17 ]
 
@@ -22,7 +22,7 @@ Acked-by: Michal Krawczyk <mk@semihalf.com>
  1 file changed, 1 insertion(+), 7 deletions(-)
 
 diff --git a/drivers/net/ena/base/ena_plat_dpdk.h b/drivers/net/ena/base/ena_plat_dpdk.h
-index 955d6302d..977bee49f 100644
+index 955d6302dc..977bee49ff 100644
 --- a/drivers/net/ena/base/ena_plat_dpdk.h
 +++ b/drivers/net/ena/base/ena_plat_dpdk.h
 @@ -224,14 +224,8 @@ typedef uint64_t dma_addr_t;

--- a/userspace/dpdk/17.08/0004-net-ena-fix-GENMASK_ULL-macro.patch
+++ b/userspace/dpdk/17.08/0004-net-ena-fix-GENMASK_ULL-macro.patch
@@ -1,7 +1,7 @@
 From c0c543e9bd15913f9516d827d718a5e6c039a66e Mon Sep 17 00:00:00 2001
 From: Rafal Kozik <rk@semihalf.com>
 Date: Thu, 7 Jun 2018 11:43:20 +0200
-Subject: [PATCH 04/15] net/ena: fix GENMASK_ULL macro
+Subject: [PATCH 04/22] net/ena: fix GENMASK_ULL macro
 
 [ upstream commit 7544aee8d0b4ae0262b1ba7e1539cf8171664df7 ]
 
@@ -20,7 +20,7 @@ Acked-by: Michal Krawczyk <mk@semihalf.com>
  1 file changed, 3 insertions(+), 1 deletion(-)
 
 diff --git a/drivers/net/ena/base/ena_plat_dpdk.h b/drivers/net/ena/base/ena_plat_dpdk.h
-index 977bee49f..06b637870 100644
+index 977bee49ff..06b6378708 100644
 --- a/drivers/net/ena/base/ena_plat_dpdk.h
 +++ b/drivers/net/ena/base/ena_plat_dpdk.h
 @@ -116,11 +116,13 @@ typedef uint64_t dma_addr_t;

--- a/userspace/dpdk/17.08/0005-net-ena-set-link-speed-as-none.patch
+++ b/userspace/dpdk/17.08/0005-net-ena-set-link-speed-as-none.patch
@@ -1,7 +1,7 @@
 From 0886f240c7fea07345cd7e5f3148a06e64c66576 Mon Sep 17 00:00:00 2001
 From: Rafal Kozik <rk@semihalf.com>
 Date: Thu, 7 Jun 2018 11:43:22 +0200
-Subject: [PATCH 05/15] net/ena: set link speed as none
+Subject: [PATCH 05/22] net/ena: set link speed as none
 
 [ upstream commit 41e59028dd8ab2038a7655c6fc3098222661aa53 ]
 
@@ -21,7 +21,7 @@ Acked-by: Michal Krawczyk <mk@semihalf.com>
  1 file changed, 1 insertion(+), 1 deletion(-)
 
 diff --git a/drivers/net/ena/ena_ethdev.c b/drivers/net/ena/ena_ethdev.c
-index 16a648206..e5da94a59 100644
+index 16a648206a..e5da94a594 100644
 --- a/drivers/net/ena/ena_ethdev.c
 +++ b/drivers/net/ena/ena_ethdev.c
 @@ -709,7 +709,7 @@ static int ena_link_update(struct rte_eth_dev *dev,

--- a/userspace/dpdk/17.08/0006-net-ena-fix-SIGFPE-with-0-Rx-queue.patch
+++ b/userspace/dpdk/17.08/0006-net-ena-fix-SIGFPE-with-0-Rx-queue.patch
@@ -1,7 +1,7 @@
 From b379064f88bbc91a6a6dd9a4f7838f88b9faff85 Mon Sep 17 00:00:00 2001
 From: Daria Kolistratova <daria.kolistratova@intel.com>
 Date: Tue, 26 Jun 2018 18:38:56 +0100
-Subject: [PATCH 06/15] net/ena: fix SIGFPE with 0 Rx queue
+Subject: [PATCH 06/22] net/ena: fix SIGFPE with 0 Rx queue
 
 [ upstream commit 361913ad6f8c05fc541fe4bfdae3b0dc095ae3af ]
 
@@ -19,7 +19,7 @@ Acked-by: Michal Krawczyk <mk@semihalf.com>
  1 file changed, 1 insertion(+), 1 deletion(-)
 
 diff --git a/drivers/net/ena/ena_ethdev.c b/drivers/net/ena/ena_ethdev.c
-index e5da94a59..01c463a33 100644
+index e5da94a594..01c463a335 100644
 --- a/drivers/net/ena/ena_ethdev.c
 +++ b/drivers/net/ena/ena_ethdev.c
 @@ -906,7 +906,7 @@ static int ena_start(struct rte_eth_dev *dev)

--- a/userspace/dpdk/17.08/0007-net-ena-fix-passing-RSS-hash-to-mbuf.patch
+++ b/userspace/dpdk/17.08/0007-net-ena-fix-passing-RSS-hash-to-mbuf.patch
@@ -1,7 +1,7 @@
 From 7eac04a7fae3075e05c9e53afb246c169f5f3dd2 Mon Sep 17 00:00:00 2001
 From: Stewart Allen <allenste@amazon.com>
 Date: Thu, 25 Oct 2018 19:59:22 +0200
-Subject: [PATCH 07/15] net/ena: fix passing RSS hash to mbuf
+Subject: [PATCH 07/22] net/ena: fix passing RSS hash to mbuf
 
 [ upstream commit e5df9f33db00eb9d322abaefff30da74fd0e625d ]
 
@@ -19,7 +19,7 @@ Acked-by: Michal Krawczyk <mk@semihalf.com>
  1 file changed, 1 insertion(+), 1 deletion(-)
 
 diff --git a/drivers/net/ena/ena_ethdev.c b/drivers/net/ena/ena_ethdev.c
-index 01c463a33..434f2ecf2 100644
+index 01c463a335..434f2ecf2b 100644
 --- a/drivers/net/ena/ena_ethdev.c
 +++ b/drivers/net/ena/ena_ethdev.c
 @@ -1572,7 +1572,7 @@ static uint16_t eth_ena_recv_pkts(void *rx_queue, struct rte_mbuf **rx_pkts,

--- a/userspace/dpdk/17.08/0008-net-ena-add-supported-RSS-offloads-types.patch
+++ b/userspace/dpdk/17.08/0008-net-ena-add-supported-RSS-offloads-types.patch
@@ -1,7 +1,7 @@
 From 2ce776b0d20f4fc8892bf4511bff6afe5a01ca6b Mon Sep 17 00:00:00 2001
 From: Rafal Kozik <rk@semihalf.com>
 Date: Fri, 14 Dec 2018 14:18:38 +0100
-Subject: [PATCH 08/15] net/ena: add supported RSS offloads types
+Subject: [PATCH 08/22] net/ena: add supported RSS offloads types
 
 [ upstream commit b01ead202beb45346d7daeb2f2b1a608006af644 ]
 
@@ -20,7 +20,7 @@ Acked-by: Michal Krawczyk <mk@semihalf.com>
  1 file changed, 3 insertions(+)
 
 diff --git a/drivers/net/ena/ena_ethdev.c b/drivers/net/ena/ena_ethdev.c
-index 434f2ecf2..97d07adc9 100644
+index 434f2ecf2b..97d07adc92 100644
 --- a/drivers/net/ena/ena_ethdev.c
 +++ b/drivers/net/ena/ena_ethdev.c
 @@ -1492,6 +1492,9 @@ static void ena_infos_get(struct rte_eth_dev *dev,

--- a/userspace/dpdk/17.08/0009-net-ena-update-completion-queue-after-cleanup.patch
+++ b/userspace/dpdk/17.08/0009-net-ena-update-completion-queue-after-cleanup.patch
@@ -1,7 +1,7 @@
 From b3bb9c7d7a41736042caaefeaf5803fe05b511a9 Mon Sep 17 00:00:00 2001
 From: Rafal Kozik <rk@semihalf.com>
 Date: Fri, 14 Dec 2018 14:18:44 +0100
-Subject: [PATCH 09/15] net/ena: update completion queue after cleanup
+Subject: [PATCH 09/22] net/ena: update completion queue after cleanup
 
 [ upstream commit a45462c507e98b49cb5c2302e0be3c72d2e20a1a ]
 
@@ -19,7 +19,7 @@ Acked-by: Michal Krawczyk <mk@semihalf.com>
  1 file changed, 5 insertions(+), 2 deletions(-)
 
 diff --git a/drivers/net/ena/ena_ethdev.c b/drivers/net/ena/ena_ethdev.c
-index 97d07adc9..0ec59a6df 100644
+index 97d07adc92..0ec59a6df5 100644
 --- a/drivers/net/ena/ena_ethdev.c
 +++ b/drivers/net/ena/ena_ethdev.c
 @@ -1586,8 +1586,10 @@ static uint16_t eth_ena_recv_pkts(void *rx_queue, struct rte_mbuf **rx_pkts,

--- a/userspace/dpdk/17.08/0010-net-ena-fix-dev-init-with-multi-process.patch
+++ b/userspace/dpdk/17.08/0010-net-ena-fix-dev-init-with-multi-process.patch
@@ -1,7 +1,7 @@
 From d634c0d8277fb9310918b5ccea0a133d6b4669e9 Mon Sep 17 00:00:00 2001
 From: Michal Krawczyk <mk@semihalf.com>
 Date: Fri, 25 Jan 2019 09:10:25 +0100
-Subject: [PATCH 10/15] net/ena: fix dev init with multi-process
+Subject: [PATCH 10/22] net/ena: fix dev init with multi-process
 
 [ upstream commit fd9768905870856a2340266d25f8c0100dfccfff ]
 
@@ -22,7 +22,7 @@ Signed-off-by: Michal Krawczyk <mk@semihalf.com>
  1 file changed, 6 insertions(+), 5 deletions(-)
 
 diff --git a/drivers/net/ena/ena_ethdev.c b/drivers/net/ena/ena_ethdev.c
-index 0ec59a6df..3409fbbcb 100644
+index 0ec59a6df5..3409fbbcb3 100644
 --- a/drivers/net/ena/ena_ethdev.c
 +++ b/drivers/net/ena/ena_ethdev.c
 @@ -1277,19 +1277,20 @@ static int eth_ena_dev_init(struct rte_eth_dev *eth_dev)

--- a/userspace/dpdk/17.08/0011-net-ena-fix-errno-to-positive-value.patch
+++ b/userspace/dpdk/17.08/0011-net-ena-fix-errno-to-positive-value.patch
@@ -1,7 +1,7 @@
 From 5bcc86fb48a7b6f8483f236e247319e2562c2abf Mon Sep 17 00:00:00 2001
 From: Michal Krawczyk <mk@semihalf.com>
 Date: Fri, 25 Jan 2019 09:10:26 +0100
-Subject: [PATCH 11/15] net/ena: fix errno to positive value
+Subject: [PATCH 11/22] net/ena: fix errno to positive value
 
 [ upstream commit baeed5f404dd1b049118cfec26a2fd3203671572 ]
 
@@ -18,7 +18,7 @@ Signed-off-by: Michal Krawczyk <mk@semihalf.com>
  1 file changed, 3 insertions(+), 3 deletions(-)
 
 diff --git a/drivers/net/ena/ena_ethdev.c b/drivers/net/ena/ena_ethdev.c
-index 3409fbbcb..7480182ca 100644
+index 3409fbbcb3..7480182cae 100644
 --- a/drivers/net/ena/ena_ethdev.c
 +++ b/drivers/net/ena/ena_ethdev.c
 @@ -1637,14 +1637,14 @@ eth_ena_prep_pkts(void *tx_queue, struct rte_mbuf **tx_pkts,

--- a/userspace/dpdk/17.08/0012-net-ena-get-device-info-statically.patch
+++ b/userspace/dpdk/17.08/0012-net-ena-get-device-info-statically.patch
@@ -1,7 +1,7 @@
 From 74655045af1cdaf8f974a9eb1f923c884ba6ed95 Mon Sep 17 00:00:00 2001
 From: Michal Krawczyk <mk@semihalf.com>
 Date: Fri, 15 Feb 2019 09:36:39 +0100
-Subject: [PATCH 12/15] net/ena: get device info statically
+Subject: [PATCH 12/22] net/ena: get device info statically
 
 [ upstream commit 117ba4a60488a0f96a5737f38ddba6d0f9a728b6 ]
 
@@ -22,7 +22,7 @@ Signed-off-by: Michal Krawczyk <mk@semihalf.com>
  2 files changed, 19 insertions(+), 20 deletions(-)
 
 diff --git a/drivers/net/ena/ena_ethdev.c b/drivers/net/ena/ena_ethdev.c
-index 7480182ca..a3ccc1c40 100644
+index 7480182cae..a3ccc1c40e 100644
 --- a/drivers/net/ena/ena_ethdev.c
 +++ b/drivers/net/ena/ena_ethdev.c
 @@ -1361,9 +1361,14 @@ static int eth_ena_dev_init(struct rte_eth_dev *eth_dev)
@@ -93,7 +93,7 @@ index 7480182ca..a3ccc1c40 100644
  		}
  
 diff --git a/drivers/net/ena/ena_ethdev.h b/drivers/net/ena/ena_ethdev.h
-index dc3080ffd..4791c53b5 100644
+index dc3080ffd3..4791c53b5a 100644
 --- a/drivers/net/ena/ena_ethdev.h
 +++ b/drivers/net/ena/ena_ethdev.h
 @@ -143,6 +143,12 @@ struct ena_stats_rx {

--- a/userspace/dpdk/17.08/0013-net-ena-fix-checksum-feature-flag.patch
+++ b/userspace/dpdk/17.08/0013-net-ena-fix-checksum-feature-flag.patch
@@ -1,7 +1,7 @@
 From 45db0a95cf5999981bac2497b1ee8ebd1dc45ef6 Mon Sep 17 00:00:00 2001
 From: Michal Krawczyk <mk@semihalf.com>
 Date: Mon, 8 Apr 2019 12:27:44 +0200
-Subject: [PATCH 13/15] net/ena: fix checksum feature flag
+Subject: [PATCH 13/22] net/ena: fix checksum feature flag
 
 [ upstream commit ef538c1a7f565c9b58518375a500aa864445fd11 ]
 
@@ -18,7 +18,7 @@ Signed-off-by: Michal Krawczyk <mk@semihalf.com>
  1 file changed, 1 insertion(+), 1 deletion(-)
 
 diff --git a/drivers/net/ena/ena_ethdev.c b/drivers/net/ena/ena_ethdev.c
-index a3ccc1c40..97e6bbb85 100644
+index a3ccc1c40e..97e6bbb85d 100644
 --- a/drivers/net/ena/ena_ethdev.c
 +++ b/drivers/net/ena/ena_ethdev.c
 @@ -1366,7 +1366,7 @@ static int eth_ena_dev_init(struct rte_eth_dev *eth_dev)

--- a/userspace/dpdk/17.08/0014-net-ena-fix-Rx-checksum-errors-statistics.patch
+++ b/userspace/dpdk/17.08/0014-net-ena-fix-Rx-checksum-errors-statistics.patch
@@ -1,7 +1,7 @@
 From 719088418df38c06bb6283ec65a76627233f3f00 Mon Sep 17 00:00:00 2001
 From: Michal Krawczyk <mk@semihalf.com>
 Date: Tue, 28 May 2019 10:28:34 +0200
-Subject: [PATCH 14/15] net/ena: fix Rx checksum errors statistics
+Subject: [PATCH 14/22] net/ena: fix Rx checksum errors statistics
 
 [ upstream commit ef74b5f7b69b9502ddab81121611243efcfe1dde ]
 
@@ -21,7 +21,7 @@ Signed-off-by: Michal Krawczyk <mk@semihalf.com>
  1 file changed, 5 insertions(+), 4 deletions(-)
 
 diff --git a/drivers/net/ena/ena_ethdev.c b/drivers/net/ena/ena_ethdev.c
-index 97e6bbb85..96aec5d08 100644
+index 97e6bbb85d..96aec5d086 100644
 --- a/drivers/net/ena/ena_ethdev.c
 +++ b/drivers/net/ena/ena_ethdev.c
 @@ -1569,6 +1569,11 @@ static uint16_t eth_ena_recv_pkts(void *rx_queue, struct rte_mbuf **rx_pkts,

--- a/userspace/dpdk/17.08/0015-net-ena-fix-assigning-NUMA-node-to-IO-queue.patch
+++ b/userspace/dpdk/17.08/0015-net-ena-fix-assigning-NUMA-node-to-IO-queue.patch
@@ -1,7 +1,7 @@
 From fde1f112ac3a6dc67b515c2ca68da113bebd563f Mon Sep 17 00:00:00 2001
 From: Michal Krawczyk <mk@semihalf.com>
 Date: Tue, 4 Jun 2019 12:59:36 +0200
-Subject: [PATCH 15/15] net/ena: fix assigning NUMA node to IO queue
+Subject: [PATCH 15/22] net/ena: fix assigning NUMA node to IO queue
 
 [ upstream commit 4217cb0b7d2c5385f06f531af7f14b860927aba7 ]
 
@@ -23,7 +23,7 @@ Reviewed-by: David Marchand <david.marchand@redhat.com>
  2 files changed, 8 insertions(+), 17 deletions(-)
 
 diff --git a/drivers/net/ena/ena_ethdev.c b/drivers/net/ena/ena_ethdev.c
-index 96aec5d08..023ceb7f3 100644
+index 96aec5d086..023ceb7f32 100644
 --- a/drivers/net/ena/ena_ethdev.c
 +++ b/drivers/net/ena/ena_ethdev.c
 @@ -39,7 +39,6 @@
@@ -106,7 +106,7 @@ index 96aec5d08..023ceb7f3 100644
  
  	rxq->rx_buffer_info = rte_zmalloc("rxq->buffer_info",
 diff --git a/drivers/net/ena/ena_ethdev.h b/drivers/net/ena/ena_ethdev.h
-index 4791c53b5..8d5eb5a7c 100644
+index 4791c53b5a..8d5eb5a7ca 100644
 --- a/drivers/net/ena/ena_ethdev.h
 +++ b/drivers/net/ena/ena_ethdev.h
 @@ -90,6 +90,8 @@ struct ena_ring {

--- a/userspace/dpdk/17.08/0016-net-ena-base-fix-node-deallocation.patch
+++ b/userspace/dpdk/17.08/0016-net-ena-base-fix-node-deallocation.patch
@@ -1,0 +1,59 @@
+From 63cbaf5598f0440bb209d518fdc36575f742dd7c Mon Sep 17 00:00:00 2001
+From: Michal Krawczyk <mk@semihalf.com>
+Date: Thu, 2 Jul 2020 10:25:03 +0000
+Subject: [PATCH 16/22] net/ena/base: fix node deallocation
+
+The memzone handle wasn't saved anywhere - it could cause free of the
+invalid memory, as the mem_handle was never holding the right value.
+
+Signed-off-by: Michal Krawczyk <mk@semihalf.com>
+---
+ drivers/net/ena/base/ena_com.c       | 2 ++
+ drivers/net/ena/base/ena_plat_dpdk.h | 4 +++-
+ 2 files changed, 5 insertions(+), 1 deletion(-)
+
+diff --git a/drivers/net/ena/base/ena_com.c b/drivers/net/ena/base/ena_com.c
+index 38a0587754..1c38a1138d 100644
+--- a/drivers/net/ena/base/ena_com.c
++++ b/drivers/net/ena/base/ena_com.c
+@@ -347,6 +347,7 @@ static int ena_com_init_io_sq(struct ena_com_dev *ena_dev,
+ 					    size,
+ 					    io_sq->desc_addr.virt_addr,
+ 					    io_sq->desc_addr.phys_addr,
++					    io_sq->desc_addr.mem_handle,
+ 					    ctx->numa_node,
+ 					    dev_node);
+ 		if (!io_sq->desc_addr.virt_addr)
+@@ -400,6 +401,7 @@ static int ena_com_init_io_cq(struct ena_com_dev *ena_dev,
+ 				    size,
+ 				    io_cq->cdesc_addr.virt_addr,
+ 				    io_cq->cdesc_addr.phys_addr,
++				    io_cq->cdesc_addr.mem_handle,
+ 				    ctx->numa_node,
+ 				    prev_node);
+ 	if (!io_cq->cdesc_addr.virt_addr)
+diff --git a/drivers/net/ena/base/ena_plat_dpdk.h b/drivers/net/ena/base/ena_plat_dpdk.h
+index 06b6378708..2c7887c190 100644
+--- a/drivers/net/ena/base/ena_plat_dpdk.h
++++ b/drivers/net/ena/base/ena_plat_dpdk.h
+@@ -206,7 +206,8 @@ typedef uint64_t dma_addr_t;
+ 		   ENA_TOUCH(dmadev);					\
+ 		   rte_memzone_free(handle); })
+ 
+-#define ENA_MEM_ALLOC_COHERENT_NODE(dmadev, size, virt, phys, node, dev_node) \
++#define ENA_MEM_ALLOC_COHERENT_NODE(					\
++	dmadev, size, virt, phys, mem_handle, node, dev_node)		\
+ 	do {								\
+ 		const struct rte_memzone *mz;				\
+ 		char z_name[RTE_MEMZONE_NAMESIZE];			\
+@@ -214,6 +215,7 @@ typedef uint64_t dma_addr_t;
+ 		snprintf(z_name, sizeof(z_name),			\
+ 				"ena_alloc_%d", ena_alloc_cnt++);	\
+ 		mz = rte_memzone_reserve(z_name, size, node, 0); \
++		mem_handle = mz;					\
+ 		if (mz == NULL) {					\
+ 			virt = NULL;					\
+ 			phys = 0;					\
+-- 
+2.20.1
+

--- a/userspace/dpdk/17.08/0017-net-ena-fix-indication-of-bad-L4-Rx-checksums.patch
+++ b/userspace/dpdk/17.08/0017-net-ena-fix-indication-of-bad-L4-Rx-checksums.patch
@@ -1,0 +1,44 @@
+From b0da6c27fd6e494e2c5c9c32a12fd2b1d3afbd04 Mon Sep 17 00:00:00 2001
+From: Igor Chauskin <igorch@amazon.com>
+Date: Mon, 28 Oct 2019 11:23:33 +0100
+Subject: [PATCH 17/22] net/ena: fix indication of bad L4 Rx checksums
+
+[ upstream commit 05817057faba9356900ced61e24a22eef6bc4c87 ]
+
+Add checking of l4_csum_checked and frag flags before checking the
+l4_csum_error flag.
+
+In case of IP fragment/unchecked L4 csum - add PKT_RX_L4_CKSUM_UNKNOWN
+flag to the indicated mbuf.
+
+Fixes: 1173fca25af9 ("ena: add polling-mode driver")
+Cc: stable@dpdk.org
+
+Change-Id: I9f1414741eb44ca289a8bfd11d7e66110c95040e
+Signed-off-by: Igor Chauskin <igorch@amazon.com>
+Reviewed-by: Maciej Bielski <mba@semihalf.com>
+Reviewed-by: Michal Krawczyk <mk@semihalf.com>
+---
+ drivers/net/ena/ena_ethdev.c | 5 ++++-
+ 1 file changed, 4 insertions(+), 1 deletion(-)
+
+diff --git a/drivers/net/ena/ena_ethdev.c b/drivers/net/ena/ena_ethdev.c
+index 023ceb7f32..14af5bd379 100644
+--- a/drivers/net/ena/ena_ethdev.c
++++ b/drivers/net/ena/ena_ethdev.c
+@@ -259,8 +259,11 @@ static inline void ena_rx_mbuf_prepare(struct rte_mbuf *mbuf,
+ 	else if (ena_rx_ctx->l3_proto == ENA_ETH_IO_L3_PROTO_IPV6)
+ 		packet_type |= RTE_PTYPE_L3_IPV6;
+ 
+-	if (unlikely(ena_rx_ctx->l4_csum_err))
++	if (unlikely(ena_rx_ctx->l4_csum_err) && !ena_rx_ctx->frag)
+ 		ol_flags |= PKT_RX_L4_CKSUM_BAD;
++	else
++		ol_flags |= PKT_RX_L4_CKSUM_UNKNOWN;
++
+ 	if (unlikely(ena_rx_ctx->l3_csum_err))
+ 		ol_flags |= PKT_RX_IP_CKSUM_BAD;
+ 
+-- 
+2.20.1
+

--- a/userspace/dpdk/17.08/0018-net-ena-ensure-Rx-buffer-size-is-at-least-1400B.patch
+++ b/userspace/dpdk/17.08/0018-net-ena-ensure-Rx-buffer-size-is-at-least-1400B.patch
@@ -1,0 +1,84 @@
+From d4b3b07189bccf1d1aa09e8e5140c54608c8136f Mon Sep 17 00:00:00 2001
+From: Michal Krawczyk <mk@semihalf.com>
+Date: Wed, 8 Apr 2020 10:28:52 +0200
+Subject: [PATCH 18/22] net/ena: ensure Rx buffer size is at least 1400B
+
+[ upstream commit 38364c2687ead97b99402310087c27131a97748c ]
+
+Some of the ENA devices can't handle buffers which are smaller than a
+1400B. Because of this limitation, size of the buffer is being checked
+and limited during the Rx queue setup.
+
+If it's below the allowed value, PMD won't finish it's configuration
+successfully..
+
+Change-Id: Ib402d3bfad98a3fc4f91095d5c6f90c6069da021
+Signed-off-by: Michal Krawczyk <mk@semihalf.com>
+Reviewed-by: Igor Chauskin <igorch@amazon.com>
+Reviewed-by: Guy Tzalik <gtzalik@amazon.com>
+---
+ drivers/net/ena/ena_ethdev.c | 12 +++++++++++-
+ drivers/net/ena/ena_ethdev.h |  3 ++-
+ 2 files changed, 13 insertions(+), 2 deletions(-)
+
+diff --git a/drivers/net/ena/ena_ethdev.c b/drivers/net/ena/ena_ethdev.c
+index 14af5bd379..71ea4b5a61 100644
+--- a/drivers/net/ena/ena_ethdev.c
++++ b/drivers/net/ena/ena_ethdev.c
+@@ -1,7 +1,7 @@
+ /*-
+ * BSD LICENSE
+ *
+-* Copyright (c) 2015-2016 Amazon.com, Inc. or its affiliates.
++* Copyright (c) 2015-2020 Amazon.com, Inc. or its affiliates.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+@@ -1049,6 +1049,7 @@ static int ena_rx_queue_setup(struct rte_eth_dev *dev,
+ 	struct ena_adapter *adapter =
+ 		(struct ena_adapter *)(dev->data->dev_private);
+ 	struct ena_ring *rxq = NULL;
++	size_t buffer_size;
+ 	uint16_t ena_qid = 0;
+ 	int rc = 0;
+ 	struct ena_com_dev *ena_dev = &adapter->ena_dev;
+@@ -1075,6 +1076,15 @@ static int ena_rx_queue_setup(struct rte_eth_dev *dev,
+ 		return -EINVAL;
+ 	}
+ 
++	/* ENA isn't supporting buffers smaller than 1400 bytes */
++	buffer_size = rte_pktmbuf_data_room_size(mp) - RTE_PKTMBUF_HEADROOM;
++	if (buffer_size < ENA_RX_BUF_MIN_SIZE) {
++		PMD_DRV_LOG(ERR,
++			"Unsupported size of RX buffer: %zu (min size: %d)\n",
++			buffer_size, ENA_RX_BUF_MIN_SIZE);
++		return -EINVAL;
++	}
++
+ 	ena_qid = ENA_IO_RXQ_IDX(queue_idx);
+ 
+ 	ctx.qid = ena_qid;
+diff --git a/drivers/net/ena/ena_ethdev.h b/drivers/net/ena/ena_ethdev.h
+index 8d5eb5a7ca..d6e5e730e1 100644
+--- a/drivers/net/ena/ena_ethdev.h
++++ b/drivers/net/ena/ena_ethdev.h
+@@ -1,7 +1,7 @@
+ /*-
+ * BSD LICENSE
+ *
+-* Copyright (c) 2015-2016 Amazon.com, Inc. or its affiliates.
++* Copyright (c) 2015-2020 Amazon.com, Inc. or its affiliates.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+@@ -46,6 +46,7 @@
+ #define ENA_MIN_FRAME_LEN	64
+ #define ENA_NAME_MAX_LEN	20
+ #define ENA_PKT_MAX_BUFS	17
++#define ENA_RX_BUF_MIN_SIZE	1400
+ 
+ #define ENA_MMIO_DISABLE_REG_READ	BIT(0)
+ 
+-- 
+2.20.1
+

--- a/userspace/dpdk/17.08/0019-net-ena-base-make-allocation-macros-thread-safe.patch
+++ b/userspace/dpdk/17.08/0019-net-ena-base-make-allocation-macros-thread-safe.patch
@@ -1,0 +1,103 @@
+From cebb205392f01b07d239375f7d55d5c49d0206c6 Mon Sep 17 00:00:00 2001
+From: Igor Chauskin <igorch@amazon.com>
+Date: Wed, 8 Apr 2020 10:28:53 +0200
+Subject: [PATCH 19/22] net/ena/base: make allocation macros thread-safe
+
+[ upstream commit b14fcac035fd8514851c9140a4e26d765b61c532 ]
+
+Memory allocation region id could possibly be non-unique
+due to non-atomic increment, causing allocation failure.
+
+Fixes: 9ba7981ec992 ("ena: add communication layer for DPDK")
+Cc: stable@dpdk.org
+
+Change-Id: Ib9207aaae4e5e7ecdf1a99a0f23a508a53af631d
+Signed-off-by: Igor Chauskin <igorch@amazon.com>
+Reviewed-by: Michal Krawczyk <mk@semihalf.com>
+Reviewed-by: Guy Tzalik <gtzalik@amazon.com>
+---
+ drivers/net/ena/base/ena_com.c       |  2 --
+ drivers/net/ena/base/ena_plat_dpdk.h | 16 ++++++++++++----
+ drivers/net/ena/ena_ethdev.c         |  6 ++++++
+ 3 files changed, 18 insertions(+), 6 deletions(-)
+
+diff --git a/drivers/net/ena/base/ena_com.c b/drivers/net/ena/base/ena_com.c
+index 1c38a1138d..0dbd1b0cd0 100644
+--- a/drivers/net/ena/base/ena_com.c
++++ b/drivers/net/ena/base/ena_com.c
+@@ -62,8 +62,6 @@
+ 
+ #define ENA_MMIO_READ_TIMEOUT 0xFFFFFFFF
+ 
+-static int ena_alloc_cnt;
+-
+ /*****************************************************************************/
+ /*****************************************************************************/
+ /*****************************************************************************/
+diff --git a/drivers/net/ena/base/ena_plat_dpdk.h b/drivers/net/ena/base/ena_plat_dpdk.h
+index 2c7887c190..791471adbd 100644
+--- a/drivers/net/ena/base/ena_plat_dpdk.h
++++ b/drivers/net/ena/base/ena_plat_dpdk.h
+@@ -1,7 +1,7 @@
+ /*-
+ * BSD LICENSE
+ *
+-* Copyright (c) 2015-2016 Amazon.com, Inc. or its affiliates.
++* Copyright (c) 2015-2020 Amazon.com, Inc. or its affiliates.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+@@ -183,13 +183,20 @@ typedef uint64_t dma_addr_t;
+ #define ena_wait_event_t ena_wait_queue_t
+ #define ENA_MIGHT_SLEEP()
+ 
++/*
++ * Each rte_memzone should have unique name.
++ * To satisfy it, count number of allocations and add it to name.
++ */
++extern rte_atomic32_t ena_alloc_cnt;
++
+ #define ENA_MEM_ALLOC_COHERENT(dmadev, size, virt, phys, handle)	\
+ 	do {								\
+ 		const struct rte_memzone *mz;				\
+ 		char z_name[RTE_MEMZONE_NAMESIZE];			\
+ 		ENA_TOUCH(dmadev); ENA_TOUCH(handle);			\
+ 		snprintf(z_name, sizeof(z_name),			\
+-				"ena_alloc_%d", ena_alloc_cnt++);	\
++			 "ena_alloc_%d",				\
++			 rte_atomic32_add_return(&ena_alloc_cnt, 1));	\
+ 		mz = rte_memzone_reserve(z_name, size, SOCKET_ID_ANY, 0); \
+ 		handle = mz;						\
+ 		if (mz == NULL) {					\
+@@ -213,8 +220,9 @@ typedef uint64_t dma_addr_t;
+ 		char z_name[RTE_MEMZONE_NAMESIZE];			\
+ 		ENA_TOUCH(dmadev); ENA_TOUCH(dev_node);			\
+ 		snprintf(z_name, sizeof(z_name),			\
+-				"ena_alloc_%d", ena_alloc_cnt++);	\
+-		mz = rte_memzone_reserve(z_name, size, node, 0); \
++			 "ena_alloc_%d",				\
++			 rte_atomic32_add_return(&ena_alloc_cnt, 1));	\
++		mz = rte_memzone_reserve(z_name, size, node, 0);	\
+ 		mem_handle = mz;					\
+ 		if (mz == NULL) {					\
+ 			virt = NULL;					\
+diff --git a/drivers/net/ena/ena_ethdev.c b/drivers/net/ena/ena_ethdev.c
+index 71ea4b5a61..15b3d373a0 100644
+--- a/drivers/net/ena/ena_ethdev.c
++++ b/drivers/net/ena/ena_ethdev.c
+@@ -113,6 +113,12 @@ struct ena_stats {
+ #define ENA_STAT_GLOBAL_ENTRY(stat) \
+ 	ENA_STAT_ENTRY(stat, dev)
+ 
++/*
++ * Each rte_memzone should have unique name.
++ * To satisfy it, count number of allocation and add it to name.
++ */
++rte_atomic32_t ena_alloc_cnt;
++
+ static const struct ena_stats ena_stats_global_strings[] = {
+ 	ENA_STAT_GLOBAL_ENTRY(tx_timeout),
+ 	ENA_STAT_GLOBAL_ENTRY(io_suspend),
+-- 
+2.20.1
+

--- a/userspace/dpdk/17.08/0020-net-ena-base-prevent-allocation-of-zero-sized-memory.patch
+++ b/userspace/dpdk/17.08/0020-net-ena-base-prevent-allocation-of-zero-sized-memory.patch
@@ -1,0 +1,74 @@
+From 9ca0dcee14bcfae34b223dd1ad838974cc9d1194 Mon Sep 17 00:00:00 2001
+From: Igor Chauskin <igorch@amazon.com>
+Date: Wed, 8 Apr 2020 10:28:54 +0200
+Subject: [PATCH 20/22] net/ena/base: prevent allocation of zero sized memory
+
+[ upstream commit 29dc10d9424ccf26a346387b0a707185e2432400 ]
+
+rte_memzone_reserve() will reserve the biggest contiguous memzone
+available if received 0 as size param.
+
+Fixes: 9ba7981ec992 ("ena: add communication layer for DPDK")
+Cc: stable@dpdk.org
+
+Change-Id: I2f71119e93c5e9addd8c538820093f030066d690
+Signed-off-by: Igor Chauskin <igorch@amazon.com>
+Reviewed-by: Michal Krawczyk <mk@semihalf.com>
+Reviewed-by: Guy Tzalik <gtzalik@amazon.com>
+---
+ drivers/net/ena/base/ena_plat_dpdk.h | 27 ++++++++++++++++-----------
+ 1 file changed, 16 insertions(+), 11 deletions(-)
+
+diff --git a/drivers/net/ena/base/ena_plat_dpdk.h b/drivers/net/ena/base/ena_plat_dpdk.h
+index 791471adbd..f3820d5ebd 100644
+--- a/drivers/net/ena/base/ena_plat_dpdk.h
++++ b/drivers/net/ena/base/ena_plat_dpdk.h
+@@ -191,14 +191,17 @@ extern rte_atomic32_t ena_alloc_cnt;
+ 
+ #define ENA_MEM_ALLOC_COHERENT(dmadev, size, virt, phys, handle)	\
+ 	do {								\
+-		const struct rte_memzone *mz;				\
+-		char z_name[RTE_MEMZONE_NAMESIZE];			\
++		const struct rte_memzone *mz = NULL;			\
+ 		ENA_TOUCH(dmadev); ENA_TOUCH(handle);			\
+-		snprintf(z_name, sizeof(z_name),			\
++		if (size > 0) {						\
++			char z_name[RTE_MEMZONE_NAMESIZE];		\
++			snprintf(z_name, sizeof(z_name),		\
+ 			 "ena_alloc_%d",				\
+ 			 rte_atomic32_add_return(&ena_alloc_cnt, 1));	\
+-		mz = rte_memzone_reserve(z_name, size, SOCKET_ID_ANY, 0); \
+-		handle = mz;						\
++			mz = rte_memzone_reserve(z_name, size,		\
++				SOCKET_ID_ANY, 0);			\
++			handle = mz;					\
++		}							\
+ 		if (mz == NULL) {					\
+ 			virt = NULL;					\
+ 			phys = 0;					\
+@@ -216,14 +219,16 @@ extern rte_atomic32_t ena_alloc_cnt;
+ #define ENA_MEM_ALLOC_COHERENT_NODE(					\
+ 	dmadev, size, virt, phys, mem_handle, node, dev_node)		\
+ 	do {								\
+-		const struct rte_memzone *mz;				\
+-		char z_name[RTE_MEMZONE_NAMESIZE];			\
++		const struct rte_memzone *mz = NULL;			\
+ 		ENA_TOUCH(dmadev); ENA_TOUCH(dev_node);			\
+-		snprintf(z_name, sizeof(z_name),			\
++		if (size > 0) {						\
++			char z_name[RTE_MEMZONE_NAMESIZE];		\
++			snprintf(z_name, sizeof(z_name),		\
+ 			 "ena_alloc_%d",				\
+-			 rte_atomic32_add_return(&ena_alloc_cnt, 1));	\
+-		mz = rte_memzone_reserve(z_name, size, node, 0);	\
+-		mem_handle = mz;					\
++			 rte_atomic32_add_return(&ena_alloc_cnt, 1));   \
++			mz = rte_memzone_reserve(z_name, size, node, 0); \
++			mem_handle = mz;				\
++		}							\
+ 		if (mz == NULL) {					\
+ 			virt = NULL;					\
+ 			phys = 0;					\
+-- 
+2.20.1
+

--- a/userspace/dpdk/17.08/0021-net-ena-set-IO-ring-size-to-valid-value.patch
+++ b/userspace/dpdk/17.08/0021-net-ena-set-IO-ring-size-to-valid-value.patch
@@ -1,0 +1,49 @@
+From e1fca328583876bd99bb108a33a46cc2c8a4d286 Mon Sep 17 00:00:00 2001
+From: Michal Krawczyk <mk@semihalf.com>
+Date: Fri, 3 Jul 2020 13:14:58 +0000
+Subject: [PATCH 21/22] net/ena: set IO ring size to valid value
+
+[ upstream commit badc3a6aa133a886a61b9e3ad666e5675f7ec3d3 ]
+
+IO rings were configured with the maximum allowed size for the Tx/Rx
+rings. However, the application could decide to create smaller rings.
+
+This patch is using value stored in the ring instead of the value from
+the adapter which is indicating the maximum allowed value.
+
+Fixes: df238f84c0a2 ("net/ena: recreate HW IO rings on start and stop")
+Cc: stable@dpdk.org
+
+Change-Id: Icf9102e2aa4e7413b6620b36dd232673239b7291
+Signed-off-by: Michal Krawczyk <mk@semihalf.com>
+Reviewed-by: Igor Chauskin <igorch@amazon.com>
+Reviewed-by: Guy Tzalik <gtzalik@amazon.com>
+---
+ drivers/net/ena/ena_ethdev.c | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/drivers/net/ena/ena_ethdev.c b/drivers/net/ena/ena_ethdev.c
+index 15b3d373a0..46c23f85b0 100644
+--- a/drivers/net/ena/ena_ethdev.c
++++ b/drivers/net/ena/ena_ethdev.c
+@@ -985,7 +985,7 @@ static int ena_tx_queue_setup(struct rte_eth_dev *dev,
+ 	ctx.qid = ena_qid;
+ 	ctx.msix_vector = -1; /* admin interrupts not used */
+ 	ctx.mem_queue_type = ena_dev->tx_mem_queue_type;
+-	ctx.queue_size = adapter->tx_ring_size;
++	ctx.queue_size = nb_desc;
+ 	ctx.numa_node = socket_id;
+ 
+ 	rc = ena_com_create_io_queue(ena_dev, &ctx);
+@@ -1097,7 +1097,7 @@ static int ena_rx_queue_setup(struct rte_eth_dev *dev,
+ 	ctx.direction = ENA_COM_IO_QUEUE_DIRECTION_RX;
+ 	ctx.mem_queue_type = ENA_ADMIN_PLACEMENT_POLICY_HOST;
+ 	ctx.msix_vector = -1; /* admin interrupts not used */
+-	ctx.queue_size = adapter->rx_ring_size;
++	ctx.queue_size = nb_desc;
+ 	ctx.numa_node = socket_id;
+ 
+ 	rc = ena_com_create_io_queue(ena_dev, &ctx);
+-- 
+2.20.1
+

--- a/userspace/dpdk/17.08/0022-net-ena-limit-refill-threshold-by-fixed-value.patch
+++ b/userspace/dpdk/17.08/0022-net-ena-limit-refill-threshold-by-fixed-value.patch
@@ -1,0 +1,118 @@
+From 563d9118ca0280cef265892791412e86e33856d0 Mon Sep 17 00:00:00 2001
+From: Michal Krawczyk <mk@semihalf.com>
+Date: Wed, 8 Apr 2020 10:29:16 +0200
+Subject: [PATCH 22/22] net/ena: limit refill threshold by fixed value
+
+[ upstream commit 7755060798de9c0146df8809926030ed47fc9086 ]
+
+Divider used for both Tx and Rx cleanup/refill threshold can cause too
+big delay in case of the really big rings - for example if the 8k Rx
+ring will be used, the refill won't trigger unless 1024 threshold will
+be reached. It will also cause driver to try to allocate that much
+descriptors.
+
+Limiting it by fixed value - 256 in that case, would limit maximum
+time spent in repopulate function.
+
+Change-Id: Ia8659e6ddf179ff612a780adc6fe55d13eeac6e9
+Signed-off-by: Michal Krawczyk <mk@semihalf.com>
+Reviewed-by: Igor Chauskin <igorch@amazon.com>
+Reviewed-by: Guy Tzalik <gtzalik@amazon.com>
+---
+ drivers/net/ena/ena_ethdev.c | 26 ++++++++++++++------------
+ drivers/net/ena/ena_ethdev.h | 10 ++++++++++
+ 2 files changed, 24 insertions(+), 12 deletions(-)
+
+diff --git a/drivers/net/ena/ena_ethdev.c b/drivers/net/ena/ena_ethdev.c
+index 46c23f85b0..608c5228fb 100644
+--- a/drivers/net/ena/ena_ethdev.c
++++ b/drivers/net/ena/ena_ethdev.c
+@@ -61,14 +61,6 @@
+ /*reverse version of ENA_IO_RXQ_IDX*/
+ #define ENA_IO_RXQ_IDX_REV(q)	((q - 1) / 2)
+ 
+-/* While processing submitted and completed descriptors (rx and tx path
+- * respectively) in a loop it is desired to:
+- *  - perform batch submissions while populating sumbissmion queue
+- *  - avoid blocking transmission of other packets during cleanup phase
+- * Hence the utilization ratio of 1/8 of a queue size.
+- */
+-#define ENA_RING_DESCS_RATIO(ring_size)	(ring_size / 8)
+-
+ #define __MERGE_64B_H_L(h, l) (((uint64_t)h << 32) | l)
+ #define TEST_BIT(val, bit_shift) (val & (1UL << bit_shift))
+ 
+@@ -1512,6 +1504,8 @@ static uint16_t eth_ena_recv_pkts(void *rx_queue, struct rte_mbuf **rx_pkts,
+ 	struct ena_ring *rx_ring = (struct ena_ring *)(rx_queue);
+ 	unsigned int ring_size = rx_ring->ring_size;
+ 	unsigned int ring_mask = ring_size - 1;
++	unsigned int free_queue_entries;
++	unsigned int refill_threshold;
+ 	uint16_t next_to_clean = rx_ring->next_to_clean;
+ 	uint16_t desc_in_use = 0;
+ 	unsigned int recv_idx = 0;
+@@ -1591,11 +1585,15 @@ static uint16_t eth_ena_recv_pkts(void *rx_queue, struct rte_mbuf **rx_pkts,
+ 
+ 	rx_ring->next_to_clean = next_to_clean;
+ 
+-	desc_in_use = desc_in_use - completed + 1;
++	free_queue_entries = ena_com_sq_empty_space(rx_ring->ena_com_io_sq);
++	refill_threshold =
++		RTE_MIN(ring_size / ENA_REFILL_THRESH_DIVIDER,
++		(unsigned int)ENA_REFILL_THRESH_PACKET);
++
+ 	/* Burst refill to save doorbells, memory barriers, const interval */
+-	if (ring_size - desc_in_use > ENA_RING_DESCS_RATIO(ring_size)) {
++	if (free_queue_entries > refill_threshold) {
+ 		ena_com_update_dev_comp_head(rx_ring->ena_com_io_cq);
+-		ena_populate_rx_queue(rx_ring, ring_size - desc_in_use);
++		ena_populate_rx_queue(rx_ring, free_queue_entries);
+ 	}
+ 
+ 	return recv_idx;
+@@ -1680,6 +1678,7 @@ static uint16_t eth_ena_xmit_pkts(void *tx_queue, struct rte_mbuf **tx_pkts,
+ 	struct rte_mbuf *mbuf;
+ 	unsigned int ring_size = tx_ring->ring_size;
+ 	unsigned int ring_mask = ring_size - 1;
++	unsigned int cleanup_budget;
+ 	struct ena_com_tx_ctx ena_tx_ctx;
+ 	struct ena_tx_buffer *tx_info;
+ 	struct ena_com_buf *ebuf;
+@@ -1786,9 +1785,12 @@ static uint16_t eth_ena_xmit_pkts(void *tx_queue, struct rte_mbuf **tx_pkts,
+ 		/* Put back descriptor to the ring for reuse */
+ 		tx_ring->empty_tx_reqs[next_to_clean & ring_mask] = req_id;
+ 		next_to_clean++;
++		cleanup_budget =
++			RTE_MIN(ring_size / ENA_REFILL_THRESH_DIVIDER,
++			(unsigned int)ENA_REFILL_THRESH_PACKET);
+ 
+ 		/* If too many descs to clean, leave it for another run */
+-		if (unlikely(total_tx_descs > ENA_RING_DESCS_RATIO(ring_size)))
++		if (unlikely(total_tx_descs > cleanup_budget))
+ 			break;
+ 	}
+ 
+diff --git a/drivers/net/ena/ena_ethdev.h b/drivers/net/ena/ena_ethdev.h
+index d6e5e730e1..2b02806db5 100644
+--- a/drivers/net/ena/ena_ethdev.h
++++ b/drivers/net/ena/ena_ethdev.h
+@@ -50,6 +50,16 @@
+ 
+ #define ENA_MMIO_DISABLE_REG_READ	BIT(0)
+ 
++/* While processing submitted and completed descriptors (rx and tx path
++ * respectively) in a loop it is desired to:
++ *  - perform batch submissions while populating sumbissmion queue
++ *  - avoid blocking transmission of other packets during cleanup phase
++ * Hence the utilization ratio of 1/8 of a queue size or max value if the size
++ * of the ring is very big - like 8k Rx rings.
++ */
++#define ENA_REFILL_THRESH_DIVIDER      8
++#define ENA_REFILL_THRESH_PACKET       256
++
+ struct ena_adapter;
+ 
+ enum ena_ring_type {
+-- 
+2.20.1
+

--- a/userspace/dpdk/17.11/0001-net-ena-do-not-set-Tx-L4-offloads-in-Rx-path.patch
+++ b/userspace/dpdk/17.11/0001-net-ena-do-not-set-Tx-L4-offloads-in-Rx-path.patch
@@ -1,7 +1,7 @@
 From 64096abb852296cb7329e753b26c941a8ed24281 Mon Sep 17 00:00:00 2001
 From: Rafal Kozik <rk@semihalf.com>
 Date: Tue, 9 Jan 2018 16:19:08 +0100
-Subject: [PATCH 01/15] net/ena: do not set Tx L4 offloads in Rx path
+Subject: [PATCH 01/22] net/ena: do not set Tx L4 offloads in Rx path
 
 [ upstream commit fd617795679019c7aea5ab1e8c85db02cf53f169 ]
 
@@ -23,7 +23,7 @@ Signed-off-by: Michal Krawczyk <mk@semihalf.com>
  1 file changed, 6 insertions(+), 4 deletions(-)
 
 diff --git a/drivers/net/ena/ena_ethdev.c b/drivers/net/ena/ena_ethdev.c
-index 22db8951f..aa24ef36a 100644
+index 22db8951f2..aa24ef36a5 100644
 --- a/drivers/net/ena/ena_ethdev.c
 +++ b/drivers/net/ena/ena_ethdev.c
 @@ -260,16 +260,17 @@ static inline void ena_rx_mbuf_prepare(struct rte_mbuf *mbuf,

--- a/userspace/dpdk/17.11/0002-net-ena-check-pointer-before-memset.patch
+++ b/userspace/dpdk/17.11/0002-net-ena-check-pointer-before-memset.patch
@@ -1,7 +1,7 @@
 From 151a5a389bb985a987f8f79389b0f6026d88fb25 Mon Sep 17 00:00:00 2001
 From: Rafal Kozik <rk@semihalf.com>
 Date: Thu, 7 Jun 2018 11:43:18 +0200
-Subject: [PATCH 02/15] net/ena: check pointer before memset
+Subject: [PATCH 02/22] net/ena: check pointer before memset
 
 [ upstream commit 46916aa17d4b2007df8c0454f99ba0ca8b8cb93b ]
 
@@ -19,7 +19,7 @@ Acked-by: Michal Krawczyk <mk@semihalf.com>
  1 file changed, 16 insertions(+), 6 deletions(-)
 
 diff --git a/drivers/net/ena/base/ena_plat_dpdk.h b/drivers/net/ena/base/ena_plat_dpdk.h
-index accecf518..362741aa2 100644
+index accecf5184..362741aa22 100644
 --- a/drivers/net/ena/base/ena_plat_dpdk.h
 +++ b/drivers/net/ena/base/ena_plat_dpdk.h
 @@ -189,10 +189,15 @@ typedef uint64_t dma_addr_t;

--- a/userspace/dpdk/17.11/0003-net-ena-change-memory-type.patch
+++ b/userspace/dpdk/17.11/0003-net-ena-change-memory-type.patch
@@ -1,7 +1,7 @@
 From e3963399ec5f886d6ea6d9b3c16d7241f3684f9f Mon Sep 17 00:00:00 2001
 From: Rafal Kozik <rk@semihalf.com>
 Date: Thu, 7 Jun 2018 11:43:19 +0200
-Subject: [PATCH 03/15] net/ena: change memory type
+Subject: [PATCH 03/22] net/ena: change memory type
 
 [ upstream commit 9f32c7e7e6ce58ab772913f54f8328c1c0186a17 ]
 
@@ -22,7 +22,7 @@ Acked-by: Michal Krawczyk <mk@semihalf.com>
  1 file changed, 1 insertion(+), 7 deletions(-)
 
 diff --git a/drivers/net/ena/base/ena_plat_dpdk.h b/drivers/net/ena/base/ena_plat_dpdk.h
-index 362741aa2..8363fb482 100644
+index 362741aa22..8363fb4821 100644
 --- a/drivers/net/ena/base/ena_plat_dpdk.h
 +++ b/drivers/net/ena/base/ena_plat_dpdk.h
 @@ -224,14 +224,8 @@ typedef uint64_t dma_addr_t;

--- a/userspace/dpdk/17.11/0004-net-ena-fix-GENMASK_ULL-macro.patch
+++ b/userspace/dpdk/17.11/0004-net-ena-fix-GENMASK_ULL-macro.patch
@@ -1,7 +1,7 @@
 From 94769c8103486abbb01d5efdf34f76cb35c0ca54 Mon Sep 17 00:00:00 2001
 From: Rafal Kozik <rk@semihalf.com>
 Date: Thu, 7 Jun 2018 11:43:20 +0200
-Subject: [PATCH 04/15] net/ena: fix GENMASK_ULL macro
+Subject: [PATCH 04/22] net/ena: fix GENMASK_ULL macro
 
 [ upstream commit 7544aee8d0b4ae0262b1ba7e1539cf8171664df7 ]
 
@@ -20,7 +20,7 @@ Acked-by: Michal Krawczyk <mk@semihalf.com>
  1 file changed, 3 insertions(+), 1 deletion(-)
 
 diff --git a/drivers/net/ena/base/ena_plat_dpdk.h b/drivers/net/ena/base/ena_plat_dpdk.h
-index 8363fb482..ea78e8d72 100644
+index 8363fb4821..ea78e8d72f 100644
 --- a/drivers/net/ena/base/ena_plat_dpdk.h
 +++ b/drivers/net/ena/base/ena_plat_dpdk.h
 @@ -116,11 +116,13 @@ typedef uint64_t dma_addr_t;

--- a/userspace/dpdk/17.11/0005-net-ena-set-link-speed-as-none.patch
+++ b/userspace/dpdk/17.11/0005-net-ena-set-link-speed-as-none.patch
@@ -1,7 +1,7 @@
 From 62eaabd44f665778739c50ce2f4076928366add5 Mon Sep 17 00:00:00 2001
 From: Rafal Kozik <rk@semihalf.com>
 Date: Thu, 7 Jun 2018 11:43:22 +0200
-Subject: [PATCH 05/15] net/ena: set link speed as none
+Subject: [PATCH 05/22] net/ena: set link speed as none
 
 [ upstream commit 41e59028dd8ab2038a7655c6fc3098222661aa53 ]
 
@@ -21,7 +21,7 @@ Acked-by: Michal Krawczyk <mk@semihalf.com>
  1 file changed, 1 insertion(+), 1 deletion(-)
 
 diff --git a/drivers/net/ena/ena_ethdev.c b/drivers/net/ena/ena_ethdev.c
-index aa24ef36a..32fcc0dc8 100644
+index aa24ef36a5..32fcc0dc83 100644
 --- a/drivers/net/ena/ena_ethdev.c
 +++ b/drivers/net/ena/ena_ethdev.c
 @@ -709,7 +709,7 @@ static int ena_link_update(struct rte_eth_dev *dev,

--- a/userspace/dpdk/17.11/0006-net-ena-fix-SIGFPE-with-0-Rx-queue.patch
+++ b/userspace/dpdk/17.11/0006-net-ena-fix-SIGFPE-with-0-Rx-queue.patch
@@ -1,7 +1,7 @@
 From d89b7d3288a278548b5ce9686effd57195f96510 Mon Sep 17 00:00:00 2001
 From: Daria Kolistratova <daria.kolistratova@intel.com>
 Date: Tue, 26 Jun 2018 18:38:56 +0100
-Subject: [PATCH 06/15] net/ena: fix SIGFPE with 0 Rx queue
+Subject: [PATCH 06/22] net/ena: fix SIGFPE with 0 Rx queue
 
 [ upstream commit 361913ad6f8c05fc541fe4bfdae3b0dc095ae3af ]
 
@@ -19,7 +19,7 @@ Acked-by: Michal Krawczyk <mk@semihalf.com>
  1 file changed, 1 insertion(+), 1 deletion(-)
 
 diff --git a/drivers/net/ena/ena_ethdev.c b/drivers/net/ena/ena_ethdev.c
-index 32fcc0dc8..4e5265679 100644
+index 32fcc0dc83..4e52656798 100644
 --- a/drivers/net/ena/ena_ethdev.c
 +++ b/drivers/net/ena/ena_ethdev.c
 @@ -907,7 +907,7 @@ static int ena_start(struct rte_eth_dev *dev)

--- a/userspace/dpdk/17.11/0007-net-ena-fix-passing-RSS-hash-to-mbuf.patch
+++ b/userspace/dpdk/17.11/0007-net-ena-fix-passing-RSS-hash-to-mbuf.patch
@@ -1,7 +1,7 @@
 From 92768ea1c337a8b7826d9cd5580df1760ba63a52 Mon Sep 17 00:00:00 2001
 From: Stewart Allen <allenste@amazon.com>
 Date: Thu, 25 Oct 2018 19:59:22 +0200
-Subject: [PATCH 07/15] net/ena: fix passing RSS hash to mbuf
+Subject: [PATCH 07/22] net/ena: fix passing RSS hash to mbuf
 
 [ upstream commit e5df9f33db00eb9d322abaefff30da74fd0e625d ]
 
@@ -19,7 +19,7 @@ Acked-by: Michal Krawczyk <mk@semihalf.com>
  1 file changed, 1 insertion(+), 1 deletion(-)
 
 diff --git a/drivers/net/ena/ena_ethdev.c b/drivers/net/ena/ena_ethdev.c
-index 4e5265679..6b96f4042 100644
+index 4e52656798..6b96f40422 100644
 --- a/drivers/net/ena/ena_ethdev.c
 +++ b/drivers/net/ena/ena_ethdev.c
 @@ -1573,7 +1573,7 @@ static uint16_t eth_ena_recv_pkts(void *rx_queue, struct rte_mbuf **rx_pkts,

--- a/userspace/dpdk/17.11/0008-net-ena-add-supported-RSS-offloads-types.patch
+++ b/userspace/dpdk/17.11/0008-net-ena-add-supported-RSS-offloads-types.patch
@@ -1,7 +1,7 @@
 From 4630c295a661a54912c5975cbfa92dfd808cfd81 Mon Sep 17 00:00:00 2001
 From: Rafal Kozik <rk@semihalf.com>
 Date: Fri, 14 Dec 2018 14:18:38 +0100
-Subject: [PATCH 08/15] net/ena: add supported RSS offloads types
+Subject: [PATCH 08/22] net/ena: add supported RSS offloads types
 
 [ upstream commit b01ead202beb45346d7daeb2f2b1a608006af644 ]
 
@@ -20,7 +20,7 @@ Acked-by: Michal Krawczyk <mk@semihalf.com>
  1 file changed, 3 insertions(+)
 
 diff --git a/drivers/net/ena/ena_ethdev.c b/drivers/net/ena/ena_ethdev.c
-index 6b96f4042..2c0a895c6 100644
+index 6b96f40422..2c0a895c60 100644
 --- a/drivers/net/ena/ena_ethdev.c
 +++ b/drivers/net/ena/ena_ethdev.c
 @@ -1493,6 +1493,9 @@ static void ena_infos_get(struct rte_eth_dev *dev,

--- a/userspace/dpdk/17.11/0009-net-ena-update-completion-queue-after-cleanup.patch
+++ b/userspace/dpdk/17.11/0009-net-ena-update-completion-queue-after-cleanup.patch
@@ -1,7 +1,7 @@
 From ce68644565f9289d42f8b7991e31459e56b77fc5 Mon Sep 17 00:00:00 2001
 From: Rafal Kozik <rk@semihalf.com>
 Date: Fri, 14 Dec 2018 14:18:44 +0100
-Subject: [PATCH 09/15] net/ena: update completion queue after cleanup
+Subject: [PATCH 09/22] net/ena: update completion queue after cleanup
 
 [ upstream commit a45462c507e98b49cb5c2302e0be3c72d2e20a1a ]
 
@@ -19,7 +19,7 @@ Acked-by: Michal Krawczyk <mk@semihalf.com>
  1 file changed, 5 insertions(+), 2 deletions(-)
 
 diff --git a/drivers/net/ena/ena_ethdev.c b/drivers/net/ena/ena_ethdev.c
-index 2c0a895c6..188938729 100644
+index 2c0a895c60..188938729a 100644
 --- a/drivers/net/ena/ena_ethdev.c
 +++ b/drivers/net/ena/ena_ethdev.c
 @@ -1587,8 +1587,10 @@ static uint16_t eth_ena_recv_pkts(void *rx_queue, struct rte_mbuf **rx_pkts,

--- a/userspace/dpdk/17.11/0010-net-ena-fix-dev-init-with-multi-process.patch
+++ b/userspace/dpdk/17.11/0010-net-ena-fix-dev-init-with-multi-process.patch
@@ -1,7 +1,7 @@
 From 0fff3abf8d883768713a0dbbd5a9ab4a74e0c915 Mon Sep 17 00:00:00 2001
 From: Michal Krawczyk <mk@semihalf.com>
 Date: Fri, 25 Jan 2019 09:10:25 +0100
-Subject: [PATCH 10/15] net/ena: fix dev init with multi-process
+Subject: [PATCH 10/22] net/ena: fix dev init with multi-process
 
 [ upstream commit fd9768905870856a2340266d25f8c0100dfccfff ]
 
@@ -22,7 +22,7 @@ Signed-off-by: Michal Krawczyk <mk@semihalf.com>
  1 file changed, 6 insertions(+), 5 deletions(-)
 
 diff --git a/drivers/net/ena/ena_ethdev.c b/drivers/net/ena/ena_ethdev.c
-index 188938729..4a43648a6 100644
+index 188938729a..4a43648a68 100644
 --- a/drivers/net/ena/ena_ethdev.c
 +++ b/drivers/net/ena/ena_ethdev.c
 @@ -1278,19 +1278,20 @@ static int eth_ena_dev_init(struct rte_eth_dev *eth_dev)

--- a/userspace/dpdk/17.11/0011-net-ena-fix-errno-to-positive-value.patch
+++ b/userspace/dpdk/17.11/0011-net-ena-fix-errno-to-positive-value.patch
@@ -1,7 +1,7 @@
 From 6af8a4cf960192b2f3e1a4904bf2aeda87ea155d Mon Sep 17 00:00:00 2001
 From: Michal Krawczyk <mk@semihalf.com>
 Date: Fri, 25 Jan 2019 09:10:26 +0100
-Subject: [PATCH 11/15] net/ena: fix errno to positive value
+Subject: [PATCH 11/22] net/ena: fix errno to positive value
 
 [ upstream commit baeed5f404dd1b049118cfec26a2fd3203671572 ]
 
@@ -18,7 +18,7 @@ Signed-off-by: Michal Krawczyk <mk@semihalf.com>
  1 file changed, 3 insertions(+), 3 deletions(-)
 
 diff --git a/drivers/net/ena/ena_ethdev.c b/drivers/net/ena/ena_ethdev.c
-index 4a43648a6..4b8eeeadd 100644
+index 4a43648a68..4b8eeeaddf 100644
 --- a/drivers/net/ena/ena_ethdev.c
 +++ b/drivers/net/ena/ena_ethdev.c
 @@ -1638,14 +1638,14 @@ eth_ena_prep_pkts(void *tx_queue, struct rte_mbuf **tx_pkts,

--- a/userspace/dpdk/17.11/0012-net-ena-get-device-info-statically.patch
+++ b/userspace/dpdk/17.11/0012-net-ena-get-device-info-statically.patch
@@ -1,7 +1,7 @@
 From 40eb10c972a4312f27bb3c2a486b9227e18618b6 Mon Sep 17 00:00:00 2001
 From: Michal Krawczyk <mk@semihalf.com>
 Date: Fri, 15 Feb 2019 09:36:39 +0100
-Subject: [PATCH 12/15] net/ena: get device info statically
+Subject: [PATCH 12/22] net/ena: get device info statically
 
 [ upstream commit 117ba4a60488a0f96a5737f38ddba6d0f9a728b6 ]
 
@@ -22,7 +22,7 @@ Signed-off-by: Michal Krawczyk <mk@semihalf.com>
  2 files changed, 19 insertions(+), 20 deletions(-)
 
 diff --git a/drivers/net/ena/ena_ethdev.c b/drivers/net/ena/ena_ethdev.c
-index 4b8eeeadd..2432714f3 100644
+index 4b8eeeaddf..2432714f32 100644
 --- a/drivers/net/ena/ena_ethdev.c
 +++ b/drivers/net/ena/ena_ethdev.c
 @@ -1362,9 +1362,14 @@ static int eth_ena_dev_init(struct rte_eth_dev *eth_dev)
@@ -93,7 +93,7 @@ index 4b8eeeadd..2432714f3 100644
  		}
  
 diff --git a/drivers/net/ena/ena_ethdev.h b/drivers/net/ena/ena_ethdev.h
-index be8bc9fa6..c4e4bee14 100644
+index be8bc9fa6f..c4e4bee14f 100644
 --- a/drivers/net/ena/ena_ethdev.h
 +++ b/drivers/net/ena/ena_ethdev.h
 @@ -144,6 +144,12 @@ struct ena_stats_rx {

--- a/userspace/dpdk/17.11/0013-net-ena-fix-checksum-feature-flag.patch
+++ b/userspace/dpdk/17.11/0013-net-ena-fix-checksum-feature-flag.patch
@@ -1,7 +1,7 @@
 From 5216b9b7d6eccf880e65829b894011f98d6990c7 Mon Sep 17 00:00:00 2001
 From: Michal Krawczyk <mk@semihalf.com>
 Date: Mon, 8 Apr 2019 12:27:44 +0200
-Subject: [PATCH 13/15] net/ena: fix checksum feature flag
+Subject: [PATCH 13/22] net/ena: fix checksum feature flag
 
 [ upstream commit ef538c1a7f565c9b58518375a500aa864445fd11 ]
 
@@ -18,7 +18,7 @@ Signed-off-by: Michal Krawczyk <mk@semihalf.com>
  1 file changed, 1 insertion(+), 1 deletion(-)
 
 diff --git a/drivers/net/ena/ena_ethdev.c b/drivers/net/ena/ena_ethdev.c
-index 2432714f3..ae63ec630 100644
+index 2432714f32..ae63ec630b 100644
 --- a/drivers/net/ena/ena_ethdev.c
 +++ b/drivers/net/ena/ena_ethdev.c
 @@ -1367,7 +1367,7 @@ static int eth_ena_dev_init(struct rte_eth_dev *eth_dev)

--- a/userspace/dpdk/17.11/0014-net-ena-fix-Rx-checksum-errors-statistics.patch
+++ b/userspace/dpdk/17.11/0014-net-ena-fix-Rx-checksum-errors-statistics.patch
@@ -1,7 +1,7 @@
 From 17cd8edaeb85bb822c6314bfd34f200173352569 Mon Sep 17 00:00:00 2001
 From: Michal Krawczyk <mk@semihalf.com>
 Date: Tue, 28 May 2019 10:28:34 +0200
-Subject: [PATCH 14/15] net/ena: fix Rx checksum errors statistics
+Subject: [PATCH 14/22] net/ena: fix Rx checksum errors statistics
 
 [ upstream commit ef74b5f7b69b9502ddab81121611243efcfe1dde ]
 
@@ -21,7 +21,7 @@ Signed-off-by: Michal Krawczyk <mk@semihalf.com>
  1 file changed, 5 insertions(+), 4 deletions(-)
 
 diff --git a/drivers/net/ena/ena_ethdev.c b/drivers/net/ena/ena_ethdev.c
-index ae63ec630..806fa3fef 100644
+index ae63ec630b..806fa3fef7 100644
 --- a/drivers/net/ena/ena_ethdev.c
 +++ b/drivers/net/ena/ena_ethdev.c
 @@ -1570,6 +1570,11 @@ static uint16_t eth_ena_recv_pkts(void *rx_queue, struct rte_mbuf **rx_pkts,

--- a/userspace/dpdk/17.11/0015-net-ena-fix-assigning-NUMA-node-to-IO-queue.patch
+++ b/userspace/dpdk/17.11/0015-net-ena-fix-assigning-NUMA-node-to-IO-queue.patch
@@ -1,7 +1,7 @@
 From 3e80ae703756491e32cb989e5bcea5ddef3a9b12 Mon Sep 17 00:00:00 2001
 From: Michal Krawczyk <mk@semihalf.com>
 Date: Tue, 4 Jun 2019 12:59:36 +0200
-Subject: [PATCH 15/15] net/ena: fix assigning NUMA node to IO queue
+Subject: [PATCH 15/22] net/ena: fix assigning NUMA node to IO queue
 
 [ upstream commit 4217cb0b7d2c5385f06f531af7f14b860927aba7 ]
 
@@ -23,7 +23,7 @@ Reviewed-by: David Marchand <david.marchand@redhat.com>
  2 files changed, 8 insertions(+), 17 deletions(-)
 
 diff --git a/drivers/net/ena/ena_ethdev.c b/drivers/net/ena/ena_ethdev.c
-index 806fa3fef..54b381b0a 100644
+index 806fa3fef7..54b381b0a7 100644
 --- a/drivers/net/ena/ena_ethdev.c
 +++ b/drivers/net/ena/ena_ethdev.c
 @@ -39,7 +39,6 @@
@@ -106,7 +106,7 @@ index 806fa3fef..54b381b0a 100644
  
  	rxq->rx_buffer_info = rte_zmalloc("rxq->buffer_info",
 diff --git a/drivers/net/ena/ena_ethdev.h b/drivers/net/ena/ena_ethdev.h
-index c4e4bee14..a64d2ee0d 100644
+index c4e4bee14f..a64d2ee0dc 100644
 --- a/drivers/net/ena/ena_ethdev.h
 +++ b/drivers/net/ena/ena_ethdev.h
 @@ -91,6 +91,8 @@ struct ena_ring {

--- a/userspace/dpdk/17.11/0016-net-ena-base-fix-node-deallocation.patch
+++ b/userspace/dpdk/17.11/0016-net-ena-base-fix-node-deallocation.patch
@@ -1,0 +1,59 @@
+From 04cf99644c64ab2c8a834bf024b714f6a62a93e2 Mon Sep 17 00:00:00 2001
+From: Michal Krawczyk <mk@semihalf.com>
+Date: Thu, 2 Jul 2020 10:25:03 +0000
+Subject: [PATCH 16/22] net/ena/base: fix node deallocation
+
+The memzone handle wasn't saved anywhere - it could cause free of the
+invalid memory, as the mem_handle was never holding the right value.
+
+Signed-off-by: Michal Krawczyk <mk@semihalf.com>
+---
+ drivers/net/ena/base/ena_com.c       | 2 ++
+ drivers/net/ena/base/ena_plat_dpdk.h | 4 +++-
+ 2 files changed, 5 insertions(+), 1 deletion(-)
+
+diff --git a/drivers/net/ena/base/ena_com.c b/drivers/net/ena/base/ena_com.c
+index 38a0587754..1c38a1138d 100644
+--- a/drivers/net/ena/base/ena_com.c
++++ b/drivers/net/ena/base/ena_com.c
+@@ -347,6 +347,7 @@ static int ena_com_init_io_sq(struct ena_com_dev *ena_dev,
+ 					    size,
+ 					    io_sq->desc_addr.virt_addr,
+ 					    io_sq->desc_addr.phys_addr,
++					    io_sq->desc_addr.mem_handle,
+ 					    ctx->numa_node,
+ 					    dev_node);
+ 		if (!io_sq->desc_addr.virt_addr)
+@@ -400,6 +401,7 @@ static int ena_com_init_io_cq(struct ena_com_dev *ena_dev,
+ 				    size,
+ 				    io_cq->cdesc_addr.virt_addr,
+ 				    io_cq->cdesc_addr.phys_addr,
++				    io_cq->cdesc_addr.mem_handle,
+ 				    ctx->numa_node,
+ 				    prev_node);
+ 	if (!io_cq->cdesc_addr.virt_addr)
+diff --git a/drivers/net/ena/base/ena_plat_dpdk.h b/drivers/net/ena/base/ena_plat_dpdk.h
+index ea78e8d72f..8ef2aeaefa 100644
+--- a/drivers/net/ena/base/ena_plat_dpdk.h
++++ b/drivers/net/ena/base/ena_plat_dpdk.h
+@@ -206,7 +206,8 @@ typedef uint64_t dma_addr_t;
+ 		   ENA_TOUCH(dmadev);					\
+ 		   rte_memzone_free(handle); })
+ 
+-#define ENA_MEM_ALLOC_COHERENT_NODE(dmadev, size, virt, phys, node, dev_node) \
++#define ENA_MEM_ALLOC_COHERENT_NODE(					\
++	dmadev, size, virt, phys, mem_handle, node, dev_node)		\
+ 	do {								\
+ 		const struct rte_memzone *mz;				\
+ 		char z_name[RTE_MEMZONE_NAMESIZE];			\
+@@ -214,6 +215,7 @@ typedef uint64_t dma_addr_t;
+ 		snprintf(z_name, sizeof(z_name),			\
+ 				"ena_alloc_%d", ena_alloc_cnt++);	\
+ 		mz = rte_memzone_reserve(z_name, size, node, 0); \
++		mem_handle = mz;					\
+ 		if (mz == NULL) {					\
+ 			virt = NULL;					\
+ 			phys = 0;					\
+-- 
+2.20.1
+

--- a/userspace/dpdk/17.11/0017-net-ena-fix-indication-of-bad-L4-Rx-checksums.patch
+++ b/userspace/dpdk/17.11/0017-net-ena-fix-indication-of-bad-L4-Rx-checksums.patch
@@ -1,0 +1,44 @@
+From 705cbf8ef6efc526048fea63c8a108b07e3532d6 Mon Sep 17 00:00:00 2001
+From: Igor Chauskin <igorch@amazon.com>
+Date: Mon, 28 Oct 2019 11:23:33 +0100
+Subject: [PATCH 17/22] net/ena: fix indication of bad L4 Rx checksums
+
+[ upstream commit 05817057faba9356900ced61e24a22eef6bc4c87 ]
+
+Add checking of l4_csum_checked and frag flags before checking the
+l4_csum_error flag.
+
+In case of IP fragment/unchecked L4 csum - add PKT_RX_L4_CKSUM_UNKNOWN
+flag to the indicated mbuf.
+
+Fixes: 1173fca25af9 ("ena: add polling-mode driver")
+Cc: stable@dpdk.org
+
+Change-Id: I9f1414741eb44ca289a8bfd11d7e66110c95040e
+Signed-off-by: Igor Chauskin <igorch@amazon.com>
+Reviewed-by: Maciej Bielski <mba@semihalf.com>
+Reviewed-by: Michal Krawczyk <mk@semihalf.com>
+---
+ drivers/net/ena/ena_ethdev.c | 5 ++++-
+ 1 file changed, 4 insertions(+), 1 deletion(-)
+
+diff --git a/drivers/net/ena/ena_ethdev.c b/drivers/net/ena/ena_ethdev.c
+index 54b381b0a7..23e71d48f1 100644
+--- a/drivers/net/ena/ena_ethdev.c
++++ b/drivers/net/ena/ena_ethdev.c
+@@ -259,8 +259,11 @@ static inline void ena_rx_mbuf_prepare(struct rte_mbuf *mbuf,
+ 	else if (ena_rx_ctx->l3_proto == ENA_ETH_IO_L3_PROTO_IPV6)
+ 		packet_type |= RTE_PTYPE_L3_IPV6;
+ 
+-	if (unlikely(ena_rx_ctx->l4_csum_err))
++	if (unlikely(ena_rx_ctx->l4_csum_err) && !ena_rx_ctx->frag)
+ 		ol_flags |= PKT_RX_L4_CKSUM_BAD;
++	else
++		ol_flags |= PKT_RX_L4_CKSUM_UNKNOWN;
++
+ 	if (unlikely(ena_rx_ctx->l3_csum_err))
+ 		ol_flags |= PKT_RX_IP_CKSUM_BAD;
+ 
+-- 
+2.20.1
+

--- a/userspace/dpdk/17.11/0018-net-ena-ensure-Rx-buffer-size-is-at-least-1400B.patch
+++ b/userspace/dpdk/17.11/0018-net-ena-ensure-Rx-buffer-size-is-at-least-1400B.patch
@@ -1,0 +1,84 @@
+From 8bbee72619630e3d285f09595a601a0ae7ac9e3c Mon Sep 17 00:00:00 2001
+From: Michal Krawczyk <mk@semihalf.com>
+Date: Wed, 8 Apr 2020 10:28:52 +0200
+Subject: [PATCH 18/22] net/ena: ensure Rx buffer size is at least 1400B
+
+[ upstream commit 38364c2687ead97b99402310087c27131a97748c ]
+
+Some of the ENA devices can't handle buffers which are smaller than a
+1400B. Because of this limitation, size of the buffer is being checked
+and limited during the Rx queue setup.
+
+If it's below the allowed value, PMD won't finish it's configuration
+successfully..
+
+Change-Id: Ib402d3bfad98a3fc4f91095d5c6f90c6069da021
+Signed-off-by: Michal Krawczyk <mk@semihalf.com>
+Reviewed-by: Igor Chauskin <igorch@amazon.com>
+Reviewed-by: Guy Tzalik <gtzalik@amazon.com>
+---
+ drivers/net/ena/ena_ethdev.c | 12 +++++++++++-
+ drivers/net/ena/ena_ethdev.h |  3 ++-
+ 2 files changed, 13 insertions(+), 2 deletions(-)
+
+diff --git a/drivers/net/ena/ena_ethdev.c b/drivers/net/ena/ena_ethdev.c
+index 23e71d48f1..fb55eeb0f0 100644
+--- a/drivers/net/ena/ena_ethdev.c
++++ b/drivers/net/ena/ena_ethdev.c
+@@ -1,7 +1,7 @@
+ /*-
+ * BSD LICENSE
+ *
+-* Copyright (c) 2015-2016 Amazon.com, Inc. or its affiliates.
++* Copyright (c) 2015-2020 Amazon.com, Inc. or its affiliates.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+@@ -1050,6 +1050,7 @@ static int ena_rx_queue_setup(struct rte_eth_dev *dev,
+ 	struct ena_adapter *adapter =
+ 		(struct ena_adapter *)(dev->data->dev_private);
+ 	struct ena_ring *rxq = NULL;
++	size_t buffer_size;
+ 	uint16_t ena_qid = 0;
+ 	int rc = 0;
+ 	struct ena_com_dev *ena_dev = &adapter->ena_dev;
+@@ -1076,6 +1077,15 @@ static int ena_rx_queue_setup(struct rte_eth_dev *dev,
+ 		return -EINVAL;
+ 	}
+ 
++	/* ENA isn't supporting buffers smaller than 1400 bytes */
++	buffer_size = rte_pktmbuf_data_room_size(mp) - RTE_PKTMBUF_HEADROOM;
++	if (buffer_size < ENA_RX_BUF_MIN_SIZE) {
++		PMD_DRV_LOG(ERR,
++			"Unsupported size of RX buffer: %zu (min size: %d)\n",
++			buffer_size, ENA_RX_BUF_MIN_SIZE);
++		return -EINVAL;
++	}
++
+ 	ena_qid = ENA_IO_RXQ_IDX(queue_idx);
+ 
+ 	ctx.qid = ena_qid;
+diff --git a/drivers/net/ena/ena_ethdev.h b/drivers/net/ena/ena_ethdev.h
+index a64d2ee0dc..42a15e874a 100644
+--- a/drivers/net/ena/ena_ethdev.h
++++ b/drivers/net/ena/ena_ethdev.h
+@@ -1,7 +1,7 @@
+ /*-
+ * BSD LICENSE
+ *
+-* Copyright (c) 2015-2016 Amazon.com, Inc. or its affiliates.
++* Copyright (c) 2015-2020 Amazon.com, Inc. or its affiliates.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+@@ -47,6 +47,7 @@
+ #define ENA_MIN_FRAME_LEN	64
+ #define ENA_NAME_MAX_LEN	20
+ #define ENA_PKT_MAX_BUFS	17
++#define ENA_RX_BUF_MIN_SIZE	1400
+ 
+ #define ENA_MMIO_DISABLE_REG_READ	BIT(0)
+ 
+-- 
+2.20.1
+

--- a/userspace/dpdk/17.11/0019-net-ena-base-make-allocation-macros-thread-safe.patch
+++ b/userspace/dpdk/17.11/0019-net-ena-base-make-allocation-macros-thread-safe.patch
@@ -1,0 +1,103 @@
+From e907e38244aea9a4f2d16661585c054a1c9349f3 Mon Sep 17 00:00:00 2001
+From: Igor Chauskin <igorch@amazon.com>
+Date: Wed, 8 Apr 2020 10:28:53 +0200
+Subject: [PATCH 19/22] net/ena/base: make allocation macros thread-safe
+
+[ upstream commit b14fcac035fd8514851c9140a4e26d765b61c532 ]
+
+Memory allocation region id could possibly be non-unique
+due to non-atomic increment, causing allocation failure.
+
+Fixes: 9ba7981ec992 ("ena: add communication layer for DPDK")
+Cc: stable@dpdk.org
+
+Change-Id: Ib9207aaae4e5e7ecdf1a99a0f23a508a53af631d
+Signed-off-by: Igor Chauskin <igorch@amazon.com>
+Reviewed-by: Michal Krawczyk <mk@semihalf.com>
+Reviewed-by: Guy Tzalik <gtzalik@amazon.com>
+---
+ drivers/net/ena/base/ena_com.c       |  2 --
+ drivers/net/ena/base/ena_plat_dpdk.h | 16 ++++++++++++----
+ drivers/net/ena/ena_ethdev.c         |  6 ++++++
+ 3 files changed, 18 insertions(+), 6 deletions(-)
+
+diff --git a/drivers/net/ena/base/ena_com.c b/drivers/net/ena/base/ena_com.c
+index 1c38a1138d..0dbd1b0cd0 100644
+--- a/drivers/net/ena/base/ena_com.c
++++ b/drivers/net/ena/base/ena_com.c
+@@ -62,8 +62,6 @@
+ 
+ #define ENA_MMIO_READ_TIMEOUT 0xFFFFFFFF
+ 
+-static int ena_alloc_cnt;
+-
+ /*****************************************************************************/
+ /*****************************************************************************/
+ /*****************************************************************************/
+diff --git a/drivers/net/ena/base/ena_plat_dpdk.h b/drivers/net/ena/base/ena_plat_dpdk.h
+index 8ef2aeaefa..7bdfcc6e0c 100644
+--- a/drivers/net/ena/base/ena_plat_dpdk.h
++++ b/drivers/net/ena/base/ena_plat_dpdk.h
+@@ -1,7 +1,7 @@
+ /*-
+ * BSD LICENSE
+ *
+-* Copyright (c) 2015-2016 Amazon.com, Inc. or its affiliates.
++* Copyright (c) 2015-2020 Amazon.com, Inc. or its affiliates.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+@@ -183,13 +183,20 @@ typedef uint64_t dma_addr_t;
+ #define ena_wait_event_t ena_wait_queue_t
+ #define ENA_MIGHT_SLEEP()
+ 
++/*
++ * Each rte_memzone should have unique name.
++ * To satisfy it, count number of allocations and add it to name.
++ */
++extern rte_atomic32_t ena_alloc_cnt;
++
+ #define ENA_MEM_ALLOC_COHERENT(dmadev, size, virt, phys, handle)	\
+ 	do {								\
+ 		const struct rte_memzone *mz;				\
+ 		char z_name[RTE_MEMZONE_NAMESIZE];			\
+ 		ENA_TOUCH(dmadev); ENA_TOUCH(handle);			\
+ 		snprintf(z_name, sizeof(z_name),			\
+-				"ena_alloc_%d", ena_alloc_cnt++);	\
++			 "ena_alloc_%d",				\
++			 rte_atomic32_add_return(&ena_alloc_cnt, 1));	\
+ 		mz = rte_memzone_reserve(z_name, size, SOCKET_ID_ANY, 0); \
+ 		handle = mz;						\
+ 		if (mz == NULL) {					\
+@@ -213,8 +220,9 @@ typedef uint64_t dma_addr_t;
+ 		char z_name[RTE_MEMZONE_NAMESIZE];			\
+ 		ENA_TOUCH(dmadev); ENA_TOUCH(dev_node);			\
+ 		snprintf(z_name, sizeof(z_name),			\
+-				"ena_alloc_%d", ena_alloc_cnt++);	\
+-		mz = rte_memzone_reserve(z_name, size, node, 0); \
++			 "ena_alloc_%d",				\
++			 rte_atomic32_add_return(&ena_alloc_cnt, 1));	\
++		mz = rte_memzone_reserve(z_name, size, node, 0);	\
+ 		mem_handle = mz;					\
+ 		if (mz == NULL) {					\
+ 			virt = NULL;					\
+diff --git a/drivers/net/ena/ena_ethdev.c b/drivers/net/ena/ena_ethdev.c
+index fb55eeb0f0..6906e69e16 100644
+--- a/drivers/net/ena/ena_ethdev.c
++++ b/drivers/net/ena/ena_ethdev.c
+@@ -113,6 +113,12 @@ struct ena_stats {
+ #define ENA_STAT_GLOBAL_ENTRY(stat) \
+ 	ENA_STAT_ENTRY(stat, dev)
+ 
++/*
++ * Each rte_memzone should have unique name.
++ * To satisfy it, count number of allocation and add it to name.
++ */
++rte_atomic32_t ena_alloc_cnt;
++
+ static const struct ena_stats ena_stats_global_strings[] = {
+ 	ENA_STAT_GLOBAL_ENTRY(tx_timeout),
+ 	ENA_STAT_GLOBAL_ENTRY(io_suspend),
+-- 
+2.20.1
+

--- a/userspace/dpdk/17.11/0020-net-ena-base-prevent-allocation-of-zero-sized-memory.patch
+++ b/userspace/dpdk/17.11/0020-net-ena-base-prevent-allocation-of-zero-sized-memory.patch
@@ -1,0 +1,74 @@
+From b735bd5f9cf50de055f28e62e9c04d15c6515401 Mon Sep 17 00:00:00 2001
+From: Igor Chauskin <igorch@amazon.com>
+Date: Wed, 8 Apr 2020 10:28:54 +0200
+Subject: [PATCH 20/22] net/ena/base: prevent allocation of zero sized memory
+
+[ upstream commit 29dc10d9424ccf26a346387b0a707185e2432400 ]
+
+rte_memzone_reserve() will reserve the biggest contiguous memzone
+available if received 0 as size param.
+
+Fixes: 9ba7981ec992 ("ena: add communication layer for DPDK")
+Cc: stable@dpdk.org
+
+Change-Id: I2f71119e93c5e9addd8c538820093f030066d690
+Signed-off-by: Igor Chauskin <igorch@amazon.com>
+Reviewed-by: Michal Krawczyk <mk@semihalf.com>
+Reviewed-by: Guy Tzalik <gtzalik@amazon.com>
+---
+ drivers/net/ena/base/ena_plat_dpdk.h | 27 ++++++++++++++++-----------
+ 1 file changed, 16 insertions(+), 11 deletions(-)
+
+diff --git a/drivers/net/ena/base/ena_plat_dpdk.h b/drivers/net/ena/base/ena_plat_dpdk.h
+index 7bdfcc6e0c..3ccaea2483 100644
+--- a/drivers/net/ena/base/ena_plat_dpdk.h
++++ b/drivers/net/ena/base/ena_plat_dpdk.h
+@@ -191,14 +191,17 @@ extern rte_atomic32_t ena_alloc_cnt;
+ 
+ #define ENA_MEM_ALLOC_COHERENT(dmadev, size, virt, phys, handle)	\
+ 	do {								\
+-		const struct rte_memzone *mz;				\
+-		char z_name[RTE_MEMZONE_NAMESIZE];			\
++		const struct rte_memzone *mz = NULL;			\
+ 		ENA_TOUCH(dmadev); ENA_TOUCH(handle);			\
+-		snprintf(z_name, sizeof(z_name),			\
++		if (size > 0) {						\
++			char z_name[RTE_MEMZONE_NAMESIZE];		\
++			snprintf(z_name, sizeof(z_name),		\
+ 			 "ena_alloc_%d",				\
+ 			 rte_atomic32_add_return(&ena_alloc_cnt, 1));	\
+-		mz = rte_memzone_reserve(z_name, size, SOCKET_ID_ANY, 0); \
+-		handle = mz;						\
++			mz = rte_memzone_reserve(z_name, size,		\
++				SOCKET_ID_ANY, 0);			\
++			handle = mz;					\
++		}							\
+ 		if (mz == NULL) {					\
+ 			virt = NULL;					\
+ 			phys = 0;					\
+@@ -216,14 +219,16 @@ extern rte_atomic32_t ena_alloc_cnt;
+ #define ENA_MEM_ALLOC_COHERENT_NODE(					\
+ 	dmadev, size, virt, phys, mem_handle, node, dev_node)		\
+ 	do {								\
+-		const struct rte_memzone *mz;				\
+-		char z_name[RTE_MEMZONE_NAMESIZE];			\
++		const struct rte_memzone *mz = NULL;			\
+ 		ENA_TOUCH(dmadev); ENA_TOUCH(dev_node);			\
+-		snprintf(z_name, sizeof(z_name),			\
++		if (size > 0) {						\
++			char z_name[RTE_MEMZONE_NAMESIZE];		\
++			snprintf(z_name, sizeof(z_name),		\
+ 			 "ena_alloc_%d",				\
+-			 rte_atomic32_add_return(&ena_alloc_cnt, 1));	\
+-		mz = rte_memzone_reserve(z_name, size, node, 0);	\
+-		mem_handle = mz;					\
++			 rte_atomic32_add_return(&ena_alloc_cnt, 1));   \
++			mz = rte_memzone_reserve(z_name, size, node, 0); \
++			mem_handle = mz;				\
++		}							\
+ 		if (mz == NULL) {					\
+ 			virt = NULL;					\
+ 			phys = 0;					\
+-- 
+2.20.1
+

--- a/userspace/dpdk/17.11/0021-net-ena-set-IO-ring-size-to-valid-value.patch
+++ b/userspace/dpdk/17.11/0021-net-ena-set-IO-ring-size-to-valid-value.patch
@@ -1,0 +1,49 @@
+From 56cd8217c14c7dc108528eb14a5480f8e887bc34 Mon Sep 17 00:00:00 2001
+From: Michal Krawczyk <mk@semihalf.com>
+Date: Fri, 3 Jul 2020 13:14:58 +0000
+Subject: [PATCH 21/22] net/ena: set IO ring size to valid value
+
+[ upstream commit badc3a6aa133a886a61b9e3ad666e5675f7ec3d3 ]
+
+IO rings were configured with the maximum allowed size for the Tx/Rx
+rings. However, the application could decide to create smaller rings.
+
+This patch is using value stored in the ring instead of the value from
+the adapter which is indicating the maximum allowed value.
+
+Fixes: df238f84c0a2 ("net/ena: recreate HW IO rings on start and stop")
+Cc: stable@dpdk.org
+
+Change-Id: Icf9102e2aa4e7413b6620b36dd232673239b7291
+Signed-off-by: Michal Krawczyk <mk@semihalf.com>
+Reviewed-by: Igor Chauskin <igorch@amazon.com>
+Reviewed-by: Guy Tzalik <gtzalik@amazon.com>
+---
+ drivers/net/ena/ena_ethdev.c | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/drivers/net/ena/ena_ethdev.c b/drivers/net/ena/ena_ethdev.c
+index 6906e69e16..d48ee184b0 100644
+--- a/drivers/net/ena/ena_ethdev.c
++++ b/drivers/net/ena/ena_ethdev.c
+@@ -986,7 +986,7 @@ static int ena_tx_queue_setup(struct rte_eth_dev *dev,
+ 	ctx.qid = ena_qid;
+ 	ctx.msix_vector = -1; /* admin interrupts not used */
+ 	ctx.mem_queue_type = ena_dev->tx_mem_queue_type;
+-	ctx.queue_size = adapter->tx_ring_size;
++	ctx.queue_size = nb_desc;
+ 	ctx.numa_node = socket_id;
+ 
+ 	rc = ena_com_create_io_queue(ena_dev, &ctx);
+@@ -1098,7 +1098,7 @@ static int ena_rx_queue_setup(struct rte_eth_dev *dev,
+ 	ctx.direction = ENA_COM_IO_QUEUE_DIRECTION_RX;
+ 	ctx.mem_queue_type = ENA_ADMIN_PLACEMENT_POLICY_HOST;
+ 	ctx.msix_vector = -1; /* admin interrupts not used */
+-	ctx.queue_size = adapter->rx_ring_size;
++	ctx.queue_size = nb_desc;
+ 	ctx.numa_node = socket_id;
+ 
+ 	rc = ena_com_create_io_queue(ena_dev, &ctx);
+-- 
+2.20.1
+

--- a/userspace/dpdk/17.11/0022-net-ena-limit-refill-threshold-by-fixed-value.patch
+++ b/userspace/dpdk/17.11/0022-net-ena-limit-refill-threshold-by-fixed-value.patch
@@ -1,0 +1,118 @@
+From da6667ddfc88c8fbde8fea468d4bf142f505d440 Mon Sep 17 00:00:00 2001
+From: Michal Krawczyk <mk@semihalf.com>
+Date: Wed, 8 Apr 2020 10:29:16 +0200
+Subject: [PATCH 22/22] net/ena: limit refill threshold by fixed value
+
+[ upstream commit 7755060798de9c0146df8809926030ed47fc9086 ]
+
+Divider used for both Tx and Rx cleanup/refill threshold can cause too
+big delay in case of the really big rings - for example if the 8k Rx
+ring will be used, the refill won't trigger unless 1024 threshold will
+be reached. It will also cause driver to try to allocate that much
+descriptors.
+
+Limiting it by fixed value - 256 in that case, would limit maximum
+time spent in repopulate function.
+
+Change-Id: Ia8659e6ddf179ff612a780adc6fe55d13eeac6e9
+Signed-off-by: Michal Krawczyk <mk@semihalf.com>
+Reviewed-by: Igor Chauskin <igorch@amazon.com>
+Reviewed-by: Guy Tzalik <gtzalik@amazon.com>
+---
+ drivers/net/ena/ena_ethdev.c | 26 ++++++++++++++------------
+ drivers/net/ena/ena_ethdev.h | 10 ++++++++++
+ 2 files changed, 24 insertions(+), 12 deletions(-)
+
+diff --git a/drivers/net/ena/ena_ethdev.c b/drivers/net/ena/ena_ethdev.c
+index d48ee184b0..40a2c958d9 100644
+--- a/drivers/net/ena/ena_ethdev.c
++++ b/drivers/net/ena/ena_ethdev.c
+@@ -61,14 +61,6 @@
+ /*reverse version of ENA_IO_RXQ_IDX*/
+ #define ENA_IO_RXQ_IDX_REV(q)	((q - 1) / 2)
+ 
+-/* While processing submitted and completed descriptors (rx and tx path
+- * respectively) in a loop it is desired to:
+- *  - perform batch submissions while populating sumbissmion queue
+- *  - avoid blocking transmission of other packets during cleanup phase
+- * Hence the utilization ratio of 1/8 of a queue size.
+- */
+-#define ENA_RING_DESCS_RATIO(ring_size)	(ring_size / 8)
+-
+ #define __MERGE_64B_H_L(h, l) (((uint64_t)h << 32) | l)
+ #define TEST_BIT(val, bit_shift) (val & (1UL << bit_shift))
+ 
+@@ -1513,6 +1505,8 @@ static uint16_t eth_ena_recv_pkts(void *rx_queue, struct rte_mbuf **rx_pkts,
+ 	struct ena_ring *rx_ring = (struct ena_ring *)(rx_queue);
+ 	unsigned int ring_size = rx_ring->ring_size;
+ 	unsigned int ring_mask = ring_size - 1;
++	unsigned int free_queue_entries;
++	unsigned int refill_threshold;
+ 	uint16_t next_to_clean = rx_ring->next_to_clean;
+ 	uint16_t desc_in_use = 0;
+ 	unsigned int recv_idx = 0;
+@@ -1592,11 +1586,15 @@ static uint16_t eth_ena_recv_pkts(void *rx_queue, struct rte_mbuf **rx_pkts,
+ 
+ 	rx_ring->next_to_clean = next_to_clean;
+ 
+-	desc_in_use = desc_in_use - completed + 1;
++	free_queue_entries = ena_com_sq_empty_space(rx_ring->ena_com_io_sq);
++	refill_threshold =
++		RTE_MIN(ring_size / ENA_REFILL_THRESH_DIVIDER,
++		(unsigned int)ENA_REFILL_THRESH_PACKET);
++
+ 	/* Burst refill to save doorbells, memory barriers, const interval */
+-	if (ring_size - desc_in_use > ENA_RING_DESCS_RATIO(ring_size)) {
++	if (free_queue_entries > refill_threshold) {
+ 		ena_com_update_dev_comp_head(rx_ring->ena_com_io_cq);
+-		ena_populate_rx_queue(rx_ring, ring_size - desc_in_use);
++		ena_populate_rx_queue(rx_ring, free_queue_entries);
+ 	}
+ 
+ 	return recv_idx;
+@@ -1681,6 +1679,7 @@ static uint16_t eth_ena_xmit_pkts(void *tx_queue, struct rte_mbuf **tx_pkts,
+ 	struct rte_mbuf *mbuf;
+ 	unsigned int ring_size = tx_ring->ring_size;
+ 	unsigned int ring_mask = ring_size - 1;
++	unsigned int cleanup_budget;
+ 	struct ena_com_tx_ctx ena_tx_ctx;
+ 	struct ena_tx_buffer *tx_info;
+ 	struct ena_com_buf *ebuf;
+@@ -1787,9 +1786,12 @@ static uint16_t eth_ena_xmit_pkts(void *tx_queue, struct rte_mbuf **tx_pkts,
+ 		/* Put back descriptor to the ring for reuse */
+ 		tx_ring->empty_tx_reqs[next_to_clean & ring_mask] = req_id;
+ 		next_to_clean++;
++		cleanup_budget =
++			RTE_MIN(ring_size / ENA_REFILL_THRESH_DIVIDER,
++			(unsigned int)ENA_REFILL_THRESH_PACKET);
+ 
+ 		/* If too many descs to clean, leave it for another run */
+-		if (unlikely(total_tx_descs > ENA_RING_DESCS_RATIO(ring_size)))
++		if (unlikely(total_tx_descs > cleanup_budget))
+ 			break;
+ 	}
+ 
+diff --git a/drivers/net/ena/ena_ethdev.h b/drivers/net/ena/ena_ethdev.h
+index 42a15e874a..4b1ae86d5b 100644
+--- a/drivers/net/ena/ena_ethdev.h
++++ b/drivers/net/ena/ena_ethdev.h
+@@ -51,6 +51,16 @@
+ 
+ #define ENA_MMIO_DISABLE_REG_READ	BIT(0)
+ 
++/* While processing submitted and completed descriptors (rx and tx path
++ * respectively) in a loop it is desired to:
++ *  - perform batch submissions while populating sumbissmion queue
++ *  - avoid blocking transmission of other packets during cleanup phase
++ * Hence the utilization ratio of 1/8 of a queue size or max value if the size
++ * of the ring is very big - like 8k Rx rings.
++ */
++#define ENA_REFILL_THRESH_DIVIDER      8
++#define ENA_REFILL_THRESH_PACKET       256
++
+ struct ena_adapter;
+ 
+ enum ena_ring_type {
+-- 
+2.20.1
+

--- a/userspace/dpdk/18.02/0001-net-ena-check-pointer-before-memset.patch
+++ b/userspace/dpdk/18.02/0001-net-ena-check-pointer-before-memset.patch
@@ -1,7 +1,7 @@
 From a81ebdfe8e3ef6224696a8d66b2daf0540903f19 Mon Sep 17 00:00:00 2001
 From: Rafal Kozik <rk@semihalf.com>
 Date: Thu, 7 Jun 2018 11:43:18 +0200
-Subject: [PATCH 01/15] net/ena: check pointer before memset
+Subject: [PATCH 01/22] net/ena: check pointer before memset
 
 [ upstream commit 46916aa17d4b2007df8c0454f99ba0ca8b8cb93b ]
 
@@ -19,7 +19,7 @@ Acked-by: Michal Krawczyk <mk@semihalf.com>
  1 file changed, 16 insertions(+), 6 deletions(-)
 
 diff --git a/drivers/net/ena/base/ena_plat_dpdk.h b/drivers/net/ena/base/ena_plat_dpdk.h
-index 8cba319eb..95f2d9f6f 100644
+index 8cba319ebb..95f2d9f6f8 100644
 --- a/drivers/net/ena/base/ena_plat_dpdk.h
 +++ b/drivers/net/ena/base/ena_plat_dpdk.h
 @@ -189,10 +189,15 @@ typedef uint64_t dma_addr_t;

--- a/userspace/dpdk/18.02/0002-net-ena-change-memory-type.patch
+++ b/userspace/dpdk/18.02/0002-net-ena-change-memory-type.patch
@@ -1,7 +1,7 @@
 From 338c21f83954ea47a3288f3ee1f64e54837b2e1f Mon Sep 17 00:00:00 2001
 From: Rafal Kozik <rk@semihalf.com>
 Date: Thu, 7 Jun 2018 11:43:19 +0200
-Subject: [PATCH 02/15] net/ena: change memory type
+Subject: [PATCH 02/22] net/ena: change memory type
 
 [ upstream commit 9f32c7e7e6ce58ab772913f54f8328c1c0186a17 ]
 
@@ -22,7 +22,7 @@ Acked-by: Michal Krawczyk <mk@semihalf.com>
  1 file changed, 1 insertion(+), 7 deletions(-)
 
 diff --git a/drivers/net/ena/base/ena_plat_dpdk.h b/drivers/net/ena/base/ena_plat_dpdk.h
-index 95f2d9f6f..00ff9363c 100644
+index 95f2d9f6f8..00ff9363cb 100644
 --- a/drivers/net/ena/base/ena_plat_dpdk.h
 +++ b/drivers/net/ena/base/ena_plat_dpdk.h
 @@ -224,14 +224,8 @@ typedef uint64_t dma_addr_t;

--- a/userspace/dpdk/18.02/0003-net-ena-fix-GENMASK_ULL-macro.patch
+++ b/userspace/dpdk/18.02/0003-net-ena-fix-GENMASK_ULL-macro.patch
@@ -1,7 +1,7 @@
 From 5960b6d766b0802a77bebe4887a6c633e4f8c3a9 Mon Sep 17 00:00:00 2001
 From: Rafal Kozik <rk@semihalf.com>
 Date: Thu, 7 Jun 2018 11:43:20 +0200
-Subject: [PATCH 03/15] net/ena: fix GENMASK_ULL macro
+Subject: [PATCH 03/22] net/ena: fix GENMASK_ULL macro
 
 [ upstream commit 7544aee8d0b4ae0262b1ba7e1539cf8171664df7 ]
 
@@ -20,7 +20,7 @@ Acked-by: Michal Krawczyk <mk@semihalf.com>
  1 file changed, 3 insertions(+), 1 deletion(-)
 
 diff --git a/drivers/net/ena/base/ena_plat_dpdk.h b/drivers/net/ena/base/ena_plat_dpdk.h
-index 00ff9363c..72d501538 100644
+index 00ff9363cb..72d501538f 100644
 --- a/drivers/net/ena/base/ena_plat_dpdk.h
 +++ b/drivers/net/ena/base/ena_plat_dpdk.h
 @@ -116,11 +116,13 @@ typedef uint64_t dma_addr_t;

--- a/userspace/dpdk/18.02/0004-net-ena-set-link-speed-as-none.patch
+++ b/userspace/dpdk/18.02/0004-net-ena-set-link-speed-as-none.patch
@@ -1,7 +1,7 @@
 From ab96831a8a190f887430181af291670826413568 Mon Sep 17 00:00:00 2001
 From: Rafal Kozik <rk@semihalf.com>
 Date: Thu, 7 Jun 2018 11:43:22 +0200
-Subject: [PATCH 04/15] net/ena: set link speed as none
+Subject: [PATCH 04/22] net/ena: set link speed as none
 
 [ upstream commit 41e59028dd8ab2038a7655c6fc3098222661aa53 ]
 
@@ -21,7 +21,7 @@ Acked-by: Michal Krawczyk <mk@semihalf.com>
  1 file changed, 1 insertion(+), 1 deletion(-)
 
 diff --git a/drivers/net/ena/ena_ethdev.c b/drivers/net/ena/ena_ethdev.c
-index 34b2a8d78..9eecb986e 100644
+index 34b2a8d782..9eecb986e7 100644
 --- a/drivers/net/ena/ena_ethdev.c
 +++ b/drivers/net/ena/ena_ethdev.c
 @@ -725,7 +725,7 @@ static int ena_link_update(struct rte_eth_dev *dev,

--- a/userspace/dpdk/18.02/0005-net-ena-fix-SIGFPE-with-0-Rx-queue.patch
+++ b/userspace/dpdk/18.02/0005-net-ena-fix-SIGFPE-with-0-Rx-queue.patch
@@ -1,7 +1,7 @@
 From 3d1ec83f9e963e57e731debc6c74e05a4e955687 Mon Sep 17 00:00:00 2001
 From: Daria Kolistratova <daria.kolistratova@intel.com>
 Date: Tue, 26 Jun 2018 18:38:56 +0100
-Subject: [PATCH 05/15] net/ena: fix SIGFPE with 0 Rx queue
+Subject: [PATCH 05/22] net/ena: fix SIGFPE with 0 Rx queue
 
 [ upstream commit 361913ad6f8c05fc541fe4bfdae3b0dc095ae3af ]
 
@@ -19,7 +19,7 @@ Acked-by: Michal Krawczyk <mk@semihalf.com>
  1 file changed, 1 insertion(+), 1 deletion(-)
 
 diff --git a/drivers/net/ena/ena_ethdev.c b/drivers/net/ena/ena_ethdev.c
-index 9eecb986e..ec72407f6 100644
+index 9eecb986e7..ec72407f60 100644
 --- a/drivers/net/ena/ena_ethdev.c
 +++ b/drivers/net/ena/ena_ethdev.c
 @@ -924,7 +924,7 @@ static int ena_start(struct rte_eth_dev *dev)

--- a/userspace/dpdk/18.02/0006-net-ena-fix-passing-RSS-hash-to-mbuf.patch
+++ b/userspace/dpdk/18.02/0006-net-ena-fix-passing-RSS-hash-to-mbuf.patch
@@ -1,7 +1,7 @@
 From 2b705349532283b0c80d7ec7ea622fce7f177142 Mon Sep 17 00:00:00 2001
 From: Stewart Allen <allenste@amazon.com>
 Date: Thu, 25 Oct 2018 19:59:22 +0200
-Subject: [PATCH 06/15] net/ena: fix passing RSS hash to mbuf
+Subject: [PATCH 06/22] net/ena: fix passing RSS hash to mbuf
 
 [ upstream commit e5df9f33db00eb9d322abaefff30da74fd0e625d ]
 
@@ -19,7 +19,7 @@ Acked-by: Michal Krawczyk <mk@semihalf.com>
  1 file changed, 1 insertion(+), 1 deletion(-)
 
 diff --git a/drivers/net/ena/ena_ethdev.c b/drivers/net/ena/ena_ethdev.c
-index ec72407f6..51b351a95 100644
+index ec72407f60..51b351a95f 100644
 --- a/drivers/net/ena/ena_ethdev.c
 +++ b/drivers/net/ena/ena_ethdev.c
 @@ -1654,7 +1654,7 @@ static uint16_t eth_ena_recv_pkts(void *rx_queue, struct rte_mbuf **rx_pkts,

--- a/userspace/dpdk/18.02/0007-net-ena-add-supported-RSS-offloads-types.patch
+++ b/userspace/dpdk/18.02/0007-net-ena-add-supported-RSS-offloads-types.patch
@@ -1,7 +1,7 @@
 From b12580f688e9fa3aab311b83ef09391ff664b27f Mon Sep 17 00:00:00 2001
 From: Rafal Kozik <rk@semihalf.com>
 Date: Fri, 14 Dec 2018 14:18:38 +0100
-Subject: [PATCH 07/15] net/ena: add supported RSS offloads types
+Subject: [PATCH 07/22] net/ena: add supported RSS offloads types
 
 [ upstream commit b01ead202beb45346d7daeb2f2b1a608006af644 ]
 
@@ -20,7 +20,7 @@ Acked-by: Michal Krawczyk <mk@semihalf.com>
  1 file changed, 3 insertions(+)
 
 diff --git a/drivers/net/ena/ena_ethdev.c b/drivers/net/ena/ena_ethdev.c
-index 51b351a95..21b9fa4c8 100644
+index 51b351a95f..21b9fa4c85 100644
 --- a/drivers/net/ena/ena_ethdev.c
 +++ b/drivers/net/ena/ena_ethdev.c
 @@ -1571,6 +1571,9 @@ static void ena_infos_get(struct rte_eth_dev *dev,

--- a/userspace/dpdk/18.02/0008-net-ena-update-completion-queue-after-cleanup.patch
+++ b/userspace/dpdk/18.02/0008-net-ena-update-completion-queue-after-cleanup.patch
@@ -1,7 +1,7 @@
 From cc79443574e2d2047bdf8d5b15049c02927c9512 Mon Sep 17 00:00:00 2001
 From: Rafal Kozik <rk@semihalf.com>
 Date: Fri, 14 Dec 2018 14:18:44 +0100
-Subject: [PATCH 08/15] net/ena: update completion queue after cleanup
+Subject: [PATCH 08/22] net/ena: update completion queue after cleanup
 
 [ upstream commit a45462c507e98b49cb5c2302e0be3c72d2e20a1a ]
 
@@ -19,7 +19,7 @@ Acked-by: Michal Krawczyk <mk@semihalf.com>
  1 file changed, 5 insertions(+), 2 deletions(-)
 
 diff --git a/drivers/net/ena/ena_ethdev.c b/drivers/net/ena/ena_ethdev.c
-index 21b9fa4c8..bd9ec3f67 100644
+index 21b9fa4c85..bd9ec3f673 100644
 --- a/drivers/net/ena/ena_ethdev.c
 +++ b/drivers/net/ena/ena_ethdev.c
 @@ -1668,8 +1668,10 @@ static uint16_t eth_ena_recv_pkts(void *rx_queue, struct rte_mbuf **rx_pkts,

--- a/userspace/dpdk/18.02/0009-net-ena-fix-dev-init-with-multi-process.patch
+++ b/userspace/dpdk/18.02/0009-net-ena-fix-dev-init-with-multi-process.patch
@@ -1,7 +1,7 @@
 From 3194c83ab3a52d3486fb914acbad7fa55f2ed39c Mon Sep 17 00:00:00 2001
 From: Michal Krawczyk <mk@semihalf.com>
 Date: Fri, 25 Jan 2019 09:10:25 +0100
-Subject: [PATCH 09/15] net/ena: fix dev init with multi-process
+Subject: [PATCH 09/22] net/ena: fix dev init with multi-process
 
 [ upstream commit fd9768905870856a2340266d25f8c0100dfccfff ]
 
@@ -22,7 +22,7 @@ Signed-off-by: Michal Krawczyk <mk@semihalf.com>
  1 file changed, 6 insertions(+), 5 deletions(-)
 
 diff --git a/drivers/net/ena/ena_ethdev.c b/drivers/net/ena/ena_ethdev.c
-index bd9ec3f67..309cf8e3f 100644
+index bd9ec3f673..309cf8e3f9 100644
 --- a/drivers/net/ena/ena_ethdev.c
 +++ b/drivers/net/ena/ena_ethdev.c
 @@ -1308,19 +1308,20 @@ static int eth_ena_dev_init(struct rte_eth_dev *eth_dev)

--- a/userspace/dpdk/18.02/0010-net-ena-fix-errno-to-positive-value.patch
+++ b/userspace/dpdk/18.02/0010-net-ena-fix-errno-to-positive-value.patch
@@ -1,7 +1,7 @@
 From 0eb5d2ca0b16edccf4495f5f71e3a0bc28493b0d Mon Sep 17 00:00:00 2001
 From: Michal Krawczyk <mk@semihalf.com>
 Date: Fri, 25 Jan 2019 09:10:26 +0100
-Subject: [PATCH 10/15] net/ena: fix errno to positive value
+Subject: [PATCH 10/22] net/ena: fix errno to positive value
 
 [ upstream commit baeed5f404dd1b049118cfec26a2fd3203671572 ]
 
@@ -18,7 +18,7 @@ Signed-off-by: Michal Krawczyk <mk@semihalf.com>
  1 file changed, 3 insertions(+), 3 deletions(-)
 
 diff --git a/drivers/net/ena/ena_ethdev.c b/drivers/net/ena/ena_ethdev.c
-index 309cf8e3f..32ba585c8 100644
+index 309cf8e3f9..32ba585c81 100644
 --- a/drivers/net/ena/ena_ethdev.c
 +++ b/drivers/net/ena/ena_ethdev.c
 @@ -1719,14 +1719,14 @@ eth_ena_prep_pkts(void *tx_queue, struct rte_mbuf **tx_pkts,

--- a/userspace/dpdk/18.02/0011-net-ena-get-device-info-statically.patch
+++ b/userspace/dpdk/18.02/0011-net-ena-get-device-info-statically.patch
@@ -1,7 +1,7 @@
 From ae85348bac77233cfb9906b9576204a8ae2f47ce Mon Sep 17 00:00:00 2001
 From: Michal Krawczyk <mk@semihalf.com>
 Date: Fri, 15 Feb 2019 09:36:39 +0100
-Subject: [PATCH 11/15] net/ena: get device info statically
+Subject: [PATCH 11/22] net/ena: get device info statically
 
 [ upstream commit 117ba4a60488a0f96a5737f38ddba6d0f9a728b6 ]
 
@@ -22,7 +22,7 @@ Signed-off-by: Michal Krawczyk <mk@semihalf.com>
  2 files changed, 19 insertions(+), 20 deletions(-)
 
 diff --git a/drivers/net/ena/ena_ethdev.c b/drivers/net/ena/ena_ethdev.c
-index 32ba585c8..32f597cb7 100644
+index 32ba585c81..32f597cb76 100644
 --- a/drivers/net/ena/ena_ethdev.c
 +++ b/drivers/net/ena/ena_ethdev.c
 @@ -1392,9 +1392,14 @@ static int eth_ena_dev_init(struct rte_eth_dev *eth_dev)
@@ -93,7 +93,7 @@ index 32ba585c8..32f597cb7 100644
  		}
  
 diff --git a/drivers/net/ena/ena_ethdev.h b/drivers/net/ena/ena_ethdev.h
-index 394d05e02..2c98b4092 100644
+index 394d05e026..2c98b40924 100644
 --- a/drivers/net/ena/ena_ethdev.h
 +++ b/drivers/net/ena/ena_ethdev.h
 @@ -145,6 +145,12 @@ struct ena_stats_rx {

--- a/userspace/dpdk/18.02/0012-net-ena-fix-checksum-feature-flag.patch
+++ b/userspace/dpdk/18.02/0012-net-ena-fix-checksum-feature-flag.patch
@@ -1,7 +1,7 @@
 From 824927c3514e5d4528605ddb867e163227c5fde4 Mon Sep 17 00:00:00 2001
 From: Michal Krawczyk <mk@semihalf.com>
 Date: Mon, 8 Apr 2019 12:27:44 +0200
-Subject: [PATCH 12/15] net/ena: fix checksum feature flag
+Subject: [PATCH 12/22] net/ena: fix checksum feature flag
 
 [ upstream commit ef538c1a7f565c9b58518375a500aa864445fd11 ]
 
@@ -18,7 +18,7 @@ Signed-off-by: Michal Krawczyk <mk@semihalf.com>
  1 file changed, 1 insertion(+), 1 deletion(-)
 
 diff --git a/drivers/net/ena/ena_ethdev.c b/drivers/net/ena/ena_ethdev.c
-index 32f597cb7..4b4a2dacb 100644
+index 32f597cb76..4b4a2dacb4 100644
 --- a/drivers/net/ena/ena_ethdev.c
 +++ b/drivers/net/ena/ena_ethdev.c
 @@ -1397,7 +1397,7 @@ static int eth_ena_dev_init(struct rte_eth_dev *eth_dev)

--- a/userspace/dpdk/18.02/0013-net-ena-fix-Rx-checksum-errors-statistics.patch
+++ b/userspace/dpdk/18.02/0013-net-ena-fix-Rx-checksum-errors-statistics.patch
@@ -1,7 +1,7 @@
 From 9e3a21bf95fcbf00d3b7e070440bf00f0af85e70 Mon Sep 17 00:00:00 2001
 From: Michal Krawczyk <mk@semihalf.com>
 Date: Tue, 28 May 2019 10:28:34 +0200
-Subject: [PATCH 13/15] net/ena: fix Rx checksum errors statistics
+Subject: [PATCH 13/22] net/ena: fix Rx checksum errors statistics
 
 [ upstream commit ef74b5f7b69b9502ddab81121611243efcfe1dde ]
 
@@ -21,7 +21,7 @@ Signed-off-by: Michal Krawczyk <mk@semihalf.com>
  1 file changed, 5 insertions(+), 4 deletions(-)
 
 diff --git a/drivers/net/ena/ena_ethdev.c b/drivers/net/ena/ena_ethdev.c
-index 4b4a2dacb..c96558b48 100644
+index 4b4a2dacb4..c96558b485 100644
 --- a/drivers/net/ena/ena_ethdev.c
 +++ b/drivers/net/ena/ena_ethdev.c
 @@ -1651,6 +1651,11 @@ static uint16_t eth_ena_recv_pkts(void *rx_queue, struct rte_mbuf **rx_pkts,

--- a/userspace/dpdk/18.02/0014-net-ena-fix-assigning-NUMA-node-to-IO-queue.patch
+++ b/userspace/dpdk/18.02/0014-net-ena-fix-assigning-NUMA-node-to-IO-queue.patch
@@ -1,7 +1,7 @@
 From 3469d75fda188b5c8f5b174737880e98f14e5c12 Mon Sep 17 00:00:00 2001
 From: Michal Krawczyk <mk@semihalf.com>
 Date: Tue, 4 Jun 2019 12:59:36 +0200
-Subject: [PATCH 14/15] net/ena: fix assigning NUMA node to IO queue
+Subject: [PATCH 14/22] net/ena: fix assigning NUMA node to IO queue
 
 [ upstream commit 4217cb0b7d2c5385f06f531af7f14b860927aba7 ]
 
@@ -23,7 +23,7 @@ Reviewed-by: David Marchand <david.marchand@redhat.com>
  2 files changed, 8 insertions(+), 17 deletions(-)
 
 diff --git a/drivers/net/ena/ena_ethdev.c b/drivers/net/ena/ena_ethdev.c
-index c96558b48..be3442ec9 100644
+index c96558b485..be3442ec91 100644
 --- a/drivers/net/ena/ena_ethdev.c
 +++ b/drivers/net/ena/ena_ethdev.c
 @@ -39,7 +39,6 @@
@@ -106,7 +106,7 @@ index c96558b48..be3442ec9 100644
  
  	rxq->rx_buffer_info = rte_zmalloc("rxq->buffer_info",
 diff --git a/drivers/net/ena/ena_ethdev.h b/drivers/net/ena/ena_ethdev.h
-index 2c98b4092..7dd8b2596 100644
+index 2c98b40924..7dd8b2596e 100644
 --- a/drivers/net/ena/ena_ethdev.h
 +++ b/drivers/net/ena/ena_ethdev.h
 @@ -92,6 +92,8 @@ struct ena_ring {

--- a/userspace/dpdk/18.02/0015-net-ena-fix-L4-checksum-Tx-offload.patch
+++ b/userspace/dpdk/18.02/0015-net-ena-fix-L4-checksum-Tx-offload.patch
@@ -1,7 +1,7 @@
 From d199ead76aa31f68c6644a6fac6185b008f0c565 Mon Sep 17 00:00:00 2001
 From: Maciej Bielski <mba@semihalf.com>
 Date: Thu, 1 Aug 2019 13:45:36 +0200
-Subject: [PATCH 15/15] net/ena: fix L4 checksum Tx offload
+Subject: [PATCH 15/22] net/ena: fix L4 checksum Tx offload
 
 [ upstream commit 40e7c02155625f18a87faf5e6a8cec2e986146e8 ]
 
@@ -27,7 +27,7 @@ Acked-by: Michal Krawczyk <mk@semihalf.com>
  1 file changed, 4 insertions(+), 3 deletions(-)
 
 diff --git a/drivers/net/ena/ena_ethdev.c b/drivers/net/ena/ena_ethdev.c
-index be3442ec9..28e561dc7 100644
+index be3442ec91..28e561dc73 100644
 --- a/drivers/net/ena/ena_ethdev.c
 +++ b/drivers/net/ena/ena_ethdev.c
 @@ -317,12 +317,13 @@ static inline void ena_tx_mbuf_prepare(struct rte_mbuf *mbuf,

--- a/userspace/dpdk/18.02/0016-net-ena-base-fix-node-deallocation.patch
+++ b/userspace/dpdk/18.02/0016-net-ena-base-fix-node-deallocation.patch
@@ -1,0 +1,59 @@
+From 88e238f67dfa34fd86a5a4e2e1aeacc0088482e8 Mon Sep 17 00:00:00 2001
+From: Michal Krawczyk <mk@semihalf.com>
+Date: Thu, 2 Jul 2020 10:25:03 +0000
+Subject: [PATCH 16/22] net/ena/base: fix node deallocation
+
+The memzone handle wasn't saved anywhere - it could cause free of the
+invalid memory, as the mem_handle was never holding the right value.
+
+Signed-off-by: Michal Krawczyk <mk@semihalf.com>
+---
+ drivers/net/ena/base/ena_com.c       | 2 ++
+ drivers/net/ena/base/ena_plat_dpdk.h | 4 +++-
+ 2 files changed, 5 insertions(+), 1 deletion(-)
+
+diff --git a/drivers/net/ena/base/ena_com.c b/drivers/net/ena/base/ena_com.c
+index 38a0587754..1c38a1138d 100644
+--- a/drivers/net/ena/base/ena_com.c
++++ b/drivers/net/ena/base/ena_com.c
+@@ -347,6 +347,7 @@ static int ena_com_init_io_sq(struct ena_com_dev *ena_dev,
+ 					    size,
+ 					    io_sq->desc_addr.virt_addr,
+ 					    io_sq->desc_addr.phys_addr,
++					    io_sq->desc_addr.mem_handle,
+ 					    ctx->numa_node,
+ 					    dev_node);
+ 		if (!io_sq->desc_addr.virt_addr)
+@@ -400,6 +401,7 @@ static int ena_com_init_io_cq(struct ena_com_dev *ena_dev,
+ 				    size,
+ 				    io_cq->cdesc_addr.virt_addr,
+ 				    io_cq->cdesc_addr.phys_addr,
++				    io_cq->cdesc_addr.mem_handle,
+ 				    ctx->numa_node,
+ 				    prev_node);
+ 	if (!io_cq->cdesc_addr.virt_addr)
+diff --git a/drivers/net/ena/base/ena_plat_dpdk.h b/drivers/net/ena/base/ena_plat_dpdk.h
+index 72d501538f..8a623ca15f 100644
+--- a/drivers/net/ena/base/ena_plat_dpdk.h
++++ b/drivers/net/ena/base/ena_plat_dpdk.h
+@@ -206,7 +206,8 @@ typedef uint64_t dma_addr_t;
+ 		   ENA_TOUCH(dmadev);					\
+ 		   rte_memzone_free(handle); })
+ 
+-#define ENA_MEM_ALLOC_COHERENT_NODE(dmadev, size, virt, phys, node, dev_node) \
++#define ENA_MEM_ALLOC_COHERENT_NODE(					\
++	dmadev, size, virt, phys, mem_handle, node, dev_node)		\
+ 	do {								\
+ 		const struct rte_memzone *mz;				\
+ 		char z_name[RTE_MEMZONE_NAMESIZE];			\
+@@ -214,6 +215,7 @@ typedef uint64_t dma_addr_t;
+ 		snprintf(z_name, sizeof(z_name),			\
+ 				"ena_alloc_%d", ena_alloc_cnt++);	\
+ 		mz = rte_memzone_reserve(z_name, size, node, 0); \
++		mem_handle = mz;					\
+ 		if (mz == NULL) {					\
+ 			virt = NULL;					\
+ 			phys = 0;					\
+-- 
+2.20.1
+

--- a/userspace/dpdk/18.02/0017-net-ena-fix-indication-of-bad-L4-Rx-checksums.patch
+++ b/userspace/dpdk/18.02/0017-net-ena-fix-indication-of-bad-L4-Rx-checksums.patch
@@ -1,0 +1,44 @@
+From 806a93121049c47e118a9012aa168416e2c3f9f5 Mon Sep 17 00:00:00 2001
+From: Igor Chauskin <igorch@amazon.com>
+Date: Mon, 28 Oct 2019 11:23:33 +0100
+Subject: [PATCH 17/22] net/ena: fix indication of bad L4 Rx checksums
+
+[ upstream commit 05817057faba9356900ced61e24a22eef6bc4c87 ]
+
+Add checking of l4_csum_checked and frag flags before checking the
+l4_csum_error flag.
+
+In case of IP fragment/unchecked L4 csum - add PKT_RX_L4_CKSUM_UNKNOWN
+flag to the indicated mbuf.
+
+Fixes: 1173fca25af9 ("ena: add polling-mode driver")
+Cc: stable@dpdk.org
+
+Change-Id: I9f1414741eb44ca289a8bfd11d7e66110c95040e
+Signed-off-by: Igor Chauskin <igorch@amazon.com>
+Reviewed-by: Maciej Bielski <mba@semihalf.com>
+Reviewed-by: Michal Krawczyk <mk@semihalf.com>
+---
+ drivers/net/ena/ena_ethdev.c | 5 ++++-
+ 1 file changed, 4 insertions(+), 1 deletion(-)
+
+diff --git a/drivers/net/ena/ena_ethdev.c b/drivers/net/ena/ena_ethdev.c
+index 28e561dc73..a22c536e31 100644
+--- a/drivers/net/ena/ena_ethdev.c
++++ b/drivers/net/ena/ena_ethdev.c
+@@ -274,8 +274,11 @@ static inline void ena_rx_mbuf_prepare(struct rte_mbuf *mbuf,
+ 	else if (ena_rx_ctx->l3_proto == ENA_ETH_IO_L3_PROTO_IPV6)
+ 		packet_type |= RTE_PTYPE_L3_IPV6;
+ 
+-	if (unlikely(ena_rx_ctx->l4_csum_err))
++	if (unlikely(ena_rx_ctx->l4_csum_err) && !ena_rx_ctx->frag)
+ 		ol_flags |= PKT_RX_L4_CKSUM_BAD;
++	else
++		ol_flags |= PKT_RX_L4_CKSUM_UNKNOWN;
++
+ 	if (unlikely(ena_rx_ctx->l3_csum_err))
+ 		ol_flags |= PKT_RX_IP_CKSUM_BAD;
+ 
+-- 
+2.20.1
+

--- a/userspace/dpdk/18.02/0018-net-ena-ensure-Rx-buffer-size-is-at-least-1400B.patch
+++ b/userspace/dpdk/18.02/0018-net-ena-ensure-Rx-buffer-size-is-at-least-1400B.patch
@@ -1,0 +1,84 @@
+From a60707acfb102b386abd9118ede8707e5b2830e6 Mon Sep 17 00:00:00 2001
+From: Michal Krawczyk <mk@semihalf.com>
+Date: Wed, 8 Apr 2020 10:28:52 +0200
+Subject: [PATCH 18/22] net/ena: ensure Rx buffer size is at least 1400B
+
+[ upstream commit 38364c2687ead97b99402310087c27131a97748c ]
+
+Some of the ENA devices can't handle buffers which are smaller than a
+1400B. Because of this limitation, size of the buffer is being checked
+and limited during the Rx queue setup.
+
+If it's below the allowed value, PMD won't finish it's configuration
+successfully..
+
+Change-Id: Ib402d3bfad98a3fc4f91095d5c6f90c6069da021
+Signed-off-by: Michal Krawczyk <mk@semihalf.com>
+Reviewed-by: Igor Chauskin <igorch@amazon.com>
+Reviewed-by: Guy Tzalik <gtzalik@amazon.com>
+---
+ drivers/net/ena/ena_ethdev.c | 12 +++++++++++-
+ drivers/net/ena/ena_ethdev.h |  3 ++-
+ 2 files changed, 13 insertions(+), 2 deletions(-)
+
+diff --git a/drivers/net/ena/ena_ethdev.c b/drivers/net/ena/ena_ethdev.c
+index a22c536e31..c284d77d2f 100644
+--- a/drivers/net/ena/ena_ethdev.c
++++ b/drivers/net/ena/ena_ethdev.c
+@@ -1,7 +1,7 @@
+ /*-
+ * BSD LICENSE
+ *
+-* Copyright (c) 2015-2016 Amazon.com, Inc. or its affiliates.
++* Copyright (c) 2015-2020 Amazon.com, Inc. or its affiliates.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+@@ -1076,6 +1076,7 @@ static int ena_rx_queue_setup(struct rte_eth_dev *dev,
+ 	struct ena_adapter *adapter =
+ 		(struct ena_adapter *)(dev->data->dev_private);
+ 	struct ena_ring *rxq = NULL;
++	size_t buffer_size;
+ 	uint16_t ena_qid = 0;
+ 	int rc = 0;
+ 	struct ena_com_dev *ena_dev = &adapter->ena_dev;
+@@ -1107,6 +1108,15 @@ static int ena_rx_queue_setup(struct rte_eth_dev *dev,
+ 		return -EINVAL;
+ 	}
+ 
++	/* ENA isn't supporting buffers smaller than 1400 bytes */
++	buffer_size = rte_pktmbuf_data_room_size(mp) - RTE_PKTMBUF_HEADROOM;
++	if (buffer_size < ENA_RX_BUF_MIN_SIZE) {
++		PMD_DRV_LOG(ERR,
++			"Unsupported size of RX buffer: %zu (min size: %d)\n",
++			buffer_size, ENA_RX_BUF_MIN_SIZE);
++		return -EINVAL;
++	}
++
+ 	ena_qid = ENA_IO_RXQ_IDX(queue_idx);
+ 
+ 	ctx.qid = ena_qid;
+diff --git a/drivers/net/ena/ena_ethdev.h b/drivers/net/ena/ena_ethdev.h
+index 7dd8b2596e..f6140e28ca 100644
+--- a/drivers/net/ena/ena_ethdev.h
++++ b/drivers/net/ena/ena_ethdev.h
+@@ -1,7 +1,7 @@
+ /*-
+ * BSD LICENSE
+ *
+-* Copyright (c) 2015-2016 Amazon.com, Inc. or its affiliates.
++* Copyright (c) 2015-2020 Amazon.com, Inc. or its affiliates.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+@@ -47,6 +47,7 @@
+ #define ENA_MIN_FRAME_LEN	64
+ #define ENA_NAME_MAX_LEN	20
+ #define ENA_PKT_MAX_BUFS	17
++#define ENA_RX_BUF_MIN_SIZE	1400
+ 
+ #define ENA_MMIO_DISABLE_REG_READ	BIT(0)
+ 
+-- 
+2.20.1
+

--- a/userspace/dpdk/18.02/0019-net-ena-base-make-allocation-macros-thread-safe.patch
+++ b/userspace/dpdk/18.02/0019-net-ena-base-make-allocation-macros-thread-safe.patch
@@ -1,0 +1,103 @@
+From 0984b6d53f6e626dcf66c82fccc28ecd69ba6b6c Mon Sep 17 00:00:00 2001
+From: Igor Chauskin <igorch@amazon.com>
+Date: Wed, 8 Apr 2020 10:28:53 +0200
+Subject: [PATCH 19/22] net/ena/base: make allocation macros thread-safe
+
+[ upstream commit b14fcac035fd8514851c9140a4e26d765b61c532 ]
+
+Memory allocation region id could possibly be non-unique
+due to non-atomic increment, causing allocation failure.
+
+Fixes: 9ba7981ec992 ("ena: add communication layer for DPDK")
+Cc: stable@dpdk.org
+
+Change-Id: Ib9207aaae4e5e7ecdf1a99a0f23a508a53af631d
+Signed-off-by: Igor Chauskin <igorch@amazon.com>
+Reviewed-by: Michal Krawczyk <mk@semihalf.com>
+Reviewed-by: Guy Tzalik <gtzalik@amazon.com>
+---
+ drivers/net/ena/base/ena_com.c       |  2 --
+ drivers/net/ena/base/ena_plat_dpdk.h | 16 ++++++++++++----
+ drivers/net/ena/ena_ethdev.c         |  6 ++++++
+ 3 files changed, 18 insertions(+), 6 deletions(-)
+
+diff --git a/drivers/net/ena/base/ena_com.c b/drivers/net/ena/base/ena_com.c
+index 1c38a1138d..0dbd1b0cd0 100644
+--- a/drivers/net/ena/base/ena_com.c
++++ b/drivers/net/ena/base/ena_com.c
+@@ -62,8 +62,6 @@
+ 
+ #define ENA_MMIO_READ_TIMEOUT 0xFFFFFFFF
+ 
+-static int ena_alloc_cnt;
+-
+ /*****************************************************************************/
+ /*****************************************************************************/
+ /*****************************************************************************/
+diff --git a/drivers/net/ena/base/ena_plat_dpdk.h b/drivers/net/ena/base/ena_plat_dpdk.h
+index 8a623ca15f..c93576f56f 100644
+--- a/drivers/net/ena/base/ena_plat_dpdk.h
++++ b/drivers/net/ena/base/ena_plat_dpdk.h
+@@ -1,7 +1,7 @@
+ /*-
+ * BSD LICENSE
+ *
+-* Copyright (c) 2015-2016 Amazon.com, Inc. or its affiliates.
++* Copyright (c) 2015-2020 Amazon.com, Inc. or its affiliates.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+@@ -183,13 +183,20 @@ typedef uint64_t dma_addr_t;
+ #define ena_wait_event_t ena_wait_queue_t
+ #define ENA_MIGHT_SLEEP()
+ 
++/*
++ * Each rte_memzone should have unique name.
++ * To satisfy it, count number of allocations and add it to name.
++ */
++extern rte_atomic32_t ena_alloc_cnt;
++
+ #define ENA_MEM_ALLOC_COHERENT(dmadev, size, virt, phys, handle)	\
+ 	do {								\
+ 		const struct rte_memzone *mz;				\
+ 		char z_name[RTE_MEMZONE_NAMESIZE];			\
+ 		ENA_TOUCH(dmadev); ENA_TOUCH(handle);			\
+ 		snprintf(z_name, sizeof(z_name),			\
+-				"ena_alloc_%d", ena_alloc_cnt++);	\
++			 "ena_alloc_%d",				\
++			 rte_atomic32_add_return(&ena_alloc_cnt, 1));	\
+ 		mz = rte_memzone_reserve(z_name, size, SOCKET_ID_ANY, 0); \
+ 		handle = mz;						\
+ 		if (mz == NULL) {					\
+@@ -213,8 +220,9 @@ typedef uint64_t dma_addr_t;
+ 		char z_name[RTE_MEMZONE_NAMESIZE];			\
+ 		ENA_TOUCH(dmadev); ENA_TOUCH(dev_node);			\
+ 		snprintf(z_name, sizeof(z_name),			\
+-				"ena_alloc_%d", ena_alloc_cnt++);	\
+-		mz = rte_memzone_reserve(z_name, size, node, 0); \
++			 "ena_alloc_%d",				\
++			 rte_atomic32_add_return(&ena_alloc_cnt, 1));	\
++		mz = rte_memzone_reserve(z_name, size, node, 0);	\
+ 		mem_handle = mz;					\
+ 		if (mz == NULL) {					\
+ 			virt = NULL;					\
+diff --git a/drivers/net/ena/ena_ethdev.c b/drivers/net/ena/ena_ethdev.c
+index c284d77d2f..2f5676c5e4 100644
+--- a/drivers/net/ena/ena_ethdev.c
++++ b/drivers/net/ena/ena_ethdev.c
+@@ -113,6 +113,12 @@ struct ena_stats {
+ #define ENA_STAT_GLOBAL_ENTRY(stat) \
+ 	ENA_STAT_ENTRY(stat, dev)
+ 
++/*
++ * Each rte_memzone should have unique name.
++ * To satisfy it, count number of allocation and add it to name.
++ */
++rte_atomic32_t ena_alloc_cnt;
++
+ static const struct ena_stats ena_stats_global_strings[] = {
+ 	ENA_STAT_GLOBAL_ENTRY(tx_timeout),
+ 	ENA_STAT_GLOBAL_ENTRY(io_suspend),
+-- 
+2.20.1
+

--- a/userspace/dpdk/18.02/0020-net-ena-base-prevent-allocation-of-zero-sized-memory.patch
+++ b/userspace/dpdk/18.02/0020-net-ena-base-prevent-allocation-of-zero-sized-memory.patch
@@ -1,0 +1,74 @@
+From 7d66a94d8b65849d3bc816beb5254c6b8a38ebcc Mon Sep 17 00:00:00 2001
+From: Igor Chauskin <igorch@amazon.com>
+Date: Wed, 8 Apr 2020 10:28:54 +0200
+Subject: [PATCH 20/22] net/ena/base: prevent allocation of zero sized memory
+
+[ upstream commit 29dc10d9424ccf26a346387b0a707185e2432400 ]
+
+rte_memzone_reserve() will reserve the biggest contiguous memzone
+available if received 0 as size param.
+
+Fixes: 9ba7981ec992 ("ena: add communication layer for DPDK")
+Cc: stable@dpdk.org
+
+Change-Id: I2f71119e93c5e9addd8c538820093f030066d690
+Signed-off-by: Igor Chauskin <igorch@amazon.com>
+Reviewed-by: Michal Krawczyk <mk@semihalf.com>
+Reviewed-by: Guy Tzalik <gtzalik@amazon.com>
+---
+ drivers/net/ena/base/ena_plat_dpdk.h | 27 ++++++++++++++++-----------
+ 1 file changed, 16 insertions(+), 11 deletions(-)
+
+diff --git a/drivers/net/ena/base/ena_plat_dpdk.h b/drivers/net/ena/base/ena_plat_dpdk.h
+index c93576f56f..eec40ad705 100644
+--- a/drivers/net/ena/base/ena_plat_dpdk.h
++++ b/drivers/net/ena/base/ena_plat_dpdk.h
+@@ -191,14 +191,17 @@ extern rte_atomic32_t ena_alloc_cnt;
+ 
+ #define ENA_MEM_ALLOC_COHERENT(dmadev, size, virt, phys, handle)	\
+ 	do {								\
+-		const struct rte_memzone *mz;				\
+-		char z_name[RTE_MEMZONE_NAMESIZE];			\
++		const struct rte_memzone *mz = NULL;			\
+ 		ENA_TOUCH(dmadev); ENA_TOUCH(handle);			\
+-		snprintf(z_name, sizeof(z_name),			\
++		if (size > 0) {						\
++			char z_name[RTE_MEMZONE_NAMESIZE];		\
++			snprintf(z_name, sizeof(z_name),		\
+ 			 "ena_alloc_%d",				\
+ 			 rte_atomic32_add_return(&ena_alloc_cnt, 1));	\
+-		mz = rte_memzone_reserve(z_name, size, SOCKET_ID_ANY, 0); \
+-		handle = mz;						\
++			mz = rte_memzone_reserve(z_name, size,		\
++				SOCKET_ID_ANY, 0);			\
++			handle = mz;					\
++		}							\
+ 		if (mz == NULL) {					\
+ 			virt = NULL;					\
+ 			phys = 0;					\
+@@ -216,14 +219,16 @@ extern rte_atomic32_t ena_alloc_cnt;
+ #define ENA_MEM_ALLOC_COHERENT_NODE(					\
+ 	dmadev, size, virt, phys, mem_handle, node, dev_node)		\
+ 	do {								\
+-		const struct rte_memzone *mz;				\
+-		char z_name[RTE_MEMZONE_NAMESIZE];			\
++		const struct rte_memzone *mz = NULL;			\
+ 		ENA_TOUCH(dmadev); ENA_TOUCH(dev_node);			\
+-		snprintf(z_name, sizeof(z_name),			\
++		if (size > 0) {						\
++			char z_name[RTE_MEMZONE_NAMESIZE];		\
++			snprintf(z_name, sizeof(z_name),		\
+ 			 "ena_alloc_%d",				\
+-			 rte_atomic32_add_return(&ena_alloc_cnt, 1));	\
+-		mz = rte_memzone_reserve(z_name, size, node, 0);	\
+-		mem_handle = mz;					\
++			 rte_atomic32_add_return(&ena_alloc_cnt, 1));   \
++			mz = rte_memzone_reserve(z_name, size, node, 0); \
++			mem_handle = mz;				\
++		}							\
+ 		if (mz == NULL) {					\
+ 			virt = NULL;					\
+ 			phys = 0;					\
+-- 
+2.20.1
+

--- a/userspace/dpdk/18.02/0021-net-ena-set-IO-ring-size-to-valid-value.patch
+++ b/userspace/dpdk/18.02/0021-net-ena-set-IO-ring-size-to-valid-value.patch
@@ -1,0 +1,49 @@
+From cd8e5707dacc29b203650087287c05601c488f40 Mon Sep 17 00:00:00 2001
+From: Michal Krawczyk <mk@semihalf.com>
+Date: Fri, 3 Jul 2020 13:14:58 +0000
+Subject: [PATCH 21/22] net/ena: set IO ring size to valid value
+
+[ upstream commit badc3a6aa133a886a61b9e3ad666e5675f7ec3d3 ]
+
+IO rings were configured with the maximum allowed size for the Tx/Rx
+rings. However, the application could decide to create smaller rings.
+
+This patch is using value stored in the ring instead of the value from
+the adapter which is indicating the maximum allowed value.
+
+Fixes: df238f84c0a2 ("net/ena: recreate HW IO rings on start and stop")
+Cc: stable@dpdk.org
+
+Change-Id: Icf9102e2aa4e7413b6620b36dd232673239b7291
+Signed-off-by: Michal Krawczyk <mk@semihalf.com>
+Reviewed-by: Igor Chauskin <igorch@amazon.com>
+Reviewed-by: Guy Tzalik <gtzalik@amazon.com>
+---
+ drivers/net/ena/ena_ethdev.c | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/drivers/net/ena/ena_ethdev.c b/drivers/net/ena/ena_ethdev.c
+index 2f5676c5e4..92678c32d6 100644
+--- a/drivers/net/ena/ena_ethdev.c
++++ b/drivers/net/ena/ena_ethdev.c
+@@ -1010,7 +1010,7 @@ static int ena_tx_queue_setup(struct rte_eth_dev *dev,
+ 	ctx.qid = ena_qid;
+ 	ctx.msix_vector = -1; /* admin interrupts not used */
+ 	ctx.mem_queue_type = ena_dev->tx_mem_queue_type;
+-	ctx.queue_size = adapter->tx_ring_size;
++	ctx.queue_size = nb_desc;
+ 	ctx.numa_node = socket_id;
+ 
+ 	rc = ena_com_create_io_queue(ena_dev, &ctx);
+@@ -1129,7 +1129,7 @@ static int ena_rx_queue_setup(struct rte_eth_dev *dev,
+ 	ctx.direction = ENA_COM_IO_QUEUE_DIRECTION_RX;
+ 	ctx.mem_queue_type = ENA_ADMIN_PLACEMENT_POLICY_HOST;
+ 	ctx.msix_vector = -1; /* admin interrupts not used */
+-	ctx.queue_size = adapter->rx_ring_size;
++	ctx.queue_size = nb_desc;
+ 	ctx.numa_node = socket_id;
+ 
+ 	rc = ena_com_create_io_queue(ena_dev, &ctx);
+-- 
+2.20.1
+

--- a/userspace/dpdk/18.02/0022-net-ena-limit-refill-threshold-by-fixed-value.patch
+++ b/userspace/dpdk/18.02/0022-net-ena-limit-refill-threshold-by-fixed-value.patch
@@ -1,0 +1,118 @@
+From e6fcf534a4f341c0e5e4dad11c68e644d6eef01a Mon Sep 17 00:00:00 2001
+From: Michal Krawczyk <mk@semihalf.com>
+Date: Wed, 8 Apr 2020 10:29:16 +0200
+Subject: [PATCH 22/22] net/ena: limit refill threshold by fixed value
+
+[ upstream commit 7755060798de9c0146df8809926030ed47fc9086 ]
+
+Divider used for both Tx and Rx cleanup/refill threshold can cause too
+big delay in case of the really big rings - for example if the 8k Rx
+ring will be used, the refill won't trigger unless 1024 threshold will
+be reached. It will also cause driver to try to allocate that much
+descriptors.
+
+Limiting it by fixed value - 256 in that case, would limit maximum
+time spent in repopulate function.
+
+Change-Id: Ia8659e6ddf179ff612a780adc6fe55d13eeac6e9
+Signed-off-by: Michal Krawczyk <mk@semihalf.com>
+Reviewed-by: Igor Chauskin <igorch@amazon.com>
+Reviewed-by: Guy Tzalik <gtzalik@amazon.com>
+---
+ drivers/net/ena/ena_ethdev.c | 26 ++++++++++++++------------
+ drivers/net/ena/ena_ethdev.h | 10 ++++++++++
+ 2 files changed, 24 insertions(+), 12 deletions(-)
+
+diff --git a/drivers/net/ena/ena_ethdev.c b/drivers/net/ena/ena_ethdev.c
+index 92678c32d6..6f85cc59c2 100644
+--- a/drivers/net/ena/ena_ethdev.c
++++ b/drivers/net/ena/ena_ethdev.c
+@@ -61,14 +61,6 @@
+ /*reverse version of ENA_IO_RXQ_IDX*/
+ #define ENA_IO_RXQ_IDX_REV(q)	((q - 1) / 2)
+ 
+-/* While processing submitted and completed descriptors (rx and tx path
+- * respectively) in a loop it is desired to:
+- *  - perform batch submissions while populating sumbissmion queue
+- *  - avoid blocking transmission of other packets during cleanup phase
+- * Hence the utilization ratio of 1/8 of a queue size.
+- */
+-#define ENA_RING_DESCS_RATIO(ring_size)	(ring_size / 8)
+-
+ #define __MERGE_64B_H_L(h, l) (((uint64_t)h << 32) | l)
+ #define TEST_BIT(val, bit_shift) (val & (1UL << bit_shift))
+ 
+@@ -1595,6 +1587,8 @@ static uint16_t eth_ena_recv_pkts(void *rx_queue, struct rte_mbuf **rx_pkts,
+ 	struct ena_ring *rx_ring = (struct ena_ring *)(rx_queue);
+ 	unsigned int ring_size = rx_ring->ring_size;
+ 	unsigned int ring_mask = ring_size - 1;
++	unsigned int free_queue_entries;
++	unsigned int refill_threshold;
+ 	uint16_t next_to_clean = rx_ring->next_to_clean;
+ 	uint16_t desc_in_use = 0;
+ 	unsigned int recv_idx = 0;
+@@ -1674,11 +1668,15 @@ static uint16_t eth_ena_recv_pkts(void *rx_queue, struct rte_mbuf **rx_pkts,
+ 
+ 	rx_ring->next_to_clean = next_to_clean;
+ 
+-	desc_in_use = desc_in_use - completed + 1;
++	free_queue_entries = ena_com_sq_empty_space(rx_ring->ena_com_io_sq);
++	refill_threshold =
++		RTE_MIN(ring_size / ENA_REFILL_THRESH_DIVIDER,
++		(unsigned int)ENA_REFILL_THRESH_PACKET);
++
+ 	/* Burst refill to save doorbells, memory barriers, const interval */
+-	if (ring_size - desc_in_use > ENA_RING_DESCS_RATIO(ring_size)) {
++	if (free_queue_entries > refill_threshold) {
+ 		ena_com_update_dev_comp_head(rx_ring->ena_com_io_cq);
+-		ena_populate_rx_queue(rx_ring, ring_size - desc_in_use);
++		ena_populate_rx_queue(rx_ring, free_queue_entries);
+ 	}
+ 
+ 	return recv_idx;
+@@ -1763,6 +1761,7 @@ static uint16_t eth_ena_xmit_pkts(void *tx_queue, struct rte_mbuf **tx_pkts,
+ 	struct rte_mbuf *mbuf;
+ 	unsigned int ring_size = tx_ring->ring_size;
+ 	unsigned int ring_mask = ring_size - 1;
++	unsigned int cleanup_budget;
+ 	struct ena_com_tx_ctx ena_tx_ctx;
+ 	struct ena_tx_buffer *tx_info;
+ 	struct ena_com_buf *ebuf;
+@@ -1869,9 +1868,12 @@ static uint16_t eth_ena_xmit_pkts(void *tx_queue, struct rte_mbuf **tx_pkts,
+ 		/* Put back descriptor to the ring for reuse */
+ 		tx_ring->empty_tx_reqs[next_to_clean & ring_mask] = req_id;
+ 		next_to_clean++;
++		cleanup_budget =
++			RTE_MIN(ring_size / ENA_REFILL_THRESH_DIVIDER,
++			(unsigned int)ENA_REFILL_THRESH_PACKET);
+ 
+ 		/* If too many descs to clean, leave it for another run */
+-		if (unlikely(total_tx_descs > ENA_RING_DESCS_RATIO(ring_size)))
++		if (unlikely(total_tx_descs > cleanup_budget))
+ 			break;
+ 	}
+ 
+diff --git a/drivers/net/ena/ena_ethdev.h b/drivers/net/ena/ena_ethdev.h
+index f6140e28ca..aa1bf5efdd 100644
+--- a/drivers/net/ena/ena_ethdev.h
++++ b/drivers/net/ena/ena_ethdev.h
+@@ -51,6 +51,16 @@
+ 
+ #define ENA_MMIO_DISABLE_REG_READ	BIT(0)
+ 
++/* While processing submitted and completed descriptors (rx and tx path
++ * respectively) in a loop it is desired to:
++ *  - perform batch submissions while populating sumbissmion queue
++ *  - avoid blocking transmission of other packets during cleanup phase
++ * Hence the utilization ratio of 1/8 of a queue size or max value if the size
++ * of the ring is very big - like 8k Rx rings.
++ */
++#define ENA_REFILL_THRESH_DIVIDER      8
++#define ENA_REFILL_THRESH_PACKET       256
++
+ struct ena_adapter;
+ 
+ enum ena_ring_type {
+-- 
+2.20.1
+

--- a/userspace/dpdk/18.05/0001-net-ena-check-pointer-before-memset.patch
+++ b/userspace/dpdk/18.05/0001-net-ena-check-pointer-before-memset.patch
@@ -1,7 +1,7 @@
 From f130532579c8a60e7757cf315189fbe5087acc46 Mon Sep 17 00:00:00 2001
 From: Rafal Kozik <rk@semihalf.com>
 Date: Thu, 7 Jun 2018 11:43:18 +0200
-Subject: [PATCH 01/15] net/ena: check pointer before memset
+Subject: [PATCH 01/22] net/ena: check pointer before memset
 
 [ upstream commit 46916aa17d4b2007df8c0454f99ba0ca8b8cb93b ]
 
@@ -19,7 +19,7 @@ Acked-by: Michal Krawczyk <mk@semihalf.com>
  1 file changed, 16 insertions(+), 6 deletions(-)
 
 diff --git a/drivers/net/ena/base/ena_plat_dpdk.h b/drivers/net/ena/base/ena_plat_dpdk.h
-index 93345199a..0ee440c21 100644
+index 93345199ad..0ee440c210 100644
 --- a/drivers/net/ena/base/ena_plat_dpdk.h
 +++ b/drivers/net/ena/base/ena_plat_dpdk.h
 @@ -190,10 +190,15 @@ typedef uint64_t dma_addr_t;

--- a/userspace/dpdk/18.05/0002-net-ena-change-memory-type.patch
+++ b/userspace/dpdk/18.05/0002-net-ena-change-memory-type.patch
@@ -1,7 +1,7 @@
 From 52b4a8350aa705f1a0bf31d40db72d18fc1e24ea Mon Sep 17 00:00:00 2001
 From: Rafal Kozik <rk@semihalf.com>
 Date: Thu, 7 Jun 2018 11:43:19 +0200
-Subject: [PATCH 02/15] net/ena: change memory type
+Subject: [PATCH 02/22] net/ena: change memory type
 
 [ upstream commit 9f32c7e7e6ce58ab772913f54f8328c1c0186a17 ]
 
@@ -22,7 +22,7 @@ Acked-by: Michal Krawczyk <mk@semihalf.com>
  1 file changed, 1 insertion(+), 8 deletions(-)
 
 diff --git a/drivers/net/ena/base/ena_plat_dpdk.h b/drivers/net/ena/base/ena_plat_dpdk.h
-index 0ee440c21..e7917c506 100644
+index 0ee440c210..e7917c5065 100644
 --- a/drivers/net/ena/base/ena_plat_dpdk.h
 +++ b/drivers/net/ena/base/ena_plat_dpdk.h
 @@ -226,15 +226,8 @@ typedef uint64_t dma_addr_t;

--- a/userspace/dpdk/18.05/0003-net-ena-fix-GENMASK_ULL-macro.patch
+++ b/userspace/dpdk/18.05/0003-net-ena-fix-GENMASK_ULL-macro.patch
@@ -1,7 +1,7 @@
 From 622fcfae471ebc7af522a43748649ec22e32a8ca Mon Sep 17 00:00:00 2001
 From: Rafal Kozik <rk@semihalf.com>
 Date: Thu, 7 Jun 2018 11:43:20 +0200
-Subject: [PATCH 03/15] net/ena: fix GENMASK_ULL macro
+Subject: [PATCH 03/22] net/ena: fix GENMASK_ULL macro
 
 [ upstream commit 7544aee8d0b4ae0262b1ba7e1539cf8171664df7 ]
 
@@ -20,7 +20,7 @@ Acked-by: Michal Krawczyk <mk@semihalf.com>
  1 file changed, 3 insertions(+), 1 deletion(-)
 
 diff --git a/drivers/net/ena/base/ena_plat_dpdk.h b/drivers/net/ena/base/ena_plat_dpdk.h
-index e7917c506..558966517 100644
+index e7917c5065..558966517c 100644
 --- a/drivers/net/ena/base/ena_plat_dpdk.h
 +++ b/drivers/net/ena/base/ena_plat_dpdk.h
 @@ -116,11 +116,13 @@ typedef uint64_t dma_addr_t;

--- a/userspace/dpdk/18.05/0004-net-ena-set-link-speed-as-none.patch
+++ b/userspace/dpdk/18.05/0004-net-ena-set-link-speed-as-none.patch
@@ -1,7 +1,7 @@
 From fd3792a1316689d1fa54346fcbf1d71f6751eccd Mon Sep 17 00:00:00 2001
 From: Rafal Kozik <rk@semihalf.com>
 Date: Thu, 7 Jun 2018 11:43:22 +0200
-Subject: [PATCH 04/15] net/ena: set link speed as none
+Subject: [PATCH 04/22] net/ena: set link speed as none
 
 [ upstream commit 41e59028dd8ab2038a7655c6fc3098222661aa53 ]
 
@@ -21,7 +21,7 @@ Acked-by: Michal Krawczyk <mk@semihalf.com>
  1 file changed, 1 insertion(+), 1 deletion(-)
 
 diff --git a/drivers/net/ena/ena_ethdev.c b/drivers/net/ena/ena_ethdev.c
-index c595cc7e6..f10bee236 100644
+index c595cc7e62..f10bee2366 100644
 --- a/drivers/net/ena/ena_ethdev.c
 +++ b/drivers/net/ena/ena_ethdev.c
 @@ -725,7 +725,7 @@ static int ena_link_update(struct rte_eth_dev *dev,

--- a/userspace/dpdk/18.05/0005-net-ena-fix-SIGFPE-with-0-Rx-queue.patch
+++ b/userspace/dpdk/18.05/0005-net-ena-fix-SIGFPE-with-0-Rx-queue.patch
@@ -1,7 +1,7 @@
 From 68f8ac904a0079e519af7ddc191f4f22f66a2069 Mon Sep 17 00:00:00 2001
 From: Daria Kolistratova <daria.kolistratova@intel.com>
 Date: Tue, 26 Jun 2018 18:38:56 +0100
-Subject: [PATCH 05/15] net/ena: fix SIGFPE with 0 Rx queue
+Subject: [PATCH 05/22] net/ena: fix SIGFPE with 0 Rx queue
 
 [ upstream commit 361913ad6f8c05fc541fe4bfdae3b0dc095ae3af ]
 
@@ -19,7 +19,7 @@ Acked-by: Michal Krawczyk <mk@semihalf.com>
  1 file changed, 1 insertion(+), 1 deletion(-)
 
 diff --git a/drivers/net/ena/ena_ethdev.c b/drivers/net/ena/ena_ethdev.c
-index f10bee236..ebc911168 100644
+index f10bee2366..ebc9111684 100644
 --- a/drivers/net/ena/ena_ethdev.c
 +++ b/drivers/net/ena/ena_ethdev.c
 @@ -924,7 +924,7 @@ static int ena_start(struct rte_eth_dev *dev)

--- a/userspace/dpdk/18.05/0006-net-ena-fix-passing-RSS-hash-to-mbuf.patch
+++ b/userspace/dpdk/18.05/0006-net-ena-fix-passing-RSS-hash-to-mbuf.patch
@@ -1,7 +1,7 @@
 From 952581ced26c55856be49a2e8220debd940966ab Mon Sep 17 00:00:00 2001
 From: Stewart Allen <allenste@amazon.com>
 Date: Thu, 25 Oct 2018 19:59:22 +0200
-Subject: [PATCH 06/15] net/ena: fix passing RSS hash to mbuf
+Subject: [PATCH 06/22] net/ena: fix passing RSS hash to mbuf
 
 [ upstream commit e5df9f33db00eb9d322abaefff30da74fd0e625d ]
 
@@ -19,7 +19,7 @@ Acked-by: Michal Krawczyk <mk@semihalf.com>
  1 file changed, 1 insertion(+), 1 deletion(-)
 
 diff --git a/drivers/net/ena/ena_ethdev.c b/drivers/net/ena/ena_ethdev.c
-index ebc911168..f0849a455 100644
+index ebc9111684..f0849a455d 100644
 --- a/drivers/net/ena/ena_ethdev.c
 +++ b/drivers/net/ena/ena_ethdev.c
 @@ -1599,7 +1599,7 @@ static uint16_t eth_ena_recv_pkts(void *rx_queue, struct rte_mbuf **rx_pkts,

--- a/userspace/dpdk/18.05/0007-net-ena-add-supported-RSS-offloads-types.patch
+++ b/userspace/dpdk/18.05/0007-net-ena-add-supported-RSS-offloads-types.patch
@@ -1,7 +1,7 @@
 From 88726d133639d9f03382af7a3f18da7c2337dc8e Mon Sep 17 00:00:00 2001
 From: Rafal Kozik <rk@semihalf.com>
 Date: Fri, 14 Dec 2018 14:18:38 +0100
-Subject: [PATCH 07/15] net/ena: add supported RSS offloads types
+Subject: [PATCH 07/22] net/ena: add supported RSS offloads types
 
 [ upstream commit b01ead202beb45346d7daeb2f2b1a608006af644 ]
 
@@ -20,7 +20,7 @@ Acked-by: Michal Krawczyk <mk@semihalf.com>
  1 file changed, 3 insertions(+)
 
 diff --git a/drivers/net/ena/ena_ethdev.c b/drivers/net/ena/ena_ethdev.c
-index f0849a455..27717e739 100644
+index f0849a455d..27717e7397 100644
 --- a/drivers/net/ena/ena_ethdev.c
 +++ b/drivers/net/ena/ena_ethdev.c
 @@ -1516,6 +1516,9 @@ static void ena_infos_get(struct rte_eth_dev *dev,

--- a/userspace/dpdk/18.05/0008-net-ena-update-completion-queue-after-cleanup.patch
+++ b/userspace/dpdk/18.05/0008-net-ena-update-completion-queue-after-cleanup.patch
@@ -1,7 +1,7 @@
 From f5003710a264d8e510e1c88cadaec2779ae64369 Mon Sep 17 00:00:00 2001
 From: Rafal Kozik <rk@semihalf.com>
 Date: Fri, 14 Dec 2018 14:18:44 +0100
-Subject: [PATCH 08/15] net/ena: update completion queue after cleanup
+Subject: [PATCH 08/22] net/ena: update completion queue after cleanup
 
 [ upstream commit a45462c507e98b49cb5c2302e0be3c72d2e20a1a ]
 
@@ -19,7 +19,7 @@ Acked-by: Michal Krawczyk <mk@semihalf.com>
  1 file changed, 5 insertions(+), 2 deletions(-)
 
 diff --git a/drivers/net/ena/ena_ethdev.c b/drivers/net/ena/ena_ethdev.c
-index 27717e739..ef6bc4067 100644
+index 27717e7397..ef6bc40671 100644
 --- a/drivers/net/ena/ena_ethdev.c
 +++ b/drivers/net/ena/ena_ethdev.c
 @@ -1613,8 +1613,10 @@ static uint16_t eth_ena_recv_pkts(void *rx_queue, struct rte_mbuf **rx_pkts,

--- a/userspace/dpdk/18.05/0009-net-ena-fix-dev-init-with-multi-process.patch
+++ b/userspace/dpdk/18.05/0009-net-ena-fix-dev-init-with-multi-process.patch
@@ -1,7 +1,7 @@
 From f6b50ee14ce8433701ce0e5d356081a509f68782 Mon Sep 17 00:00:00 2001
 From: Michal Krawczyk <mk@semihalf.com>
 Date: Fri, 25 Jan 2019 09:10:25 +0100
-Subject: [PATCH 09/15] net/ena: fix dev init with multi-process
+Subject: [PATCH 09/22] net/ena: fix dev init with multi-process
 
 [ upstream commit fd9768905870856a2340266d25f8c0100dfccfff ]
 
@@ -22,7 +22,7 @@ Signed-off-by: Michal Krawczyk <mk@semihalf.com>
  1 file changed, 6 insertions(+), 5 deletions(-)
 
 diff --git a/drivers/net/ena/ena_ethdev.c b/drivers/net/ena/ena_ethdev.c
-index ef6bc4067..6bbfd62c0 100644
+index ef6bc40671..6bbfd62c0d 100644
 --- a/drivers/net/ena/ena_ethdev.c
 +++ b/drivers/net/ena/ena_ethdev.c
 @@ -1297,19 +1297,20 @@ static int eth_ena_dev_init(struct rte_eth_dev *eth_dev)

--- a/userspace/dpdk/18.05/0010-net-ena-fix-errno-to-positive-value.patch
+++ b/userspace/dpdk/18.05/0010-net-ena-fix-errno-to-positive-value.patch
@@ -1,7 +1,7 @@
 From 3a207a2ce92ded436d0f25fb26b3b529f22dafdb Mon Sep 17 00:00:00 2001
 From: Michal Krawczyk <mk@semihalf.com>
 Date: Fri, 25 Jan 2019 09:10:26 +0100
-Subject: [PATCH 10/15] net/ena: fix errno to positive value
+Subject: [PATCH 10/22] net/ena: fix errno to positive value
 
 [ upstream commit baeed5f404dd1b049118cfec26a2fd3203671572 ]
 
@@ -18,7 +18,7 @@ Signed-off-by: Michal Krawczyk <mk@semihalf.com>
  1 file changed, 3 insertions(+), 3 deletions(-)
 
 diff --git a/drivers/net/ena/ena_ethdev.c b/drivers/net/ena/ena_ethdev.c
-index 6bbfd62c0..d09633912 100644
+index 6bbfd62c0d..d096339121 100644
 --- a/drivers/net/ena/ena_ethdev.c
 +++ b/drivers/net/ena/ena_ethdev.c
 @@ -1664,14 +1664,14 @@ eth_ena_prep_pkts(void *tx_queue, struct rte_mbuf **tx_pkts,

--- a/userspace/dpdk/18.05/0011-net-ena-get-device-info-statically.patch
+++ b/userspace/dpdk/18.05/0011-net-ena-get-device-info-statically.patch
@@ -1,7 +1,7 @@
 From d07a557dce8d3adc5f5b434418473f7ab36e6129 Mon Sep 17 00:00:00 2001
 From: Michal Krawczyk <mk@semihalf.com>
 Date: Fri, 15 Feb 2019 09:36:39 +0100
-Subject: [PATCH 11/15] net/ena: get device info statically
+Subject: [PATCH 11/22] net/ena: get device info statically
 
 [ upstream commit 117ba4a60488a0f96a5737f38ddba6d0f9a728b6 ]
 
@@ -22,7 +22,7 @@ Signed-off-by: Michal Krawczyk <mk@semihalf.com>
  2 files changed, 19 insertions(+), 20 deletions(-)
 
 diff --git a/drivers/net/ena/ena_ethdev.c b/drivers/net/ena/ena_ethdev.c
-index d09633912..a4ae53920 100644
+index d096339121..a4ae539201 100644
 --- a/drivers/net/ena/ena_ethdev.c
 +++ b/drivers/net/ena/ena_ethdev.c
 @@ -1381,9 +1381,14 @@ static int eth_ena_dev_init(struct rte_eth_dev *eth_dev)
@@ -93,7 +93,7 @@ index d09633912..a4ae53920 100644
  		}
  
 diff --git a/drivers/net/ena/ena_ethdev.h b/drivers/net/ena/ena_ethdev.h
-index 394d05e02..2c98b4092 100644
+index 394d05e026..2c98b40924 100644
 --- a/drivers/net/ena/ena_ethdev.h
 +++ b/drivers/net/ena/ena_ethdev.h
 @@ -145,6 +145,12 @@ struct ena_stats_rx {

--- a/userspace/dpdk/18.05/0012-net-ena-fix-checksum-feature-flag.patch
+++ b/userspace/dpdk/18.05/0012-net-ena-fix-checksum-feature-flag.patch
@@ -1,7 +1,7 @@
 From 5188eb77f07ac1c3b3542e2812b3a8f15df27c7d Mon Sep 17 00:00:00 2001
 From: Michal Krawczyk <mk@semihalf.com>
 Date: Mon, 8 Apr 2019 12:27:44 +0200
-Subject: [PATCH 12/15] net/ena: fix checksum feature flag
+Subject: [PATCH 12/22] net/ena: fix checksum feature flag
 
 [ upstream commit ef538c1a7f565c9b58518375a500aa864445fd11 ]
 
@@ -18,7 +18,7 @@ Signed-off-by: Michal Krawczyk <mk@semihalf.com>
  1 file changed, 1 insertion(+), 1 deletion(-)
 
 diff --git a/drivers/net/ena/ena_ethdev.c b/drivers/net/ena/ena_ethdev.c
-index a4ae53920..72aa7c758 100644
+index a4ae539201..72aa7c7589 100644
 --- a/drivers/net/ena/ena_ethdev.c
 +++ b/drivers/net/ena/ena_ethdev.c
 @@ -1386,7 +1386,7 @@ static int eth_ena_dev_init(struct rte_eth_dev *eth_dev)

--- a/userspace/dpdk/18.05/0013-net-ena-fix-Rx-checksum-errors-statistics.patch
+++ b/userspace/dpdk/18.05/0013-net-ena-fix-Rx-checksum-errors-statistics.patch
@@ -1,7 +1,7 @@
 From a7591a5a9ea623198f01adac7e209a0a5e234b89 Mon Sep 17 00:00:00 2001
 From: Michal Krawczyk <mk@semihalf.com>
 Date: Tue, 28 May 2019 10:28:34 +0200
-Subject: [PATCH 13/15] net/ena: fix Rx checksum errors statistics
+Subject: [PATCH 13/22] net/ena: fix Rx checksum errors statistics
 
 [ upstream commit ef74b5f7b69b9502ddab81121611243efcfe1dde ]
 
@@ -21,7 +21,7 @@ Signed-off-by: Michal Krawczyk <mk@semihalf.com>
  1 file changed, 5 insertions(+), 4 deletions(-)
 
 diff --git a/drivers/net/ena/ena_ethdev.c b/drivers/net/ena/ena_ethdev.c
-index 72aa7c758..758cdfa15 100644
+index 72aa7c7589..758cdfa15a 100644
 --- a/drivers/net/ena/ena_ethdev.c
 +++ b/drivers/net/ena/ena_ethdev.c
 @@ -1596,6 +1596,11 @@ static uint16_t eth_ena_recv_pkts(void *rx_queue, struct rte_mbuf **rx_pkts,

--- a/userspace/dpdk/18.05/0014-net-ena-fix-assigning-NUMA-node-to-IO-queue.patch
+++ b/userspace/dpdk/18.05/0014-net-ena-fix-assigning-NUMA-node-to-IO-queue.patch
@@ -1,7 +1,7 @@
 From 5c6ad2dc2a94612aaf68ab48f5e945747f0d79eb Mon Sep 17 00:00:00 2001
 From: Michal Krawczyk <mk@semihalf.com>
 Date: Tue, 4 Jun 2019 12:59:36 +0200
-Subject: [PATCH 14/15] net/ena: fix assigning NUMA node to IO queue
+Subject: [PATCH 14/22] net/ena: fix assigning NUMA node to IO queue
 
 [ upstream commit 4217cb0b7d2c5385f06f531af7f14b860927aba7 ]
 
@@ -23,7 +23,7 @@ Reviewed-by: David Marchand <david.marchand@redhat.com>
  2 files changed, 8 insertions(+), 21 deletions(-)
 
 diff --git a/drivers/net/ena/ena_ethdev.c b/drivers/net/ena/ena_ethdev.c
-index 758cdfa15..58ce419fd 100644
+index 758cdfa15a..58ce419fdc 100644
 --- a/drivers/net/ena/ena_ethdev.c
 +++ b/drivers/net/ena/ena_ethdev.c
 @@ -39,7 +39,6 @@
@@ -110,7 +110,7 @@ index 758cdfa15..58ce419fd 100644
  
  	rxq->rx_buffer_info = rte_zmalloc("rxq->buffer_info",
 diff --git a/drivers/net/ena/ena_ethdev.h b/drivers/net/ena/ena_ethdev.h
-index 2c98b4092..7dd8b2596 100644
+index 2c98b40924..7dd8b2596e 100644
 --- a/drivers/net/ena/ena_ethdev.h
 +++ b/drivers/net/ena/ena_ethdev.h
 @@ -92,6 +92,8 @@ struct ena_ring {

--- a/userspace/dpdk/18.05/0015-net-ena-fix-L4-checksum-Tx-offload.patch
+++ b/userspace/dpdk/18.05/0015-net-ena-fix-L4-checksum-Tx-offload.patch
@@ -1,7 +1,7 @@
 From 731eed0e60a4dbfce98b9dc3860f713ac0671b10 Mon Sep 17 00:00:00 2001
 From: Maciej Bielski <mba@semihalf.com>
 Date: Thu, 1 Aug 2019 13:45:36 +0200
-Subject: [PATCH 15/15] net/ena: fix L4 checksum Tx offload
+Subject: [PATCH 15/22] net/ena: fix L4 checksum Tx offload
 
 [ upstream commit 40e7c02155625f18a87faf5e6a8cec2e986146e8 ]
 
@@ -27,7 +27,7 @@ Acked-by: Michal Krawczyk <mk@semihalf.com>
  1 file changed, 4 insertions(+), 3 deletions(-)
 
 diff --git a/drivers/net/ena/ena_ethdev.c b/drivers/net/ena/ena_ethdev.c
-index 58ce419fd..1ef7809a1 100644
+index 58ce419fdc..1ef7809a15 100644
 --- a/drivers/net/ena/ena_ethdev.c
 +++ b/drivers/net/ena/ena_ethdev.c
 @@ -313,12 +313,13 @@ static inline void ena_tx_mbuf_prepare(struct rte_mbuf *mbuf,

--- a/userspace/dpdk/18.05/0016-net-ena-base-fix-node-deallocation.patch
+++ b/userspace/dpdk/18.05/0016-net-ena-base-fix-node-deallocation.patch
@@ -1,0 +1,59 @@
+From 604cf6102f48c887a556d281294f1876f4673712 Mon Sep 17 00:00:00 2001
+From: Michal Krawczyk <mk@semihalf.com>
+Date: Thu, 2 Jul 2020 10:25:03 +0000
+Subject: [PATCH 16/22] net/ena/base: fix node deallocation
+
+The memzone handle wasn't saved anywhere - it could cause free of the
+invalid memory, as the mem_handle was never holding the right value.
+
+Signed-off-by: Michal Krawczyk <mk@semihalf.com>
+---
+ drivers/net/ena/base/ena_com.c       | 2 ++
+ drivers/net/ena/base/ena_plat_dpdk.h | 4 +++-
+ 2 files changed, 5 insertions(+), 1 deletion(-)
+
+diff --git a/drivers/net/ena/base/ena_com.c b/drivers/net/ena/base/ena_com.c
+index 38a0587754..1c38a1138d 100644
+--- a/drivers/net/ena/base/ena_com.c
++++ b/drivers/net/ena/base/ena_com.c
+@@ -347,6 +347,7 @@ static int ena_com_init_io_sq(struct ena_com_dev *ena_dev,
+ 					    size,
+ 					    io_sq->desc_addr.virt_addr,
+ 					    io_sq->desc_addr.phys_addr,
++					    io_sq->desc_addr.mem_handle,
+ 					    ctx->numa_node,
+ 					    dev_node);
+ 		if (!io_sq->desc_addr.virt_addr)
+@@ -400,6 +401,7 @@ static int ena_com_init_io_cq(struct ena_com_dev *ena_dev,
+ 				    size,
+ 				    io_cq->cdesc_addr.virt_addr,
+ 				    io_cq->cdesc_addr.phys_addr,
++				    io_cq->cdesc_addr.mem_handle,
+ 				    ctx->numa_node,
+ 				    prev_node);
+ 	if (!io_cq->cdesc_addr.virt_addr)
+diff --git a/drivers/net/ena/base/ena_plat_dpdk.h b/drivers/net/ena/base/ena_plat_dpdk.h
+index 558966517c..b6e2b74573 100644
+--- a/drivers/net/ena/base/ena_plat_dpdk.h
++++ b/drivers/net/ena/base/ena_plat_dpdk.h
+@@ -207,7 +207,8 @@ typedef uint64_t dma_addr_t;
+ 		   ENA_TOUCH(dmadev);					\
+ 		   rte_memzone_free(handle); })
+ 
+-#define ENA_MEM_ALLOC_COHERENT_NODE(dmadev, size, virt, phys, node, dev_node) \
++#define ENA_MEM_ALLOC_COHERENT_NODE(					\
++	dmadev, size, virt, phys, mem_handle, node, dev_node)		\
+ 	do {								\
+ 		const struct rte_memzone *mz;				\
+ 		char z_name[RTE_MEMZONE_NAMESIZE];			\
+@@ -216,6 +217,7 @@ typedef uint64_t dma_addr_t;
+ 				"ena_alloc_%d", ena_alloc_cnt++);	\
+ 		mz = rte_memzone_reserve(z_name, size, node,		\
+ 				RTE_MEMZONE_IOVA_CONTIG);		\
++		mem_handle = mz;					\
+ 		if (mz == NULL) {					\
+ 			virt = NULL;					\
+ 			phys = 0;					\
+-- 
+2.20.1
+

--- a/userspace/dpdk/18.05/0017-net-ena-fix-indication-of-bad-L4-Rx-checksums.patch
+++ b/userspace/dpdk/18.05/0017-net-ena-fix-indication-of-bad-L4-Rx-checksums.patch
@@ -1,0 +1,44 @@
+From 9feefcc8cbb651605c440b882269420deb3ea1bd Mon Sep 17 00:00:00 2001
+From: Igor Chauskin <igorch@amazon.com>
+Date: Mon, 28 Oct 2019 11:23:33 +0100
+Subject: [PATCH 17/22] net/ena: fix indication of bad L4 Rx checksums
+
+[ upstream commit 05817057faba9356900ced61e24a22eef6bc4c87 ]
+
+Add checking of l4_csum_checked and frag flags before checking the
+l4_csum_error flag.
+
+In case of IP fragment/unchecked L4 csum - add PKT_RX_L4_CKSUM_UNKNOWN
+flag to the indicated mbuf.
+
+Fixes: 1173fca25af9 ("ena: add polling-mode driver")
+Cc: stable@dpdk.org
+
+Change-Id: I9f1414741eb44ca289a8bfd11d7e66110c95040e
+Signed-off-by: Igor Chauskin <igorch@amazon.com>
+Reviewed-by: Maciej Bielski <mba@semihalf.com>
+Reviewed-by: Michal Krawczyk <mk@semihalf.com>
+---
+ drivers/net/ena/ena_ethdev.c | 5 ++++-
+ 1 file changed, 4 insertions(+), 1 deletion(-)
+
+diff --git a/drivers/net/ena/ena_ethdev.c b/drivers/net/ena/ena_ethdev.c
+index 1ef7809a15..954806b6ac 100644
+--- a/drivers/net/ena/ena_ethdev.c
++++ b/drivers/net/ena/ena_ethdev.c
+@@ -270,8 +270,11 @@ static inline void ena_rx_mbuf_prepare(struct rte_mbuf *mbuf,
+ 	else if (ena_rx_ctx->l3_proto == ENA_ETH_IO_L3_PROTO_IPV6)
+ 		packet_type |= RTE_PTYPE_L3_IPV6;
+ 
+-	if (unlikely(ena_rx_ctx->l4_csum_err))
++	if (unlikely(ena_rx_ctx->l4_csum_err) && !ena_rx_ctx->frag)
+ 		ol_flags |= PKT_RX_L4_CKSUM_BAD;
++	else
++		ol_flags |= PKT_RX_L4_CKSUM_UNKNOWN;
++
+ 	if (unlikely(ena_rx_ctx->l3_csum_err))
+ 		ol_flags |= PKT_RX_IP_CKSUM_BAD;
+ 
+-- 
+2.20.1
+

--- a/userspace/dpdk/18.05/0018-net-ena-ensure-Rx-buffer-size-is-at-least-1400B.patch
+++ b/userspace/dpdk/18.05/0018-net-ena-ensure-Rx-buffer-size-is-at-least-1400B.patch
@@ -1,0 +1,84 @@
+From 69c3e213d1129ccfcebcccb85c842cce2d403167 Mon Sep 17 00:00:00 2001
+From: Michal Krawczyk <mk@semihalf.com>
+Date: Wed, 8 Apr 2020 10:28:52 +0200
+Subject: [PATCH 18/22] net/ena: ensure Rx buffer size is at least 1400B
+
+[ upstream commit 38364c2687ead97b99402310087c27131a97748c ]
+
+Some of the ENA devices can't handle buffers which are smaller than a
+1400B. Because of this limitation, size of the buffer is being checked
+and limited during the Rx queue setup.
+
+If it's below the allowed value, PMD won't finish it's configuration
+successfully..
+
+Change-Id: Ib402d3bfad98a3fc4f91095d5c6f90c6069da021
+Signed-off-by: Michal Krawczyk <mk@semihalf.com>
+Reviewed-by: Igor Chauskin <igorch@amazon.com>
+Reviewed-by: Guy Tzalik <gtzalik@amazon.com>
+---
+ drivers/net/ena/ena_ethdev.c | 12 +++++++++++-
+ drivers/net/ena/ena_ethdev.h |  3 ++-
+ 2 files changed, 13 insertions(+), 2 deletions(-)
+
+diff --git a/drivers/net/ena/ena_ethdev.c b/drivers/net/ena/ena_ethdev.c
+index 954806b6ac..e0ee064b9f 100644
+--- a/drivers/net/ena/ena_ethdev.c
++++ b/drivers/net/ena/ena_ethdev.c
+@@ -1,7 +1,7 @@
+ /*-
+ * BSD LICENSE
+ *
+-* Copyright (c) 2015-2016 Amazon.com, Inc. or its affiliates.
++* Copyright (c) 2015-2020 Amazon.com, Inc. or its affiliates.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+@@ -1066,6 +1066,7 @@ static int ena_rx_queue_setup(struct rte_eth_dev *dev,
+ 	struct ena_adapter *adapter =
+ 		(struct ena_adapter *)(dev->data->dev_private);
+ 	struct ena_ring *rxq = NULL;
++	size_t buffer_size;
+ 	uint16_t ena_qid = 0;
+ 	int rc = 0;
+ 	struct ena_com_dev *ena_dev = &adapter->ena_dev;
+@@ -1092,6 +1093,15 @@ static int ena_rx_queue_setup(struct rte_eth_dev *dev,
+ 		return -EINVAL;
+ 	}
+ 
++	/* ENA isn't supporting buffers smaller than 1400 bytes */
++	buffer_size = rte_pktmbuf_data_room_size(mp) - RTE_PKTMBUF_HEADROOM;
++	if (buffer_size < ENA_RX_BUF_MIN_SIZE) {
++		PMD_DRV_LOG(ERR,
++			"Unsupported size of RX buffer: %zu (min size: %d)\n",
++			buffer_size, ENA_RX_BUF_MIN_SIZE);
++		return -EINVAL;
++	}
++
+ 	ena_qid = ENA_IO_RXQ_IDX(queue_idx);
+ 
+ 	ctx.qid = ena_qid;
+diff --git a/drivers/net/ena/ena_ethdev.h b/drivers/net/ena/ena_ethdev.h
+index 7dd8b2596e..f6140e28ca 100644
+--- a/drivers/net/ena/ena_ethdev.h
++++ b/drivers/net/ena/ena_ethdev.h
+@@ -1,7 +1,7 @@
+ /*-
+ * BSD LICENSE
+ *
+-* Copyright (c) 2015-2016 Amazon.com, Inc. or its affiliates.
++* Copyright (c) 2015-2020 Amazon.com, Inc. or its affiliates.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+@@ -47,6 +47,7 @@
+ #define ENA_MIN_FRAME_LEN	64
+ #define ENA_NAME_MAX_LEN	20
+ #define ENA_PKT_MAX_BUFS	17
++#define ENA_RX_BUF_MIN_SIZE	1400
+ 
+ #define ENA_MMIO_DISABLE_REG_READ	BIT(0)
+ 
+-- 
+2.20.1
+

--- a/userspace/dpdk/18.05/0019-net-ena-base-make-allocation-macros-thread-safe.patch
+++ b/userspace/dpdk/18.05/0019-net-ena-base-make-allocation-macros-thread-safe.patch
@@ -1,0 +1,101 @@
+From f12d0cddb9419641efefc9acaebd683880208ea5 Mon Sep 17 00:00:00 2001
+From: Igor Chauskin <igorch@amazon.com>
+Date: Wed, 8 Apr 2020 10:28:53 +0200
+Subject: [PATCH 19/22] net/ena/base: make allocation macros thread-safe
+
+[ upstream commit b14fcac035fd8514851c9140a4e26d765b61c532 ]
+
+Memory allocation region id could possibly be non-unique
+due to non-atomic increment, causing allocation failure.
+
+Fixes: 9ba7981ec992 ("ena: add communication layer for DPDK")
+Cc: stable@dpdk.org
+
+Change-Id: Ib9207aaae4e5e7ecdf1a99a0f23a508a53af631d
+Signed-off-by: Igor Chauskin <igorch@amazon.com>
+Reviewed-by: Michal Krawczyk <mk@semihalf.com>
+Reviewed-by: Guy Tzalik <gtzalik@amazon.com>
+---
+ drivers/net/ena/base/ena_com.c       |  2 --
+ drivers/net/ena/base/ena_plat_dpdk.h | 14 +++++++++++---
+ drivers/net/ena/ena_ethdev.c         |  6 ++++++
+ 3 files changed, 17 insertions(+), 5 deletions(-)
+
+diff --git a/drivers/net/ena/base/ena_com.c b/drivers/net/ena/base/ena_com.c
+index 1c38a1138d..0dbd1b0cd0 100644
+--- a/drivers/net/ena/base/ena_com.c
++++ b/drivers/net/ena/base/ena_com.c
+@@ -62,8 +62,6 @@
+ 
+ #define ENA_MMIO_READ_TIMEOUT 0xFFFFFFFF
+ 
+-static int ena_alloc_cnt;
+-
+ /*****************************************************************************/
+ /*****************************************************************************/
+ /*****************************************************************************/
+diff --git a/drivers/net/ena/base/ena_plat_dpdk.h b/drivers/net/ena/base/ena_plat_dpdk.h
+index b6e2b74573..c78429506d 100644
+--- a/drivers/net/ena/base/ena_plat_dpdk.h
++++ b/drivers/net/ena/base/ena_plat_dpdk.h
+@@ -1,7 +1,7 @@
+ /*-
+ * BSD LICENSE
+ *
+-* Copyright (c) 2015-2016 Amazon.com, Inc. or its affiliates.
++* Copyright (c) 2015-2020 Amazon.com, Inc. or its affiliates.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+@@ -183,13 +183,20 @@ typedef uint64_t dma_addr_t;
+ #define ena_wait_event_t ena_wait_queue_t
+ #define ENA_MIGHT_SLEEP()
+ 
++/*
++ * Each rte_memzone should have unique name.
++ * To satisfy it, count number of allocations and add it to name.
++ */
++extern rte_atomic32_t ena_alloc_cnt;
++
+ #define ENA_MEM_ALLOC_COHERENT(dmadev, size, virt, phys, handle)	\
+ 	do {								\
+ 		const struct rte_memzone *mz;				\
+ 		char z_name[RTE_MEMZONE_NAMESIZE];			\
+ 		ENA_TOUCH(dmadev); ENA_TOUCH(handle);			\
+ 		snprintf(z_name, sizeof(z_name),			\
+-				"ena_alloc_%d", ena_alloc_cnt++);	\
++			 "ena_alloc_%d",				\
++			 rte_atomic32_add_return(&ena_alloc_cnt, 1));	\
+ 		mz = rte_memzone_reserve(z_name, size, SOCKET_ID_ANY,	\
+ 				RTE_MEMZONE_IOVA_CONTIG);		\
+ 		handle = mz;						\
+@@ -214,7 +221,8 @@ typedef uint64_t dma_addr_t;
+ 		char z_name[RTE_MEMZONE_NAMESIZE];			\
+ 		ENA_TOUCH(dmadev); ENA_TOUCH(dev_node);			\
+ 		snprintf(z_name, sizeof(z_name),			\
+-				"ena_alloc_%d", ena_alloc_cnt++);	\
++			 "ena_alloc_%d",				\
++			 rte_atomic32_add_return(&ena_alloc_cnt, 1));	\
+ 		mz = rte_memzone_reserve(z_name, size, node,		\
+ 				RTE_MEMZONE_IOVA_CONTIG);		\
+ 		mem_handle = mz;					\
+diff --git a/drivers/net/ena/ena_ethdev.c b/drivers/net/ena/ena_ethdev.c
+index e0ee064b9f..5598cbb4c6 100644
+--- a/drivers/net/ena/ena_ethdev.c
++++ b/drivers/net/ena/ena_ethdev.c
+@@ -113,6 +113,12 @@ struct ena_stats {
+ #define ENA_STAT_GLOBAL_ENTRY(stat) \
+ 	ENA_STAT_ENTRY(stat, dev)
+ 
++/*
++ * Each rte_memzone should have unique name.
++ * To satisfy it, count number of allocation and add it to name.
++ */
++rte_atomic32_t ena_alloc_cnt;
++
+ static const struct ena_stats ena_stats_global_strings[] = {
+ 	ENA_STAT_GLOBAL_ENTRY(tx_timeout),
+ 	ENA_STAT_GLOBAL_ENTRY(io_suspend),
+-- 
+2.20.1
+

--- a/userspace/dpdk/18.05/0020-net-ena-base-prevent-allocation-of-zero-sized-memory.patch
+++ b/userspace/dpdk/18.05/0020-net-ena-base-prevent-allocation-of-zero-sized-memory.patch
@@ -1,0 +1,77 @@
+From a31df74f43ab5935f7daeed4b8c4782446a46859 Mon Sep 17 00:00:00 2001
+From: Igor Chauskin <igorch@amazon.com>
+Date: Wed, 8 Apr 2020 10:28:54 +0200
+Subject: [PATCH 20/22] net/ena/base: prevent allocation of zero sized memory
+
+[ upstream commit 29dc10d9424ccf26a346387b0a707185e2432400 ]
+
+rte_memzone_reserve() will reserve the biggest contiguous memzone
+available if received 0 as size param.
+
+Fixes: 9ba7981ec992 ("ena: add communication layer for DPDK")
+Cc: stable@dpdk.org
+
+Change-Id: I2f71119e93c5e9addd8c538820093f030066d690
+Signed-off-by: Igor Chauskin <igorch@amazon.com>
+Reviewed-by: Michal Krawczyk <mk@semihalf.com>
+Reviewed-by: Guy Tzalik <gtzalik@amazon.com>
+---
+ drivers/net/ena/base/ena_plat_dpdk.h | 29 ++++++++++++++++------------
+ 1 file changed, 17 insertions(+), 12 deletions(-)
+
+diff --git a/drivers/net/ena/base/ena_plat_dpdk.h b/drivers/net/ena/base/ena_plat_dpdk.h
+index c78429506d..486e2099fe 100644
+--- a/drivers/net/ena/base/ena_plat_dpdk.h
++++ b/drivers/net/ena/base/ena_plat_dpdk.h
+@@ -191,15 +191,18 @@ extern rte_atomic32_t ena_alloc_cnt;
+ 
+ #define ENA_MEM_ALLOC_COHERENT(dmadev, size, virt, phys, handle)	\
+ 	do {								\
+-		const struct rte_memzone *mz;				\
+-		char z_name[RTE_MEMZONE_NAMESIZE];			\
++		const struct rte_memzone *mz = NULL;			\
+ 		ENA_TOUCH(dmadev); ENA_TOUCH(handle);			\
+-		snprintf(z_name, sizeof(z_name),			\
++		if (size > 0) {						\
++			char z_name[RTE_MEMZONE_NAMESIZE];		\
++			snprintf(z_name, sizeof(z_name),		\
+ 			 "ena_alloc_%d",				\
+ 			 rte_atomic32_add_return(&ena_alloc_cnt, 1));	\
+-		mz = rte_memzone_reserve(z_name, size, SOCKET_ID_ANY,	\
+-				RTE_MEMZONE_IOVA_CONTIG);		\
+-		handle = mz;						\
++			mz = rte_memzone_reserve(z_name, size,		\
++					SOCKET_ID_ANY,			\
++					RTE_MEMZONE_IOVA_CONTIG);	\
++			handle = mz;					\
++		}							\
+ 		if (mz == NULL) {					\
+ 			virt = NULL;					\
+ 			phys = 0;					\
+@@ -217,15 +220,17 @@ extern rte_atomic32_t ena_alloc_cnt;
+ #define ENA_MEM_ALLOC_COHERENT_NODE(					\
+ 	dmadev, size, virt, phys, mem_handle, node, dev_node)		\
+ 	do {								\
+-		const struct rte_memzone *mz;				\
+-		char z_name[RTE_MEMZONE_NAMESIZE];			\
++		const struct rte_memzone *mz = NULL;			\
+ 		ENA_TOUCH(dmadev); ENA_TOUCH(dev_node);			\
+-		snprintf(z_name, sizeof(z_name),			\
++		if (size > 0) {						\
++			char z_name[RTE_MEMZONE_NAMESIZE];		\
++			snprintf(z_name, sizeof(z_name),		\
+ 			 "ena_alloc_%d",				\
+-			 rte_atomic32_add_return(&ena_alloc_cnt, 1));	\
+-		mz = rte_memzone_reserve(z_name, size, node,		\
++			 rte_atomic32_add_return(&ena_alloc_cnt, 1));   \
++			mz = rte_memzone_reserve(z_name, size, node,	\
+ 				RTE_MEMZONE_IOVA_CONTIG);		\
+-		mem_handle = mz;					\
++			mem_handle = mz;				\
++		}							\
+ 		if (mz == NULL) {					\
+ 			virt = NULL;					\
+ 			phys = 0;					\
+-- 
+2.20.1
+

--- a/userspace/dpdk/18.05/0021-net-ena-set-IO-ring-size-to-valid-value.patch
+++ b/userspace/dpdk/18.05/0021-net-ena-set-IO-ring-size-to-valid-value.patch
@@ -1,0 +1,49 @@
+From 32894228b9d1c87c181b29815d183eb78ad1a235 Mon Sep 17 00:00:00 2001
+From: Michal Krawczyk <mk@semihalf.com>
+Date: Fri, 3 Jul 2020 13:14:58 +0000
+Subject: [PATCH 21/22] net/ena: set IO ring size to valid value
+
+[ upstream commit badc3a6aa133a886a61b9e3ad666e5675f7ec3d3 ]
+
+IO rings were configured with the maximum allowed size for the Tx/Rx
+rings. However, the application could decide to create smaller rings.
+
+This patch is using value stored in the ring instead of the value from
+the adapter which is indicating the maximum allowed value.
+
+Fixes: df238f84c0a2 ("net/ena: recreate HW IO rings on start and stop")
+Cc: stable@dpdk.org
+
+Change-Id: Icf9102e2aa4e7413b6620b36dd232673239b7291
+Signed-off-by: Michal Krawczyk <mk@semihalf.com>
+Reviewed-by: Igor Chauskin <igorch@amazon.com>
+Reviewed-by: Guy Tzalik <gtzalik@amazon.com>
+---
+ drivers/net/ena/ena_ethdev.c | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/drivers/net/ena/ena_ethdev.c b/drivers/net/ena/ena_ethdev.c
+index 5598cbb4c6..c94417e0b1 100644
+--- a/drivers/net/ena/ena_ethdev.c
++++ b/drivers/net/ena/ena_ethdev.c
+@@ -1000,7 +1000,7 @@ static int ena_tx_queue_setup(struct rte_eth_dev *dev,
+ 	ctx.qid = ena_qid;
+ 	ctx.msix_vector = -1; /* admin interrupts not used */
+ 	ctx.mem_queue_type = ena_dev->tx_mem_queue_type;
+-	ctx.queue_size = adapter->tx_ring_size;
++	ctx.queue_size = nb_desc;
+ 	ctx.numa_node = socket_id;
+ 
+ 	rc = ena_com_create_io_queue(ena_dev, &ctx);
+@@ -1114,7 +1114,7 @@ static int ena_rx_queue_setup(struct rte_eth_dev *dev,
+ 	ctx.direction = ENA_COM_IO_QUEUE_DIRECTION_RX;
+ 	ctx.mem_queue_type = ENA_ADMIN_PLACEMENT_POLICY_HOST;
+ 	ctx.msix_vector = -1; /* admin interrupts not used */
+-	ctx.queue_size = adapter->rx_ring_size;
++	ctx.queue_size = nb_desc;
+ 	ctx.numa_node = socket_id;
+ 
+ 	rc = ena_com_create_io_queue(ena_dev, &ctx);
+-- 
+2.20.1
+

--- a/userspace/dpdk/18.05/0022-net-ena-limit-refill-threshold-by-fixed-value.patch
+++ b/userspace/dpdk/18.05/0022-net-ena-limit-refill-threshold-by-fixed-value.patch
@@ -1,0 +1,118 @@
+From 2471fd9b9a446d4d55f4707d4c2eddc4bff29ec7 Mon Sep 17 00:00:00 2001
+From: Michal Krawczyk <mk@semihalf.com>
+Date: Wed, 8 Apr 2020 10:29:16 +0200
+Subject: [PATCH 22/22] net/ena: limit refill threshold by fixed value
+
+[ upstream commit 7755060798de9c0146df8809926030ed47fc9086 ]
+
+Divider used for both Tx and Rx cleanup/refill threshold can cause too
+big delay in case of the really big rings - for example if the 8k Rx
+ring will be used, the refill won't trigger unless 1024 threshold will
+be reached. It will also cause driver to try to allocate that much
+descriptors.
+
+Limiting it by fixed value - 256 in that case, would limit maximum
+time spent in repopulate function.
+
+Change-Id: Ia8659e6ddf179ff612a780adc6fe55d13eeac6e9
+Signed-off-by: Michal Krawczyk <mk@semihalf.com>
+Reviewed-by: Igor Chauskin <igorch@amazon.com>
+Reviewed-by: Guy Tzalik <gtzalik@amazon.com>
+---
+ drivers/net/ena/ena_ethdev.c | 26 ++++++++++++++------------
+ drivers/net/ena/ena_ethdev.h | 10 ++++++++++
+ 2 files changed, 24 insertions(+), 12 deletions(-)
+
+diff --git a/drivers/net/ena/ena_ethdev.c b/drivers/net/ena/ena_ethdev.c
+index c94417e0b1..9f2bb98217 100644
+--- a/drivers/net/ena/ena_ethdev.c
++++ b/drivers/net/ena/ena_ethdev.c
+@@ -61,14 +61,6 @@
+ /*reverse version of ENA_IO_RXQ_IDX*/
+ #define ENA_IO_RXQ_IDX_REV(q)	((q - 1) / 2)
+ 
+-/* While processing submitted and completed descriptors (rx and tx path
+- * respectively) in a loop it is desired to:
+- *  - perform batch submissions while populating sumbissmion queue
+- *  - avoid blocking transmission of other packets during cleanup phase
+- * Hence the utilization ratio of 1/8 of a queue size.
+- */
+-#define ENA_RING_DESCS_RATIO(ring_size)	(ring_size / 8)
+-
+ #define __MERGE_64B_H_L(h, l) (((uint64_t)h << 32) | l)
+ #define TEST_BIT(val, bit_shift) (val & (1UL << bit_shift))
+ 
+@@ -1536,6 +1528,8 @@ static uint16_t eth_ena_recv_pkts(void *rx_queue, struct rte_mbuf **rx_pkts,
+ 	struct ena_ring *rx_ring = (struct ena_ring *)(rx_queue);
+ 	unsigned int ring_size = rx_ring->ring_size;
+ 	unsigned int ring_mask = ring_size - 1;
++	unsigned int free_queue_entries;
++	unsigned int refill_threshold;
+ 	uint16_t next_to_clean = rx_ring->next_to_clean;
+ 	uint16_t desc_in_use = 0;
+ 	unsigned int recv_idx = 0;
+@@ -1615,11 +1609,15 @@ static uint16_t eth_ena_recv_pkts(void *rx_queue, struct rte_mbuf **rx_pkts,
+ 
+ 	rx_ring->next_to_clean = next_to_clean;
+ 
+-	desc_in_use = desc_in_use - completed + 1;
++	free_queue_entries = ena_com_sq_empty_space(rx_ring->ena_com_io_sq);
++	refill_threshold =
++		RTE_MIN(ring_size / ENA_REFILL_THRESH_DIVIDER,
++		(unsigned int)ENA_REFILL_THRESH_PACKET);
++
+ 	/* Burst refill to save doorbells, memory barriers, const interval */
+-	if (ring_size - desc_in_use > ENA_RING_DESCS_RATIO(ring_size)) {
++	if (free_queue_entries > refill_threshold) {
+ 		ena_com_update_dev_comp_head(rx_ring->ena_com_io_cq);
+-		ena_populate_rx_queue(rx_ring, ring_size - desc_in_use);
++		ena_populate_rx_queue(rx_ring, free_queue_entries);
+ 	}
+ 
+ 	return recv_idx;
+@@ -1704,6 +1702,7 @@ static uint16_t eth_ena_xmit_pkts(void *tx_queue, struct rte_mbuf **tx_pkts,
+ 	struct rte_mbuf *mbuf;
+ 	unsigned int ring_size = tx_ring->ring_size;
+ 	unsigned int ring_mask = ring_size - 1;
++	unsigned int cleanup_budget;
+ 	struct ena_com_tx_ctx ena_tx_ctx;
+ 	struct ena_tx_buffer *tx_info;
+ 	struct ena_com_buf *ebuf;
+@@ -1810,9 +1809,12 @@ static uint16_t eth_ena_xmit_pkts(void *tx_queue, struct rte_mbuf **tx_pkts,
+ 		/* Put back descriptor to the ring for reuse */
+ 		tx_ring->empty_tx_reqs[next_to_clean & ring_mask] = req_id;
+ 		next_to_clean++;
++		cleanup_budget =
++			RTE_MIN(ring_size / ENA_REFILL_THRESH_DIVIDER,
++			(unsigned int)ENA_REFILL_THRESH_PACKET);
+ 
+ 		/* If too many descs to clean, leave it for another run */
+-		if (unlikely(total_tx_descs > ENA_RING_DESCS_RATIO(ring_size)))
++		if (unlikely(total_tx_descs > cleanup_budget))
+ 			break;
+ 	}
+ 
+diff --git a/drivers/net/ena/ena_ethdev.h b/drivers/net/ena/ena_ethdev.h
+index f6140e28ca..aa1bf5efdd 100644
+--- a/drivers/net/ena/ena_ethdev.h
++++ b/drivers/net/ena/ena_ethdev.h
+@@ -51,6 +51,16 @@
+ 
+ #define ENA_MMIO_DISABLE_REG_READ	BIT(0)
+ 
++/* While processing submitted and completed descriptors (rx and tx path
++ * respectively) in a loop it is desired to:
++ *  - perform batch submissions while populating sumbissmion queue
++ *  - avoid blocking transmission of other packets during cleanup phase
++ * Hence the utilization ratio of 1/8 of a queue size or max value if the size
++ * of the ring is very big - like 8k Rx rings.
++ */
++#define ENA_REFILL_THRESH_DIVIDER      8
++#define ENA_REFILL_THRESH_PACKET       256
++
+ struct ena_adapter;
+ 
+ enum ena_ring_type {
+-- 
+2.20.1
+

--- a/userspace/dpdk/18.08/0001-net-ena-recreate-HW-IO-rings-on-start-and-stop.patch
+++ b/userspace/dpdk/18.08/0001-net-ena-recreate-HW-IO-rings-on-start-and-stop.patch
@@ -1,7 +1,7 @@
 From 126e0497aa41ff7b6fb6f2569626e6fed44bfe78 Mon Sep 17 00:00:00 2001
 From: Michal Krawczyk <mk@semihalf.com>
 Date: Thu, 25 Oct 2018 19:59:21 +0200
-Subject: [PATCH 01/19] net/ena: recreate HW IO rings on start and stop
+Subject: [PATCH 01/27] net/ena: recreate HW IO rings on start and stop
 
 [ upstream commit df238f84c0a21d642bb9517d0c75ba831eeceb46 ]
 
@@ -25,7 +25,7 @@ Signed-off-by: Michal Krawczyk <mk@semihalf.com>
  1 file changed, 91 insertions(+), 105 deletions(-)
 
 diff --git a/drivers/net/ena/ena_ethdev.c b/drivers/net/ena/ena_ethdev.c
-index c255dc6db..de5d2edc2 100644
+index c255dc6dbd..de5d2edc21 100644
 --- a/drivers/net/ena/ena_ethdev.c
 +++ b/drivers/net/ena/ena_ethdev.c
 @@ -239,6 +239,8 @@ static void ena_rx_queue_release_bufs(struct ena_ring *ring);

--- a/userspace/dpdk/18.08/0002-net-ena-fix-passing-RSS-hash-to-mbuf.patch
+++ b/userspace/dpdk/18.08/0002-net-ena-fix-passing-RSS-hash-to-mbuf.patch
@@ -1,7 +1,7 @@
 From 8e68880600b5ac56dc55850d5f9b9db03823e668 Mon Sep 17 00:00:00 2001
 From: Stewart Allen <allenste@amazon.com>
 Date: Thu, 25 Oct 2018 19:59:22 +0200
-Subject: [PATCH 02/19] net/ena: fix passing RSS hash to mbuf
+Subject: [PATCH 02/27] net/ena: fix passing RSS hash to mbuf
 
 [ upstream commit e5df9f33db00eb9d322abaefff30da74fd0e625d ]
 
@@ -19,7 +19,7 @@ Acked-by: Michal Krawczyk <mk@semihalf.com>
  1 file changed, 1 insertion(+), 1 deletion(-)
 
 diff --git a/drivers/net/ena/ena_ethdev.c b/drivers/net/ena/ena_ethdev.c
-index de5d2edc2..acb1a08e0 100644
+index de5d2edc21..acb1a08e05 100644
 --- a/drivers/net/ena/ena_ethdev.c
 +++ b/drivers/net/ena/ena_ethdev.c
 @@ -1910,7 +1910,7 @@ static uint16_t eth_ena_recv_pkts(void *rx_queue, struct rte_mbuf **rx_pkts,

--- a/userspace/dpdk/18.08/0003-net-ena-fix-cleaning-HW-IO-rings-configuration.patch
+++ b/userspace/dpdk/18.08/0003-net-ena-fix-cleaning-HW-IO-rings-configuration.patch
@@ -1,7 +1,7 @@
 From 79f7b061bfc354f660d4db0173bec4d47e6c43dd Mon Sep 17 00:00:00 2001
 From: Rafal Kozik <rk@semihalf.com>
 Date: Wed, 14 Nov 2018 10:59:45 +0100
-Subject: [PATCH 03/19] net/ena: fix cleaning HW IO rings configuration
+Subject: [PATCH 03/27] net/ena: fix cleaning HW IO rings configuration
 
 [ upstream commit 778677dcb20cf29d966f239972b043f0640f55ef ]
 
@@ -19,7 +19,7 @@ Acked-by: Michal Krawczyk <mk@semihalf.com>
  1 file changed, 7 insertions(+)
 
 diff --git a/drivers/net/ena/ena_ethdev.c b/drivers/net/ena/ena_ethdev.c
-index acb1a08e0..9e462099f 100644
+index acb1a08e05..9e462099f3 100644
 --- a/drivers/net/ena/ena_ethdev.c
 +++ b/drivers/net/ena/ena_ethdev.c
 @@ -1080,6 +1080,7 @@ static int ena_create_io_queue(struct ena_ring *ring)

--- a/userspace/dpdk/18.08/0004-net-ena-fix-out-of-order-completion.patch
+++ b/userspace/dpdk/18.08/0004-net-ena-fix-out-of-order-completion.patch
@@ -1,7 +1,7 @@
 From 53253faf9e1064d1571eed8d95d3be1cc47cbff9 Mon Sep 17 00:00:00 2001
 From: Rafal Kozik <rk@semihalf.com>
 Date: Wed, 21 Nov 2018 09:21:14 +0100
-Subject: [PATCH 04/19] net/ena: fix out of order completion
+Subject: [PATCH 04/27] net/ena: fix out of order completion
 
 [ upstream commit 79405ee175857cfdbb508f9d55e2a51d95483be6 ]
 
@@ -25,7 +25,7 @@ Acked-by: Michal Krawczyk <mk@semihalf.com>
  2 files changed, 29 insertions(+), 12 deletions(-)
 
 diff --git a/drivers/net/ena/ena_ethdev.c b/drivers/net/ena/ena_ethdev.c
-index 9e462099f..87c95b2e7 100644
+index 9e462099f3..87c95b2e7f 100644
 --- a/drivers/net/ena/ena_ethdev.c
 +++ b/drivers/net/ena/ena_ethdev.c
 @@ -760,6 +760,10 @@ static void ena_rx_queue_release(void *queue)
@@ -134,7 +134,7 @@ index 9e462099f..87c95b2e7 100644
  	/* When we submitted free recources to device... */
  	if (likely(i > 0)) {
 diff --git a/drivers/net/ena/ena_ethdev.h b/drivers/net/ena/ena_ethdev.h
-index 2dc8129e0..322e90ace 100644
+index 2dc8129e0e..322e90ace8 100644
 --- a/drivers/net/ena/ena_ethdev.h
 +++ b/drivers/net/ena/ena_ethdev.h
 @@ -87,6 +87,7 @@ struct ena_ring {

--- a/userspace/dpdk/18.08/0005-net-ena-add-reset-reason-in-Rx-error.patch
+++ b/userspace/dpdk/18.08/0005-net-ena-add-reset-reason-in-Rx-error.patch
@@ -1,7 +1,7 @@
 From 9b101ebef9993996594c00756ef6c0e2817e3037 Mon Sep 17 00:00:00 2001
 From: Rafal Kozik <rk@semihalf.com>
 Date: Fri, 14 Dec 2018 14:18:29 +0100
-Subject: [PATCH 05/19] net/ena: add reset reason in Rx error
+Subject: [PATCH 05/27] net/ena: add reset reason in Rx error
 
 [ upstream commit 9b260dbf7412819f9a5fc544872b1447d6938afe ]
 
@@ -20,7 +20,7 @@ Acked-by: Michal Krawczyk <mk@semihalf.com>
  1 file changed, 2 insertions(+)
 
 diff --git a/drivers/net/ena/ena_ethdev.c b/drivers/net/ena/ena_ethdev.c
-index 87c95b2e7..b74276d98 100644
+index 87c95b2e7f..b74276d985 100644
 --- a/drivers/net/ena/ena_ethdev.c
 +++ b/drivers/net/ena/ena_ethdev.c
 @@ -1895,6 +1895,8 @@ static uint16_t eth_ena_recv_pkts(void *rx_queue, struct rte_mbuf **rx_pkts,

--- a/userspace/dpdk/18.08/0006-net-ena-skip-packet-with-wrong-request-id.patch
+++ b/userspace/dpdk/18.08/0006-net-ena-skip-packet-with-wrong-request-id.patch
@@ -1,7 +1,7 @@
 From 9056e84fe8cea67e116be9663a56586b16bf96c4 Mon Sep 17 00:00:00 2001
 From: Rafal Kozik <rk@semihalf.com>
 Date: Fri, 14 Dec 2018 14:18:31 +0100
-Subject: [PATCH 06/19] net/ena: skip packet with wrong request id
+Subject: [PATCH 06/27] net/ena: skip packet with wrong request id
 
 [ upstream commit f00930d929151fc09914e6d61b827f9f81645324 ]
 
@@ -20,7 +20,7 @@ Acked-by: Michal Krawczyk <mk@semihalf.com>
  1 file changed, 2 insertions(+)
 
 diff --git a/drivers/net/ena/ena_ethdev.c b/drivers/net/ena/ena_ethdev.c
-index b74276d98..f050dea82 100644
+index b74276d985..f050dea82a 100644
 --- a/drivers/net/ena/ena_ethdev.c
 +++ b/drivers/net/ena/ena_ethdev.c
 @@ -1932,6 +1932,8 @@ static uint16_t eth_ena_recv_pkts(void *rx_queue, struct rte_mbuf **rx_pkts,

--- a/userspace/dpdk/18.08/0007-net-ena-do-not-reconfigure-queues-on-reset.patch
+++ b/userspace/dpdk/18.08/0007-net-ena-do-not-reconfigure-queues-on-reset.patch
@@ -1,7 +1,7 @@
 From 348d89e8be808017512a318b64108552b97a5fa8 Mon Sep 17 00:00:00 2001
 From: Rafal Kozik <rk@semihalf.com>
 Date: Fri, 14 Dec 2018 14:18:36 +0100
-Subject: [PATCH 07/19] net/ena: do not reconfigure queues on reset
+Subject: [PATCH 07/27] net/ena: do not reconfigure queues on reset
 
 [ upstream commit e457bc70e5d6d589b1c3e1e93979aa42a64fbc06 ]
 
@@ -26,7 +26,7 @@ Acked-by: Michal Krawczyk <mk@semihalf.com>
  1 file changed, 46 insertions(+), 73 deletions(-)
 
 diff --git a/drivers/net/ena/ena_ethdev.c b/drivers/net/ena/ena_ethdev.c
-index f050dea82..383028318 100644
+index f050dea82a..383028318e 100644
 --- a/drivers/net/ena/ena_ethdev.c
 +++ b/drivers/net/ena/ena_ethdev.c
 @@ -256,6 +256,8 @@ static int ena_rss_reta_query(struct rte_eth_dev *dev,

--- a/userspace/dpdk/18.08/0008-net-ena-add-supported-RSS-offloads-types.patch
+++ b/userspace/dpdk/18.08/0008-net-ena-add-supported-RSS-offloads-types.patch
@@ -1,7 +1,7 @@
 From eec4b9335239bbb7468314bbc2e4f7e96ef66795 Mon Sep 17 00:00:00 2001
 From: Rafal Kozik <rk@semihalf.com>
 Date: Fri, 14 Dec 2018 14:18:38 +0100
-Subject: [PATCH 08/19] net/ena: add supported RSS offloads types
+Subject: [PATCH 08/27] net/ena: add supported RSS offloads types
 
 [ upstream commit b01ead202beb45346d7daeb2f2b1a608006af644 ]
 
@@ -20,7 +20,7 @@ Acked-by: Michal Krawczyk <mk@semihalf.com>
  1 file changed, 3 insertions(+)
 
 diff --git a/drivers/net/ena/ena_ethdev.c b/drivers/net/ena/ena_ethdev.c
-index 383028318..9cab09b57 100644
+index 383028318e..9cab09b574 100644
 --- a/drivers/net/ena/ena_ethdev.c
 +++ b/drivers/net/ena/ena_ethdev.c
 @@ -1804,6 +1804,9 @@ static void ena_infos_get(struct rte_eth_dev *dev,

--- a/userspace/dpdk/18.08/0009-net-ena-fix-invalid-reference-to-variable-in-union.patch
+++ b/userspace/dpdk/18.08/0009-net-ena-fix-invalid-reference-to-variable-in-union.patch
@@ -1,7 +1,7 @@
 From a1aa40a4e7d291f9cb389dc5ca3988ce2c30b92b Mon Sep 17 00:00:00 2001
 From: Rafal Kozik <rk@semihalf.com>
 Date: Fri, 14 Dec 2018 14:18:39 +0100
-Subject: [PATCH 09/19] net/ena: fix invalid reference to variable in union
+Subject: [PATCH 09/27] net/ena: fix invalid reference to variable in union
 
 [ upstream commit eccbe2ffdc755a9e759c6ba480f6c15ccb1163c7 ]
 
@@ -20,7 +20,7 @@ Acked-by: Michal Krawczyk <mk@semihalf.com>
  1 file changed, 1 insertion(+), 1 deletion(-)
 
 diff --git a/drivers/net/ena/ena_ethdev.c b/drivers/net/ena/ena_ethdev.c
-index 9cab09b57..59375dd2f 100644
+index 9cab09b574..59375dd2fc 100644
 --- a/drivers/net/ena/ena_ethdev.c
 +++ b/drivers/net/ena/ena_ethdev.c
 @@ -1280,7 +1280,7 @@ static int ena_rx_queue_setup(struct rte_eth_dev *dev,

--- a/userspace/dpdk/18.08/0010-net-ena-fix-cleanup-for-out-of-order-packets.patch
+++ b/userspace/dpdk/18.08/0010-net-ena-fix-cleanup-for-out-of-order-packets.patch
@@ -1,7 +1,7 @@
 From 96a79e7e9e8904fb742ab223cfae0ad6a695cec7 Mon Sep 17 00:00:00 2001
 From: Rafal Kozik <rk@semihalf.com>
 Date: Mon, 17 Dec 2018 12:06:18 +0100
-Subject: [PATCH 10/19] net/ena: fix cleanup for out of order packets
+Subject: [PATCH 10/27] net/ena: fix cleanup for out of order packets
 
 [ upstream commit 709b1dcb73adebb3fc1a838b57d72028feb97e47 ]
 
@@ -27,7 +27,7 @@ Acked-by: Michal Krawczyk <mk@semihalf.com>
  1 file changed, 11 insertions(+), 13 deletions(-)
 
 diff --git a/drivers/net/ena/ena_ethdev.c b/drivers/net/ena/ena_ethdev.c
-index 59375dd2f..96880aa87 100644
+index 59375dd2fc..96880aa87b 100644
 --- a/drivers/net/ena/ena_ethdev.c
 +++ b/drivers/net/ena/ena_ethdev.c
 @@ -746,17 +746,13 @@ static void ena_tx_queue_release(void *queue)

--- a/userspace/dpdk/18.08/0011-net-ena-add-new-way-of-getting-Rx-drops.patch
+++ b/userspace/dpdk/18.08/0011-net-ena-add-new-way-of-getting-Rx-drops.patch
@@ -1,7 +1,7 @@
 From ea9b91a8a853dd97380de080f878c034e16240ec Mon Sep 17 00:00:00 2001
 From: Rafal Kozik <rk@semihalf.com>
 Date: Fri, 14 Dec 2018 14:18:43 +0100
-Subject: [PATCH 11/19] net/ena: add new way of getting Rx drops
+Subject: [PATCH 11/27] net/ena: add new way of getting Rx drops
 
 [ upstream commit 94c3e3765d9e0366acf145668d32d5eee3200c2b ]
 
@@ -17,7 +17,7 @@ Acked-by: Michal Krawczyk <mk@semihalf.com>
  2 files changed, 9 insertions(+), 2 deletions(-)
 
 diff --git a/drivers/net/ena/ena_ethdev.c b/drivers/net/ena/ena_ethdev.c
-index 96880aa87..ee7605a3b 100644
+index 96880aa87b..ee7605a3b6 100644
 --- a/drivers/net/ena/ena_ethdev.c
 +++ b/drivers/net/ena/ena_ethdev.c
 @@ -890,6 +890,7 @@ static void ena_stats_restart(struct rte_eth_dev *dev)
@@ -56,7 +56,7 @@ index 96880aa87..ee7605a3b 100644
  
  /**
 diff --git a/drivers/net/ena/ena_ethdev.h b/drivers/net/ena/ena_ethdev.h
-index 322e90ace..8eb8543c2 100644
+index 322e90ace8..8eb8543c21 100644
 --- a/drivers/net/ena/ena_ethdev.h
 +++ b/drivers/net/ena/ena_ethdev.h
 @@ -120,6 +120,7 @@ struct ena_driver_stats {

--- a/userspace/dpdk/18.08/0012-net-ena-update-completion-queue-after-cleanup.patch
+++ b/userspace/dpdk/18.08/0012-net-ena-update-completion-queue-after-cleanup.patch
@@ -1,7 +1,7 @@
 From 28a3fd0a5fd89a61c5992c2acc7626b844f5a60d Mon Sep 17 00:00:00 2001
 From: Rafal Kozik <rk@semihalf.com>
 Date: Fri, 14 Dec 2018 14:18:44 +0100
-Subject: [PATCH 12/19] net/ena: update completion queue after cleanup
+Subject: [PATCH 12/27] net/ena: update completion queue after cleanup
 
 [ upstream commit a45462c507e98b49cb5c2302e0be3c72d2e20a1a ]
 
@@ -19,7 +19,7 @@ Acked-by: Michal Krawczyk <mk@semihalf.com>
  1 file changed, 5 insertions(+), 2 deletions(-)
 
 diff --git a/drivers/net/ena/ena_ethdev.c b/drivers/net/ena/ena_ethdev.c
-index ee7605a3b..813e95e95 100644
+index ee7605a3b6..813e95e95e 100644
 --- a/drivers/net/ena/ena_ethdev.c
 +++ b/drivers/net/ena/ena_ethdev.c
 @@ -1922,8 +1922,10 @@ static uint16_t eth_ena_recv_pkts(void *rx_queue, struct rte_mbuf **rx_pkts,

--- a/userspace/dpdk/18.08/0013-net-ena-fix-dev-init-with-multi-process.patch
+++ b/userspace/dpdk/18.08/0013-net-ena-fix-dev-init-with-multi-process.patch
@@ -1,7 +1,7 @@
 From 1278928ed5362188fa9003da082dfa97aa5b5678 Mon Sep 17 00:00:00 2001
 From: Michal Krawczyk <mk@semihalf.com>
 Date: Fri, 25 Jan 2019 09:10:25 +0100
-Subject: [PATCH 13/19] net/ena: fix dev init with multi-process
+Subject: [PATCH 13/27] net/ena: fix dev init with multi-process
 
 [ upstream commit fd9768905870856a2340266d25f8c0100dfccfff ]
 
@@ -22,7 +22,7 @@ Signed-off-by: Michal Krawczyk <mk@semihalf.com>
  1 file changed, 6 insertions(+), 5 deletions(-)
 
 diff --git a/drivers/net/ena/ena_ethdev.c b/drivers/net/ena/ena_ethdev.c
-index 813e95e95..a96ec6975 100644
+index 813e95e95e..a96ec69753 100644
 --- a/drivers/net/ena/ena_ethdev.c
 +++ b/drivers/net/ena/ena_ethdev.c
 @@ -1531,19 +1531,20 @@ static int eth_ena_dev_init(struct rte_eth_dev *eth_dev)

--- a/userspace/dpdk/18.08/0014-net-ena-fix-errno-to-positive-value.patch
+++ b/userspace/dpdk/18.08/0014-net-ena-fix-errno-to-positive-value.patch
@@ -1,7 +1,7 @@
 From a453fb83d52bdcd1e74bfbcccf9185c9f3d4ca36 Mon Sep 17 00:00:00 2001
 From: Michal Krawczyk <mk@semihalf.com>
 Date: Fri, 25 Jan 2019 09:10:26 +0100
-Subject: [PATCH 14/19] net/ena: fix errno to positive value
+Subject: [PATCH 14/27] net/ena: fix errno to positive value
 
 [ upstream commit baeed5f404dd1b049118cfec26a2fd3203671572 ]
 
@@ -18,7 +18,7 @@ Signed-off-by: Michal Krawczyk <mk@semihalf.com>
  1 file changed, 3 insertions(+), 3 deletions(-)
 
 diff --git a/drivers/net/ena/ena_ethdev.c b/drivers/net/ena/ena_ethdev.c
-index a96ec6975..26316fa75 100644
+index a96ec69753..26316fa752 100644
 --- a/drivers/net/ena/ena_ethdev.c
 +++ b/drivers/net/ena/ena_ethdev.c
 @@ -1973,14 +1973,14 @@ eth_ena_prep_pkts(void *tx_queue, struct rte_mbuf **tx_pkts,

--- a/userspace/dpdk/18.08/0015-net-ena-get-device-info-statically.patch
+++ b/userspace/dpdk/18.08/0015-net-ena-get-device-info-statically.patch
@@ -1,7 +1,7 @@
 From 2b83153af74ba5661c3b65164a48d14aa043b01c Mon Sep 17 00:00:00 2001
 From: Michal Krawczyk <mk@semihalf.com>
 Date: Fri, 15 Feb 2019 09:36:39 +0100
-Subject: [PATCH 15/19] net/ena: get device info statically
+Subject: [PATCH 15/27] net/ena: get device info statically
 
 [ upstream commit 117ba4a60488a0f96a5737f38ddba6d0f9a728b6 ]
 
@@ -22,7 +22,7 @@ Signed-off-by: Michal Krawczyk <mk@semihalf.com>
  2 files changed, 21 insertions(+), 22 deletions(-)
 
 diff --git a/drivers/net/ena/ena_ethdev.c b/drivers/net/ena/ena_ethdev.c
-index 26316fa75..05624cc64 100644
+index 26316fa752..05624cc646 100644
 --- a/drivers/net/ena/ena_ethdev.c
 +++ b/drivers/net/ena/ena_ethdev.c
 @@ -1604,9 +1604,14 @@ static int eth_ena_dev_init(struct rte_eth_dev *eth_dev)
@@ -105,7 +105,7 @@ index 26316fa75..05624cc64 100644
  		}
  
 diff --git a/drivers/net/ena/ena_ethdev.h b/drivers/net/ena/ena_ethdev.h
-index 8eb8543c2..982ad7854 100644
+index 8eb8543c21..982ad7854e 100644
 --- a/drivers/net/ena/ena_ethdev.h
 +++ b/drivers/net/ena/ena_ethdev.h
 @@ -160,6 +160,12 @@ struct ena_stats_rx {

--- a/userspace/dpdk/18.08/0016-net-ena-fix-checksum-feature-flag.patch
+++ b/userspace/dpdk/18.08/0016-net-ena-fix-checksum-feature-flag.patch
@@ -1,7 +1,7 @@
 From fdeb1ff02b47b10bfc9b11f8fa1b2dd12ee59af5 Mon Sep 17 00:00:00 2001
 From: Michal Krawczyk <mk@semihalf.com>
 Date: Mon, 8 Apr 2019 12:27:44 +0200
-Subject: [PATCH 16/19] net/ena: fix checksum feature flag
+Subject: [PATCH 16/27] net/ena: fix checksum feature flag
 
 [ upstream commit ef538c1a7f565c9b58518375a500aa864445fd11 ]
 
@@ -18,7 +18,7 @@ Signed-off-by: Michal Krawczyk <mk@semihalf.com>
  1 file changed, 1 insertion(+), 1 deletion(-)
 
 diff --git a/drivers/net/ena/ena_ethdev.c b/drivers/net/ena/ena_ethdev.c
-index 05624cc64..65596db92 100644
+index 05624cc646..65596db92e 100644
 --- a/drivers/net/ena/ena_ethdev.c
 +++ b/drivers/net/ena/ena_ethdev.c
 @@ -1609,7 +1609,7 @@ static int eth_ena_dev_init(struct rte_eth_dev *eth_dev)

--- a/userspace/dpdk/18.08/0017-net-ena-fix-Rx-checksum-errors-statistics.patch
+++ b/userspace/dpdk/18.08/0017-net-ena-fix-Rx-checksum-errors-statistics.patch
@@ -1,7 +1,7 @@
 From 5fb459c3a479ce3afcfe8215ae903afa0c9fd0e9 Mon Sep 17 00:00:00 2001
 From: Michal Krawczyk <mk@semihalf.com>
 Date: Tue, 28 May 2019 10:28:34 +0200
-Subject: [PATCH 17/19] net/ena: fix Rx checksum errors statistics
+Subject: [PATCH 17/27] net/ena: fix Rx checksum errors statistics
 
 [ upstream commit ef74b5f7b69b9502ddab81121611243efcfe1dde ]
 
@@ -21,7 +21,7 @@ Signed-off-by: Michal Krawczyk <mk@semihalf.com>
  1 file changed, 5 insertions(+), 4 deletions(-)
 
 diff --git a/drivers/net/ena/ena_ethdev.c b/drivers/net/ena/ena_ethdev.c
-index 65596db92..c03ce3ab3 100644
+index 65596db92e..c03ce3ab3f 100644
 --- a/drivers/net/ena/ena_ethdev.c
 +++ b/drivers/net/ena/ena_ethdev.c
 @@ -1905,6 +1905,11 @@ static uint16_t eth_ena_recv_pkts(void *rx_queue, struct rte_mbuf **rx_pkts,

--- a/userspace/dpdk/18.08/0018-net-ena-fix-assigning-NUMA-node-to-IO-queue.patch
+++ b/userspace/dpdk/18.08/0018-net-ena-fix-assigning-NUMA-node-to-IO-queue.patch
@@ -1,7 +1,7 @@
 From c1ab86b1dca90567b768291644149e2f06c94bae Mon Sep 17 00:00:00 2001
 From: Michal Krawczyk <mk@semihalf.com>
 Date: Tue, 4 Jun 2019 12:59:36 +0200
-Subject: [PATCH 18/19] net/ena: fix assigning NUMA node to IO queue
+Subject: [PATCH 18/27] net/ena: fix assigning NUMA node to IO queue
 
 [ upstream commit 4217cb0b7d2c5385f06f531af7f14b860927aba7 ]
 
@@ -23,7 +23,7 @@ Reviewed-by: David Marchand <david.marchand@redhat.com>
  2 files changed, 7 insertions(+), 20 deletions(-)
 
 diff --git a/drivers/net/ena/ena_ethdev.c b/drivers/net/ena/ena_ethdev.c
-index c03ce3ab3..f25e5ba82 100644
+index c03ce3ab3f..f25e5ba827 100644
 --- a/drivers/net/ena/ena_ethdev.c
 +++ b/drivers/net/ena/ena_ethdev.c
 @@ -39,7 +39,6 @@
@@ -101,7 +101,7 @@ index c03ce3ab3..f25e5ba82 100644
  
  	rxq->rx_buffer_info = rte_zmalloc("rxq->buffer_info",
 diff --git a/drivers/net/ena/ena_ethdev.h b/drivers/net/ena/ena_ethdev.h
-index 982ad7854..2ce0eb79e 100644
+index 982ad7854e..2ce0eb79ec 100644
 --- a/drivers/net/ena/ena_ethdev.h
 +++ b/drivers/net/ena/ena_ethdev.h
 @@ -105,6 +105,8 @@ struct ena_ring {

--- a/userspace/dpdk/18.08/0019-net-ena-fix-L4-checksum-Tx-offload.patch
+++ b/userspace/dpdk/18.08/0019-net-ena-fix-L4-checksum-Tx-offload.patch
@@ -27,7 +27,7 @@ Acked-by: Michal Krawczyk <mk@semihalf.com>
  1 file changed, 4 insertions(+), 3 deletions(-)
 
 diff --git a/drivers/net/ena/ena_ethdev.c b/drivers/net/ena/ena_ethdev.c
-index f25e5ba82..7768eabba 100644
+index f25e5ba827..7768eabbab 100644
 --- a/drivers/net/ena/ena_ethdev.c
 +++ b/drivers/net/ena/ena_ethdev.c
 @@ -335,12 +335,13 @@ static inline void ena_tx_mbuf_prepare(struct rte_mbuf *mbuf,

--- a/userspace/dpdk/18.08/0019-net-ena-fix-admin-CQ-polling-for-32-bit.patch
+++ b/userspace/dpdk/18.08/0019-net-ena-fix-admin-CQ-polling-for-32-bit.patch
@@ -1,0 +1,37 @@
+From 78d11f06090eef2cf52d78187b4ce2c1bd4cecaa Mon Sep 17 00:00:00 2001
+From: David Harton <dharton@cisco.com>
+Date: Fri, 12 Jul 2019 13:35:43 -0400
+Subject: [PATCH 19/27] net/ena: fix admin CQ polling for 32-bit
+
+[ upstream commit 8190a843ef9bce3696b74ad2b057b5d86cc7b0df ]
+
+Recent modifications to admin command queue polling logic
+did not support 32-bit applications.  Updated the driver to
+work for 32 or 64 bit applications
+
+Fixes: 3adcba9a8987 ("net/ena: update HAL to the newer version")
+Cc: stable@dpdk.org
+
+Change-Id: I254d8d36af4208c713fbffcfbd0d241a88a972ce
+Signed-off-by: David Harton <dharton@cisco.com>
+Acked-by: Michal Krawczyk <mk@semihalf.com>
+---
+ drivers/net/ena/base/ena_com.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/drivers/net/ena/base/ena_com.c b/drivers/net/ena/base/ena_com.c
+index 4abf1a28a1..f22d67cd4d 100644
+--- a/drivers/net/ena/base/ena_com.c
++++ b/drivers/net/ena/base/ena_com.c
+@@ -526,7 +526,7 @@ static int ena_com_wait_and_process_admin_cq_polling(struct ena_comp_ctx *comp_c
+ 						     struct ena_com_admin_queue *admin_queue)
+ {
+ 	unsigned long flags = 0;
+-	unsigned long timeout;
++	uint64_t timeout;
+ 	int ret;
+ 
+ 	timeout = ENA_GET_SYSTEM_TIMEOUT(admin_queue->completion_timeout);
+-- 
+2.20.1
+

--- a/userspace/dpdk/18.08/0020-net-ena-fix-L4-checksum-Tx-offload.patch
+++ b/userspace/dpdk/18.08/0020-net-ena-fix-L4-checksum-Tx-offload.patch
@@ -1,0 +1,52 @@
+From 08656827fef0ce82b466fad5590a02fd66054613 Mon Sep 17 00:00:00 2001
+From: Maciej Bielski <mba@semihalf.com>
+Date: Thu, 1 Aug 2019 13:45:36 +0200
+Subject: [PATCH 20/27] net/ena: fix L4 checksum Tx offload
+
+[ upstream commit 40e7c02155625f18a87faf5e6a8cec2e986146e8 ]
+
+During an if-condition evaluation, a 2-bit flag evaluates to 'true' for
+'0x1', '0x2' and '0x3'. Thus, from this perspective these flags are
+indistinguishable. To make them distinct, respective bits must be
+extracted with a mask and then checked for strict equality.
+
+Specifically here, even if `PKT_TX_UDP_CKSUM` (value '0x3') was set, the
+expression `mbuf->ol_flags & PKT_TX_TCP` (the second flag of value
+'0x1') is evaluated first and the result is 'true'. In consequence, for
+UDP packets the execution flow enters an incorrect branch.
+
+Fixes: 56b8b9b7e5d2 ("net/ena: convert to new Tx offloads API")
+Cc: stable@dpdk.org
+
+Change-Id: I7917b209856f24e5d0b6481a94b322d09266bc5b
+Reported-by: Eduard Serra <eserra@vmware.com>
+Signed-off-by: Maciej Bielski <mba@semihalf.com>
+Acked-by: Michal Krawczyk <mk@semihalf.com>
+---
+ drivers/net/ena/ena_ethdev.c | 7 ++++---
+ 1 file changed, 4 insertions(+), 3 deletions(-)
+
+diff --git a/drivers/net/ena/ena_ethdev.c b/drivers/net/ena/ena_ethdev.c
+index f25e5ba827..7768eabbab 100644
+--- a/drivers/net/ena/ena_ethdev.c
++++ b/drivers/net/ena/ena_ethdev.c
+@@ -335,12 +335,13 @@ static inline void ena_tx_mbuf_prepare(struct rte_mbuf *mbuf,
+ 		}
+ 
+ 		/* check if L4 checksum is needed */
+-		if ((mbuf->ol_flags & PKT_TX_TCP_CKSUM) &&
++		if (((mbuf->ol_flags & PKT_TX_L4_MASK) == PKT_TX_TCP_CKSUM) &&
+ 		    (queue_offloads & DEV_TX_OFFLOAD_TCP_CKSUM)) {
+ 			ena_tx_ctx->l4_proto = ENA_ETH_IO_L4_PROTO_TCP;
+ 			ena_tx_ctx->l4_csum_enable = true;
+-		} else if ((mbuf->ol_flags & PKT_TX_UDP_CKSUM) &&
+-			   (queue_offloads & DEV_TX_OFFLOAD_UDP_CKSUM)) {
++		} else if (((mbuf->ol_flags & PKT_TX_L4_MASK) ==
++				PKT_TX_UDP_CKSUM) &&
++				(queue_offloads & DEV_TX_OFFLOAD_UDP_CKSUM)) {
+ 			ena_tx_ctx->l4_proto = ENA_ETH_IO_L4_PROTO_UDP;
+ 			ena_tx_ctx->l4_csum_enable = true;
+ 		} else {
+-- 
+2.20.1
+

--- a/userspace/dpdk/18.08/0021-net-ena-fix-indication-of-bad-L4-Rx-checksums.patch
+++ b/userspace/dpdk/18.08/0021-net-ena-fix-indication-of-bad-L4-Rx-checksums.patch
@@ -1,0 +1,44 @@
+From a0233e4d8570687b69098c4bd8c6de3f7d0f3729 Mon Sep 17 00:00:00 2001
+From: Igor Chauskin <igorch@amazon.com>
+Date: Mon, 28 Oct 2019 11:23:33 +0100
+Subject: [PATCH 21/27] net/ena: fix indication of bad L4 Rx checksums
+
+[ upstream commit 05817057faba9356900ced61e24a22eef6bc4c87 ]
+
+Add checking of l4_csum_checked and frag flags before checking the
+l4_csum_error flag.
+
+In case of IP fragment/unchecked L4 csum - add PKT_RX_L4_CKSUM_UNKNOWN
+flag to the indicated mbuf.
+
+Fixes: 1173fca25af9 ("ena: add polling-mode driver")
+Cc: stable@dpdk.org
+
+Change-Id: I9f1414741eb44ca289a8bfd11d7e66110c95040e
+Signed-off-by: Igor Chauskin <igorch@amazon.com>
+Reviewed-by: Maciej Bielski <mba@semihalf.com>
+Reviewed-by: Michal Krawczyk <mk@semihalf.com>
+---
+ drivers/net/ena/ena_ethdev.c | 5 ++++-
+ 1 file changed, 4 insertions(+), 1 deletion(-)
+
+diff --git a/drivers/net/ena/ena_ethdev.c b/drivers/net/ena/ena_ethdev.c
+index 7768eabbab..dd60b7582d 100644
+--- a/drivers/net/ena/ena_ethdev.c
++++ b/drivers/net/ena/ena_ethdev.c
+@@ -292,8 +292,11 @@ static inline void ena_rx_mbuf_prepare(struct rte_mbuf *mbuf,
+ 	else if (ena_rx_ctx->l3_proto == ENA_ETH_IO_L3_PROTO_IPV6)
+ 		packet_type |= RTE_PTYPE_L3_IPV6;
+ 
+-	if (unlikely(ena_rx_ctx->l4_csum_err))
++	if (unlikely(ena_rx_ctx->l4_csum_err) && !ena_rx_ctx->frag)
+ 		ol_flags |= PKT_RX_L4_CKSUM_BAD;
++	else
++		ol_flags |= PKT_RX_L4_CKSUM_UNKNOWN;
++
+ 	if (unlikely(ena_rx_ctx->l3_csum_err))
+ 		ol_flags |= PKT_RX_IP_CKSUM_BAD;
+ 
+-- 
+2.20.1
+

--- a/userspace/dpdk/18.08/0022-net-ena-ensure-Rx-buffer-size-is-at-least-1400B.patch
+++ b/userspace/dpdk/18.08/0022-net-ena-ensure-Rx-buffer-size-is-at-least-1400B.patch
@@ -1,0 +1,84 @@
+From 08aaa39c149818d55bb2f31419c355d7310ebe41 Mon Sep 17 00:00:00 2001
+From: Michal Krawczyk <mk@semihalf.com>
+Date: Wed, 8 Apr 2020 10:28:52 +0200
+Subject: [PATCH 22/27] net/ena: ensure Rx buffer size is at least 1400B
+
+[ upstream commit 38364c2687ead97b99402310087c27131a97748c ]
+
+Some of the ENA devices can't handle buffers which are smaller than a
+1400B. Because of this limitation, size of the buffer is being checked
+and limited during the Rx queue setup.
+
+If it's below the allowed value, PMD won't finish it's configuration
+successfully..
+
+Change-Id: Ib402d3bfad98a3fc4f91095d5c6f90c6069da021
+Signed-off-by: Michal Krawczyk <mk@semihalf.com>
+Reviewed-by: Igor Chauskin <igorch@amazon.com>
+Reviewed-by: Guy Tzalik <gtzalik@amazon.com>
+---
+ drivers/net/ena/ena_ethdev.c | 12 +++++++++++-
+ drivers/net/ena/ena_ethdev.h |  3 ++-
+ 2 files changed, 13 insertions(+), 2 deletions(-)
+
+diff --git a/drivers/net/ena/ena_ethdev.c b/drivers/net/ena/ena_ethdev.c
+index dd60b7582d..288e53265a 100644
+--- a/drivers/net/ena/ena_ethdev.c
++++ b/drivers/net/ena/ena_ethdev.c
+@@ -1,7 +1,7 @@
+ /*-
+ * BSD LICENSE
+ *
+-* Copyright (c) 2015-2016 Amazon.com, Inc. or its affiliates.
++* Copyright (c) 2015-2020 Amazon.com, Inc. or its affiliates.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+@@ -1200,6 +1200,7 @@ static int ena_rx_queue_setup(struct rte_eth_dev *dev,
+ 	struct ena_adapter *adapter =
+ 		(struct ena_adapter *)(dev->data->dev_private);
+ 	struct ena_ring *rxq = NULL;
++	size_t buffer_size;
+ 	int i;
+ 
+ 	rxq = &adapter->rx_ring[queue_idx];
+@@ -1224,6 +1225,15 @@ static int ena_rx_queue_setup(struct rte_eth_dev *dev,
+ 		return -EINVAL;
+ 	}
+ 
++	/* ENA isn't supporting buffers smaller than 1400 bytes */
++	buffer_size = rte_pktmbuf_data_room_size(mp) - RTE_PKTMBUF_HEADROOM;
++	if (buffer_size < ENA_RX_BUF_MIN_SIZE) {
++		PMD_DRV_LOG(ERR,
++			"Unsupported size of RX buffer: %zu (min size: %d)\n",
++			buffer_size, ENA_RX_BUF_MIN_SIZE);
++		return -EINVAL;
++	}
++
+ 	rxq->port_id = dev->data->port_id;
+ 	rxq->next_to_clean = 0;
+ 	rxq->next_to_use = 0;
+diff --git a/drivers/net/ena/ena_ethdev.h b/drivers/net/ena/ena_ethdev.h
+index 2ce0eb79ec..9d887d4b5b 100644
+--- a/drivers/net/ena/ena_ethdev.h
++++ b/drivers/net/ena/ena_ethdev.h
+@@ -1,7 +1,7 @@
+ /*-
+ * BSD LICENSE
+ *
+-* Copyright (c) 2015-2016 Amazon.com, Inc. or its affiliates.
++* Copyright (c) 2015-2020 Amazon.com, Inc. or its affiliates.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+@@ -49,6 +49,7 @@
+ #define ENA_MIN_FRAME_LEN	64
+ #define ENA_NAME_MAX_LEN	20
+ #define ENA_PKT_MAX_BUFS	17
++#define ENA_RX_BUF_MIN_SIZE	1400
+ 
+ #define ENA_MIN_MTU		128
+ 
+-- 
+2.20.1
+

--- a/userspace/dpdk/18.08/0023-net-ena-base-make-allocation-macros-thread-safe.patch
+++ b/userspace/dpdk/18.08/0023-net-ena-base-make-allocation-macros-thread-safe.patch
@@ -1,0 +1,80 @@
+From fdcc0fb63b9014b820a045134799fe87cda9f368 Mon Sep 17 00:00:00 2001
+From: Igor Chauskin <igorch@amazon.com>
+Date: Wed, 8 Apr 2020 10:28:53 +0200
+Subject: [PATCH 23/27] net/ena/base: make allocation macros thread-safe
+
+[ upstream commit b14fcac035fd8514851c9140a4e26d765b61c532 ]
+
+Memory allocation region id could possibly be non-unique
+due to non-atomic increment, causing allocation failure.
+
+Fixes: 9ba7981ec992 ("ena: add communication layer for DPDK")
+Cc: stable@dpdk.org
+
+Change-Id: Ib9207aaae4e5e7ecdf1a99a0f23a508a53af631d
+Signed-off-by: Igor Chauskin <igorch@amazon.com>
+Reviewed-by: Michal Krawczyk <mk@semihalf.com>
+Reviewed-by: Guy Tzalik <gtzalik@amazon.com>
+---
+ drivers/net/ena/base/ena_plat_dpdk.h | 10 ++++++----
+ drivers/net/ena/ena_ethdev.c         |  2 +-
+ 2 files changed, 7 insertions(+), 5 deletions(-)
+
+diff --git a/drivers/net/ena/base/ena_plat_dpdk.h b/drivers/net/ena/base/ena_plat_dpdk.h
+index 900ba1a6b0..ac2c281297 100644
+--- a/drivers/net/ena/base/ena_plat_dpdk.h
++++ b/drivers/net/ena/base/ena_plat_dpdk.h
+@@ -1,7 +1,7 @@
+ /*-
+ * BSD LICENSE
+ *
+-* Copyright (c) 2015-2016 Amazon.com, Inc. or its affiliates.
++* Copyright (c) 2015-2020 Amazon.com, Inc. or its affiliates.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+@@ -201,7 +201,7 @@ do {                                                                   \
+  * Each rte_memzone should have unique name.
+  * To satisfy it, count number of allocations and add it to name.
+  */
+-extern uint32_t ena_alloc_cnt;
++extern rte_atomic32_t ena_alloc_cnt;
+ 
+ #define ENA_MEM_ALLOC_COHERENT(dmadev, size, virt, phys, handle)	\
+ 	do {								\
+@@ -209,7 +209,8 @@ extern uint32_t ena_alloc_cnt;
+ 		char z_name[RTE_MEMZONE_NAMESIZE];			\
+ 		ENA_TOUCH(dmadev); ENA_TOUCH(handle);			\
+ 		snprintf(z_name, sizeof(z_name),			\
+-				"ena_alloc_%d", ena_alloc_cnt++);	\
++			 "ena_alloc_%d",				\
++			 rte_atomic32_add_return(&ena_alloc_cnt, 1));	\
+ 		mz = rte_memzone_reserve(z_name, size, SOCKET_ID_ANY,	\
+ 				RTE_MEMZONE_IOVA_CONTIG);		\
+ 		handle = mz;						\
+@@ -234,7 +235,8 @@ extern uint32_t ena_alloc_cnt;
+ 		char z_name[RTE_MEMZONE_NAMESIZE];			\
+ 		ENA_TOUCH(dmadev); ENA_TOUCH(dev_node);			\
+ 		snprintf(z_name, sizeof(z_name),			\
+-				"ena_alloc_%d", ena_alloc_cnt++);	\
++			 "ena_alloc_%d",				\
++			 rte_atomic32_add_return(&ena_alloc_cnt, 1));	\
+ 		mz = rte_memzone_reserve(z_name, size, node,		\
+ 				RTE_MEMZONE_IOVA_CONTIG);		\
+ 		mem_handle = mz;					\
+diff --git a/drivers/net/ena/ena_ethdev.c b/drivers/net/ena/ena_ethdev.c
+index 288e53265a..08e21c59b8 100644
+--- a/drivers/net/ena/ena_ethdev.c
++++ b/drivers/net/ena/ena_ethdev.c
+@@ -120,7 +120,7 @@ struct ena_stats {
+  * Each rte_memzone should have unique name.
+  * To satisfy it, count number of allocation and add it to name.
+  */
+-uint32_t ena_alloc_cnt;
++rte_atomic32_t ena_alloc_cnt;
+ 
+ static const struct ena_stats ena_stats_global_strings[] = {
+ 	ENA_STAT_GLOBAL_ENTRY(tx_timeout),
+-- 
+2.20.1
+

--- a/userspace/dpdk/18.08/0024-net-ena-base-prevent-allocation-of-zero-sized-memory.patch
+++ b/userspace/dpdk/18.08/0024-net-ena-base-prevent-allocation-of-zero-sized-memory.patch
@@ -1,0 +1,77 @@
+From d5fe29f02d748a043884f5762fb26cb291af3471 Mon Sep 17 00:00:00 2001
+From: Igor Chauskin <igorch@amazon.com>
+Date: Wed, 8 Apr 2020 10:28:54 +0200
+Subject: [PATCH 24/27] net/ena/base: prevent allocation of zero sized memory
+
+[ upstream commit 29dc10d9424ccf26a346387b0a707185e2432400 ]
+
+rte_memzone_reserve() will reserve the biggest contiguous memzone
+available if received 0 as size param.
+
+Fixes: 9ba7981ec992 ("ena: add communication layer for DPDK")
+Cc: stable@dpdk.org
+
+Change-Id: I2f71119e93c5e9addd8c538820093f030066d690
+Signed-off-by: Igor Chauskin <igorch@amazon.com>
+Reviewed-by: Michal Krawczyk <mk@semihalf.com>
+Reviewed-by: Guy Tzalik <gtzalik@amazon.com>
+---
+ drivers/net/ena/base/ena_plat_dpdk.h | 29 ++++++++++++++++------------
+ 1 file changed, 17 insertions(+), 12 deletions(-)
+
+diff --git a/drivers/net/ena/base/ena_plat_dpdk.h b/drivers/net/ena/base/ena_plat_dpdk.h
+index ac2c281297..57cf5078ea 100644
+--- a/drivers/net/ena/base/ena_plat_dpdk.h
++++ b/drivers/net/ena/base/ena_plat_dpdk.h
+@@ -205,15 +205,18 @@ extern rte_atomic32_t ena_alloc_cnt;
+ 
+ #define ENA_MEM_ALLOC_COHERENT(dmadev, size, virt, phys, handle)	\
+ 	do {								\
+-		const struct rte_memzone *mz;				\
+-		char z_name[RTE_MEMZONE_NAMESIZE];			\
++		const struct rte_memzone *mz = NULL;			\
+ 		ENA_TOUCH(dmadev); ENA_TOUCH(handle);			\
+-		snprintf(z_name, sizeof(z_name),			\
++		if (size > 0) {						\
++			char z_name[RTE_MEMZONE_NAMESIZE];		\
++			snprintf(z_name, sizeof(z_name),		\
+ 			 "ena_alloc_%d",				\
+ 			 rte_atomic32_add_return(&ena_alloc_cnt, 1));	\
+-		mz = rte_memzone_reserve(z_name, size, SOCKET_ID_ANY,	\
+-				RTE_MEMZONE_IOVA_CONTIG);		\
+-		handle = mz;						\
++			mz = rte_memzone_reserve(z_name, size,		\
++					SOCKET_ID_ANY,			\
++					RTE_MEMZONE_IOVA_CONTIG);	\
++			handle = mz;					\
++		}							\
+ 		if (mz == NULL) {					\
+ 			virt = NULL;					\
+ 			phys = 0;					\
+@@ -231,15 +234,17 @@ extern rte_atomic32_t ena_alloc_cnt;
+ #define ENA_MEM_ALLOC_COHERENT_NODE(					\
+ 	dmadev, size, virt, phys, mem_handle, node, dev_node)		\
+ 	do {								\
+-		const struct rte_memzone *mz;				\
+-		char z_name[RTE_MEMZONE_NAMESIZE];			\
++		const struct rte_memzone *mz = NULL;			\
+ 		ENA_TOUCH(dmadev); ENA_TOUCH(dev_node);			\
+-		snprintf(z_name, sizeof(z_name),			\
++		if (size > 0) {						\
++			char z_name[RTE_MEMZONE_NAMESIZE];		\
++			snprintf(z_name, sizeof(z_name),		\
+ 			 "ena_alloc_%d",				\
+-			 rte_atomic32_add_return(&ena_alloc_cnt, 1));	\
+-		mz = rte_memzone_reserve(z_name, size, node,		\
++			 rte_atomic32_add_return(&ena_alloc_cnt, 1));   \
++			mz = rte_memzone_reserve(z_name, size, node,	\
+ 				RTE_MEMZONE_IOVA_CONTIG);		\
+-		mem_handle = mz;					\
++			mem_handle = mz;				\
++		}							\
+ 		if (mz == NULL) {					\
+ 			virt = NULL;					\
+ 			phys = 0;					\
+-- 
+2.20.1
+

--- a/userspace/dpdk/18.08/0025-net-ena-set-IO-ring-size-to-valid-value.patch
+++ b/userspace/dpdk/18.08/0025-net-ena-set-IO-ring-size-to-valid-value.patch
@@ -1,0 +1,49 @@
+From 8efc69ce234a2684fd10c85183fba743cb0c2572 Mon Sep 17 00:00:00 2001
+From: Michal Krawczyk <mk@semihalf.com>
+Date: Wed, 8 Apr 2020 10:29:08 +0200
+Subject: [PATCH 25/27] net/ena: set IO ring size to valid value
+
+[ upstream commit badc3a6aa133a886a61b9e3ad666e5675f7ec3d3 ]
+
+IO rings were configured with the maximum allowed size for the Tx/Rx
+rings. However, the application could decide to create smaller rings.
+
+This patch is using value stored in the ring instead of the value from
+the adapter which is indicating the maximum allowed value.
+
+Fixes: df238f84c0a2 ("net/ena: recreate HW IO rings on start and stop")
+Cc: stable@dpdk.org
+
+Change-Id: Icf9102e2aa4e7413b6620b36dd232673239b7291
+Signed-off-by: Michal Krawczyk <mk@semihalf.com>
+Reviewed-by: Igor Chauskin <igorch@amazon.com>
+Reviewed-by: Guy Tzalik <gtzalik@amazon.com>
+---
+ drivers/net/ena/ena_ethdev.c | 3 +--
+ 1 file changed, 1 insertion(+), 2 deletions(-)
+
+diff --git a/drivers/net/ena/ena_ethdev.c b/drivers/net/ena/ena_ethdev.c
+index 08e21c59b8..640e3dae28 100644
+--- a/drivers/net/ena/ena_ethdev.c
++++ b/drivers/net/ena/ena_ethdev.c
+@@ -1025,16 +1025,15 @@ static int ena_create_io_queue(struct ena_ring *ring)
+ 		ena_qid = ENA_IO_TXQ_IDX(ring->id);
+ 		ctx.direction = ENA_COM_IO_QUEUE_DIRECTION_TX;
+ 		ctx.mem_queue_type = ena_dev->tx_mem_queue_type;
+-		ctx.queue_size = adapter->tx_ring_size;
+ 		for (i = 0; i < ring->ring_size; i++)
+ 			ring->empty_tx_reqs[i] = i;
+ 	} else {
+ 		ena_qid = ENA_IO_RXQ_IDX(ring->id);
+ 		ctx.direction = ENA_COM_IO_QUEUE_DIRECTION_RX;
+-		ctx.queue_size = adapter->rx_ring_size;
+ 		for (i = 0; i < ring->ring_size; i++)
+ 			ring->empty_rx_reqs[i] = i;
+ 	}
++	ctx.queue_size = ring->ring_size;
+ 	ctx.qid = ena_qid;
+ 	ctx.msix_vector = -1; /* interrupts not used */
+ 	ctx.numa_node = ring->numa_socket_id;
+-- 
+2.20.1
+

--- a/userspace/dpdk/18.08/0026-net-ena-limit-refill-threshold-by-fixed-value.patch
+++ b/userspace/dpdk/18.08/0026-net-ena-limit-refill-threshold-by-fixed-value.patch
@@ -1,0 +1,118 @@
+From 88eeb3df7726bcfffed693ac8593d588d3639723 Mon Sep 17 00:00:00 2001
+From: Michal Krawczyk <mk@semihalf.com>
+Date: Wed, 8 Apr 2020 10:29:16 +0200
+Subject: [PATCH 26/27] net/ena: limit refill threshold by fixed value
+
+[ upstream commit 7755060798de9c0146df8809926030ed47fc9086 ]
+
+Divider used for both Tx and Rx cleanup/refill threshold can cause too
+big delay in case of the really big rings - for example if the 8k Rx
+ring will be used, the refill won't trigger unless 1024 threshold will
+be reached. It will also cause driver to try to allocate that much
+descriptors.
+
+Limiting it by fixed value - 256 in that case, would limit maximum
+time spent in repopulate function.
+
+Change-Id: Ia8659e6ddf179ff612a780adc6fe55d13eeac6e9
+Signed-off-by: Michal Krawczyk <mk@semihalf.com>
+Reviewed-by: Igor Chauskin <igorch@amazon.com>
+Reviewed-by: Guy Tzalik <gtzalik@amazon.com>
+---
+ drivers/net/ena/ena_ethdev.c | 26 ++++++++++++++------------
+ drivers/net/ena/ena_ethdev.h | 10 ++++++++++
+ 2 files changed, 24 insertions(+), 12 deletions(-)
+
+diff --git a/drivers/net/ena/ena_ethdev.c b/drivers/net/ena/ena_ethdev.c
+index 640e3dae28..31a768eceb 100644
+--- a/drivers/net/ena/ena_ethdev.c
++++ b/drivers/net/ena/ena_ethdev.c
+@@ -61,14 +61,6 @@
+ /*reverse version of ENA_IO_RXQ_IDX*/
+ #define ENA_IO_RXQ_IDX_REV(q)	((q - 1) / 2)
+ 
+-/* While processing submitted and completed descriptors (rx and tx path
+- * respectively) in a loop it is desired to:
+- *  - perform batch submissions while populating sumbissmion queue
+- *  - avoid blocking transmission of other packets during cleanup phase
+- * Hence the utilization ratio of 1/8 of a queue size.
+- */
+-#define ENA_RING_DESCS_RATIO(ring_size)	(ring_size / 8)
+-
+ #define __MERGE_64B_H_L(h, l) (((uint64_t)h << 32) | l)
+ #define TEST_BIT(val, bit_shift) (val & (1UL << bit_shift))
+ 
+@@ -1821,6 +1813,8 @@ static uint16_t eth_ena_recv_pkts(void *rx_queue, struct rte_mbuf **rx_pkts,
+ 	struct ena_ring *rx_ring = (struct ena_ring *)(rx_queue);
+ 	unsigned int ring_size = rx_ring->ring_size;
+ 	unsigned int ring_mask = ring_size - 1;
++	unsigned int free_queue_entries;
++	unsigned int refill_threshold;
+ 	uint16_t next_to_clean = rx_ring->next_to_clean;
+ 	uint16_t desc_in_use = 0;
+ 	uint16_t req_id;
+@@ -1917,11 +1911,15 @@ static uint16_t eth_ena_recv_pkts(void *rx_queue, struct rte_mbuf **rx_pkts,
+ 
+ 	rx_ring->next_to_clean = next_to_clean;
+ 
+-	desc_in_use = desc_in_use - completed + 1;
++	free_queue_entries = ena_com_sq_empty_space(rx_ring->ena_com_io_sq);
++	refill_threshold =
++		RTE_MIN(ring_size / ENA_REFILL_THRESH_DIVIDER,
++		(unsigned int)ENA_REFILL_THRESH_PACKET);
++
+ 	/* Burst refill to save doorbells, memory barriers, const interval */
+-	if (ring_size - desc_in_use > ENA_RING_DESCS_RATIO(ring_size)) {
++	if (free_queue_entries > refill_threshold) {
+ 		ena_com_update_dev_comp_head(rx_ring->ena_com_io_cq);
+-		ena_populate_rx_queue(rx_ring, ring_size - desc_in_use);
++		ena_populate_rx_queue(rx_ring, free_queue_entries);
+ 	}
+ 
+ 	return recv_idx;
+@@ -2046,6 +2044,7 @@ static uint16_t eth_ena_xmit_pkts(void *tx_queue, struct rte_mbuf **tx_pkts,
+ 	struct rte_mbuf *mbuf;
+ 	unsigned int ring_size = tx_ring->ring_size;
+ 	unsigned int ring_mask = ring_size - 1;
++	unsigned int cleanup_budget;
+ 	struct ena_com_tx_ctx ena_tx_ctx;
+ 	struct ena_tx_buffer *tx_info;
+ 	struct ena_com_buf *ebuf;
+@@ -2160,9 +2159,12 @@ static uint16_t eth_ena_xmit_pkts(void *tx_queue, struct rte_mbuf **tx_pkts,
+ 		/* Put back descriptor to the ring for reuse */
+ 		tx_ring->empty_tx_reqs[next_to_clean & ring_mask] = req_id;
+ 		next_to_clean++;
++		cleanup_budget =
++			RTE_MIN(ring_size / ENA_REFILL_THRESH_DIVIDER,
++			(unsigned int)ENA_REFILL_THRESH_PACKET);
+ 
+ 		/* If too many descs to clean, leave it for another run */
+-		if (unlikely(total_tx_descs > ENA_RING_DESCS_RATIO(ring_size)))
++		if (unlikely(total_tx_descs > cleanup_budget))
+ 			break;
+ 	}
+ 
+diff --git a/drivers/net/ena/ena_ethdev.h b/drivers/net/ena/ena_ethdev.h
+index 9d887d4b5b..b11a9cb122 100644
+--- a/drivers/net/ena/ena_ethdev.h
++++ b/drivers/net/ena/ena_ethdev.h
+@@ -58,6 +58,16 @@
+ #define ENA_WD_TIMEOUT_SEC	3
+ #define ENA_DEVICE_KALIVE_TIMEOUT (ENA_WD_TIMEOUT_SEC * rte_get_timer_hz())
+ 
++/* While processing submitted and completed descriptors (rx and tx path
++ * respectively) in a loop it is desired to:
++ *  - perform batch submissions while populating sumbissmion queue
++ *  - avoid blocking transmission of other packets during cleanup phase
++ * Hence the utilization ratio of 1/8 of a queue size or max value if the size
++ * of the ring is very big - like 8k Rx rings.
++ */
++#define ENA_REFILL_THRESH_DIVIDER      8
++#define ENA_REFILL_THRESH_PACKET       256
++
+ struct ena_adapter;
+ 
+ enum ena_ring_type {
+-- 
+2.20.1
+

--- a/userspace/dpdk/18.08/0027-net-ena-fix-build-for-O1-optimization.patch
+++ b/userspace/dpdk/18.08/0027-net-ena-fix-build-for-O1-optimization.patch
@@ -1,0 +1,47 @@
+From 198c105b25519ca4eb65b8c6c0c54cdb8e4c238a Mon Sep 17 00:00:00 2001
+From: Ferruh Yigit <ferruh.yigit@intel.com>
+Date: Mon, 11 May 2020 17:07:24 +0100
+Subject: [PATCH 27/27] net/ena: fix build for O1 optimization
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+[ upstream commit 5f267cb01b41def2af37b8fa56828e75ae91add0 ]
+
+Can be reproduced with "make EXTRA_CFLAGS='-O1'" command using
+gcc (GCC) 9.3.1 20200408 (Red Hat 9.3.1-2)
+
+Build error:
+.../drivers/net/ena/ena_ethdev.c: In function ‘eth_ena_dev_init’:
+.../drivers/net/ena/ena_ethdev.c:1815:20:
+    error: ‘wd_state’ may be used uninitialized in this function
+           [-Werror=maybe-uninitialized]
+ 1815 |  adapter->wd_state = wd_state;
+      |  ~~~~~~~~~~~~~~~~~~^~~~~~~~~~
+
+This looks like false positive, fixing by assigning initial value to
+'wd_state' variable.
+
+Change-Id: I68bd21d4e2a4b41466e670e282856d4f072dadc0
+Signed-off-by: Ferruh Yigit <ferruh.yigit@intel.com>
+Acked-by: Michal Krawczyk <mk@semihalf.com>
+---
+ drivers/net/ena/ena_ethdev.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/drivers/net/ena/ena_ethdev.c b/drivers/net/ena/ena_ethdev.c
+index 31a768eceb..aa20c7f8c1 100644
+--- a/drivers/net/ena/ena_ethdev.c
++++ b/drivers/net/ena/ena_ethdev.c
+@@ -1519,7 +1519,7 @@ static int eth_ena_dev_init(struct rte_eth_dev *eth_dev)
+ 	u16 tx_sgl_size = 0;
+ 
+ 	static int adapters_found;
+-	bool wd_state;
++	bool wd_state = false;
+ 
+ 	eth_dev->dev_ops = &ena_dev_ops;
+ 	eth_dev->rx_pkt_burst = &eth_ena_recv_pkts;
+-- 
+2.20.1
+

--- a/userspace/dpdk/18.11/0001-net-ena-add-reset-reason-in-Rx-error.patch
+++ b/userspace/dpdk/18.11/0001-net-ena-add-reset-reason-in-Rx-error.patch
@@ -1,7 +1,7 @@
 From 067b480529882526471322001562002b8f23a1d7 Mon Sep 17 00:00:00 2001
 From: Rafal Kozik <rk@semihalf.com>
 Date: Fri, 14 Dec 2018 14:18:29 +0100
-Subject: [PATCH 01/16] net/ena: add reset reason in Rx error
+Subject: [PATCH 01/24] net/ena: add reset reason in Rx error
 
 [ upstream commit 9b260dbf7412819f9a5fc544872b1447d6938afe ]
 
@@ -20,7 +20,7 @@ Acked-by: Michal Krawczyk <mk@semihalf.com>
  1 file changed, 2 insertions(+)
 
 diff --git a/drivers/net/ena/ena_ethdev.c b/drivers/net/ena/ena_ethdev.c
-index a07bd2b49..7a84783b6 100644
+index a07bd2b493..7a84783b62 100644
 --- a/drivers/net/ena/ena_ethdev.c
 +++ b/drivers/net/ena/ena_ethdev.c
 @@ -1907,6 +1907,8 @@ static uint16_t eth_ena_recv_pkts(void *rx_queue, struct rte_mbuf **rx_pkts,

--- a/userspace/dpdk/18.11/0002-net-ena-skip-packet-with-wrong-request-id.patch
+++ b/userspace/dpdk/18.11/0002-net-ena-skip-packet-with-wrong-request-id.patch
@@ -1,7 +1,7 @@
 From aa598c8325215876567bb3c785090c56c7fb618c Mon Sep 17 00:00:00 2001
 From: Rafal Kozik <rk@semihalf.com>
 Date: Fri, 14 Dec 2018 14:18:31 +0100
-Subject: [PATCH 02/16] net/ena: skip packet with wrong request id
+Subject: [PATCH 02/24] net/ena: skip packet with wrong request id
 
 [ upstream commit f00930d929151fc09914e6d61b827f9f81645324 ]
 
@@ -20,7 +20,7 @@ Acked-by: Michal Krawczyk <mk@semihalf.com>
  1 file changed, 2 insertions(+)
 
 diff --git a/drivers/net/ena/ena_ethdev.c b/drivers/net/ena/ena_ethdev.c
-index 7a84783b6..6d3a60c7a 100644
+index 7a84783b62..6d3a60c7a4 100644
 --- a/drivers/net/ena/ena_ethdev.c
 +++ b/drivers/net/ena/ena_ethdev.c
 @@ -1944,6 +1944,8 @@ static uint16_t eth_ena_recv_pkts(void *rx_queue, struct rte_mbuf **rx_pkts,

--- a/userspace/dpdk/18.11/0003-net-ena-destroy-queues-if-start-failed.patch
+++ b/userspace/dpdk/18.11/0003-net-ena-destroy-queues-if-start-failed.patch
@@ -1,7 +1,7 @@
 From b497931c27c5641df96f82dc844e0322ef14bd65 Mon Sep 17 00:00:00 2001
 From: Rafal Kozik <rk@semihalf.com>
 Date: Fri, 14 Dec 2018 14:18:35 +0100
-Subject: [PATCH 03/16] net/ena: destroy queues if start failed
+Subject: [PATCH 03/24] net/ena: destroy queues if start failed
 
 [ upstream commit 26e5543dc85b3be23879ba90ddb00e3456179805 ]
 
@@ -23,7 +23,7 @@ Acked-by: Michal Krawczyk <mk@semihalf.com>
  1 file changed, 60 insertions(+), 35 deletions(-)
 
 diff --git a/drivers/net/ena/ena_ethdev.c b/drivers/net/ena/ena_ethdev.c
-index 6d3a60c7a..f41c8b8e8 100644
+index 6d3a60c7a4..f41c8b8e85 100644
 --- a/drivers/net/ena/ena_ethdev.c
 +++ b/drivers/net/ena/ena_ethdev.c
 @@ -240,10 +240,12 @@ static void ena_tx_queue_release_bufs(struct ena_ring *ring);

--- a/userspace/dpdk/18.11/0004-net-ena-do-not-reconfigure-queues-on-reset.patch
+++ b/userspace/dpdk/18.11/0004-net-ena-do-not-reconfigure-queues-on-reset.patch
@@ -1,7 +1,7 @@
 From bc12ed25639cc0bdda4fd294137e97e56f666af1 Mon Sep 17 00:00:00 2001
 From: Rafal Kozik <rk@semihalf.com>
 Date: Fri, 14 Dec 2018 14:18:36 +0100
-Subject: [PATCH 04/16] net/ena: do not reconfigure queues on reset
+Subject: [PATCH 04/24] net/ena: do not reconfigure queues on reset
 
 [ upstream commit e457bc70e5d6d589b1c3e1e93979aa42a64fbc06 ]
 
@@ -26,7 +26,7 @@ Acked-by: Michal Krawczyk <mk@semihalf.com>
  1 file changed, 38 insertions(+), 69 deletions(-)
 
 diff --git a/drivers/net/ena/ena_ethdev.c b/drivers/net/ena/ena_ethdev.c
-index f41c8b8e8..6bfda3516 100644
+index f41c8b8e85..6bfda35168 100644
 --- a/drivers/net/ena/ena_ethdev.c
 +++ b/drivers/net/ena/ena_ethdev.c
 @@ -258,6 +258,8 @@ static int ena_rss_reta_query(struct rte_eth_dev *dev,

--- a/userspace/dpdk/18.11/0005-net-ena-add-supported-RSS-offloads-types.patch
+++ b/userspace/dpdk/18.11/0005-net-ena-add-supported-RSS-offloads-types.patch
@@ -1,7 +1,7 @@
 From 6b822a13ac30962df62aa1ab537d7795ef1ec154 Mon Sep 17 00:00:00 2001
 From: Rafal Kozik <rk@semihalf.com>
 Date: Fri, 14 Dec 2018 14:18:38 +0100
-Subject: [PATCH 05/16] net/ena: add supported RSS offloads types
+Subject: [PATCH 05/24] net/ena: add supported RSS offloads types
 
 [ upstream commit b01ead202beb45346d7daeb2f2b1a608006af644 ]
 
@@ -20,7 +20,7 @@ Acked-by: Michal Krawczyk <mk@semihalf.com>
  1 file changed, 3 insertions(+)
 
 diff --git a/drivers/net/ena/ena_ethdev.c b/drivers/net/ena/ena_ethdev.c
-index 6bfda3516..73cebe843 100644
+index 6bfda35168..73cebe8434 100644
 --- a/drivers/net/ena/ena_ethdev.c
 +++ b/drivers/net/ena/ena_ethdev.c
 @@ -1837,6 +1837,9 @@ static void ena_infos_get(struct rte_eth_dev *dev,

--- a/userspace/dpdk/18.11/0006-net-ena-fix-invalid-reference-to-variable-in-union.patch
+++ b/userspace/dpdk/18.11/0006-net-ena-fix-invalid-reference-to-variable-in-union.patch
@@ -1,7 +1,7 @@
 From 143b491d07c872ad1b0517013efe42ea399610c7 Mon Sep 17 00:00:00 2001
 From: Rafal Kozik <rk@semihalf.com>
 Date: Fri, 14 Dec 2018 14:18:39 +0100
-Subject: [PATCH 06/16] net/ena: fix invalid reference to variable in union
+Subject: [PATCH 06/24] net/ena: fix invalid reference to variable in union
 
 [ upstream commit eccbe2ffdc755a9e759c6ba480f6c15ccb1163c7 ]
 
@@ -20,7 +20,7 @@ Acked-by: Michal Krawczyk <mk@semihalf.com>
  1 file changed, 1 insertion(+), 1 deletion(-)
 
 diff --git a/drivers/net/ena/ena_ethdev.c b/drivers/net/ena/ena_ethdev.c
-index 73cebe843..bd3d256da 100644
+index 73cebe8434..bd3d256daf 100644
 --- a/drivers/net/ena/ena_ethdev.c
 +++ b/drivers/net/ena/ena_ethdev.c
 @@ -1321,7 +1321,7 @@ static int ena_rx_queue_setup(struct rte_eth_dev *dev,

--- a/userspace/dpdk/18.11/0007-net-ena-fix-cleanup-for-out-of-order-packets.patch
+++ b/userspace/dpdk/18.11/0007-net-ena-fix-cleanup-for-out-of-order-packets.patch
@@ -1,7 +1,7 @@
 From ee05f98f3ad55e4509922c707220c1d47027ca35 Mon Sep 17 00:00:00 2001
 From: Rafal Kozik <rk@semihalf.com>
 Date: Mon, 17 Dec 2018 12:06:18 +0100
-Subject: [PATCH 07/16] net/ena: fix cleanup for out of order packets
+Subject: [PATCH 07/24] net/ena: fix cleanup for out of order packets
 
 [ upstream commit 709b1dcb73adebb3fc1a838b57d72028feb97e47 ]
 
@@ -27,7 +27,7 @@ Acked-by: Michal Krawczyk <mk@semihalf.com>
  1 file changed, 11 insertions(+), 13 deletions(-)
 
 diff --git a/drivers/net/ena/ena_ethdev.c b/drivers/net/ena/ena_ethdev.c
-index bd3d256da..79266d17e 100644
+index bd3d256daf..79266d17e9 100644
 --- a/drivers/net/ena/ena_ethdev.c
 +++ b/drivers/net/ena/ena_ethdev.c
 @@ -761,17 +761,13 @@ static void ena_tx_queue_release(void *queue)

--- a/userspace/dpdk/18.11/0008-net-ena-add-new-way-of-getting-Rx-drops.patch
+++ b/userspace/dpdk/18.11/0008-net-ena-add-new-way-of-getting-Rx-drops.patch
@@ -1,7 +1,7 @@
 From 8927533a74100b6620a2c2bd264a1cff7afe4170 Mon Sep 17 00:00:00 2001
 From: Rafal Kozik <rk@semihalf.com>
 Date: Fri, 14 Dec 2018 14:18:43 +0100
-Subject: [PATCH 08/16] net/ena: add new way of getting Rx drops
+Subject: [PATCH 08/24] net/ena: add new way of getting Rx drops
 
 [ upstream commit 94c3e3765d9e0366acf145668d32d5eee3200c2b ]
 
@@ -17,7 +17,7 @@ Acked-by: Michal Krawczyk <mk@semihalf.com>
  2 files changed, 9 insertions(+), 2 deletions(-)
 
 diff --git a/drivers/net/ena/ena_ethdev.c b/drivers/net/ena/ena_ethdev.c
-index 79266d17e..ee35c9793 100644
+index 79266d17e9..ee35c97930 100644
 --- a/drivers/net/ena/ena_ethdev.c
 +++ b/drivers/net/ena/ena_ethdev.c
 @@ -912,6 +912,7 @@ static void ena_stats_restart(struct rte_eth_dev *dev)
@@ -56,7 +56,7 @@ index 79266d17e..ee35c9793 100644
  
  /**
 diff --git a/drivers/net/ena/ena_ethdev.h b/drivers/net/ena/ena_ethdev.h
-index 322e90ace..8eb8543c2 100644
+index 322e90ace8..8eb8543c21 100644
 --- a/drivers/net/ena/ena_ethdev.h
 +++ b/drivers/net/ena/ena_ethdev.h
 @@ -120,6 +120,7 @@ struct ena_driver_stats {

--- a/userspace/dpdk/18.11/0009-net-ena-update-completion-queue-after-cleanup.patch
+++ b/userspace/dpdk/18.11/0009-net-ena-update-completion-queue-after-cleanup.patch
@@ -1,7 +1,7 @@
 From 24bc59ab5b1cf17255cb36287bb2601741164736 Mon Sep 17 00:00:00 2001
 From: Rafal Kozik <rk@semihalf.com>
 Date: Fri, 14 Dec 2018 14:18:44 +0100
-Subject: [PATCH 09/16] net/ena: update completion queue after cleanup
+Subject: [PATCH 09/24] net/ena: update completion queue after cleanup
 
 [ upstream commit a45462c507e98b49cb5c2302e0be3c72d2e20a1a ]
 
@@ -19,7 +19,7 @@ Acked-by: Michal Krawczyk <mk@semihalf.com>
  1 file changed, 5 insertions(+), 2 deletions(-)
 
 diff --git a/drivers/net/ena/ena_ethdev.c b/drivers/net/ena/ena_ethdev.c
-index ee35c9793..309e358ad 100644
+index ee35c97930..309e358ada 100644
 --- a/drivers/net/ena/ena_ethdev.c
 +++ b/drivers/net/ena/ena_ethdev.c
 @@ -1955,8 +1955,10 @@ static uint16_t eth_ena_recv_pkts(void *rx_queue, struct rte_mbuf **rx_pkts,

--- a/userspace/dpdk/18.11/0010-net-ena-fix-dev-init-with-multi-process.patch
+++ b/userspace/dpdk/18.11/0010-net-ena-fix-dev-init-with-multi-process.patch
@@ -1,7 +1,7 @@
 From 6d3a043c4139b84a1aa2df8a7b7f4a576c44770d Mon Sep 17 00:00:00 2001
 From: Michal Krawczyk <mk@semihalf.com>
 Date: Fri, 25 Jan 2019 09:10:25 +0100
-Subject: [PATCH 10/16] net/ena: fix dev init with multi-process
+Subject: [PATCH 10/24] net/ena: fix dev init with multi-process
 
 [ upstream commit fd9768905870856a2340266d25f8c0100dfccfff ]
 
@@ -22,7 +22,7 @@ Signed-off-by: Michal Krawczyk <mk@semihalf.com>
  1 file changed, 6 insertions(+), 5 deletions(-)
 
 diff --git a/drivers/net/ena/ena_ethdev.c b/drivers/net/ena/ena_ethdev.c
-index 309e358ad..3507e69ab 100644
+index 309e358ada..3507e69ab1 100644
 --- a/drivers/net/ena/ena_ethdev.c
 +++ b/drivers/net/ena/ena_ethdev.c
 @@ -1572,19 +1572,20 @@ static int eth_ena_dev_init(struct rte_eth_dev *eth_dev)

--- a/userspace/dpdk/18.11/0011-net-ena-fix-errno-to-positive-value.patch
+++ b/userspace/dpdk/18.11/0011-net-ena-fix-errno-to-positive-value.patch
@@ -1,7 +1,7 @@
 From 80cb46cd599694535d26a5c6d77fb4e06de3a2cc Mon Sep 17 00:00:00 2001
 From: Michal Krawczyk <mk@semihalf.com>
 Date: Fri, 25 Jan 2019 09:10:26 +0100
-Subject: [PATCH 11/16] net/ena: fix errno to positive value
+Subject: [PATCH 11/24] net/ena: fix errno to positive value
 
 [ upstream commit baeed5f404dd1b049118cfec26a2fd3203671572 ]
 
@@ -18,7 +18,7 @@ Signed-off-by: Michal Krawczyk <mk@semihalf.com>
  1 file changed, 3 insertions(+), 3 deletions(-)
 
 diff --git a/drivers/net/ena/ena_ethdev.c b/drivers/net/ena/ena_ethdev.c
-index 3507e69ab..04b989347 100644
+index 3507e69ab1..04b989347d 100644
 --- a/drivers/net/ena/ena_ethdev.c
 +++ b/drivers/net/ena/ena_ethdev.c
 @@ -2006,14 +2006,14 @@ eth_ena_prep_pkts(void *tx_queue, struct rte_mbuf **tx_pkts,

--- a/userspace/dpdk/18.11/0012-net-ena-get-device-info-statically.patch
+++ b/userspace/dpdk/18.11/0012-net-ena-get-device-info-statically.patch
@@ -1,7 +1,7 @@
 From efb706142341fd3d3b6bc4c5a83d958a1e031d2d Mon Sep 17 00:00:00 2001
 From: Michal Krawczyk <mk@semihalf.com>
 Date: Fri, 15 Feb 2019 09:36:39 +0100
-Subject: [PATCH 12/16] net/ena: get device info statically
+Subject: [PATCH 12/24] net/ena: get device info statically
 
 [ upstream commit 117ba4a60488a0f96a5737f38ddba6d0f9a728b6 ]
 
@@ -22,7 +22,7 @@ Signed-off-by: Michal Krawczyk <mk@semihalf.com>
  2 files changed, 21 insertions(+), 22 deletions(-)
 
 diff --git a/drivers/net/ena/ena_ethdev.c b/drivers/net/ena/ena_ethdev.c
-index 04b989347..4a816e259 100644
+index 04b989347d..4a816e259f 100644
 --- a/drivers/net/ena/ena_ethdev.c
 +++ b/drivers/net/ena/ena_ethdev.c
 @@ -1645,9 +1645,14 @@ static int eth_ena_dev_init(struct rte_eth_dev *eth_dev)
@@ -105,7 +105,7 @@ index 04b989347..4a816e259 100644
  		}
  
 diff --git a/drivers/net/ena/ena_ethdev.h b/drivers/net/ena/ena_ethdev.h
-index 8eb8543c2..982ad7854 100644
+index 8eb8543c21..982ad7854e 100644
 --- a/drivers/net/ena/ena_ethdev.h
 +++ b/drivers/net/ena/ena_ethdev.h
 @@ -160,6 +160,12 @@ struct ena_stats_rx {

--- a/userspace/dpdk/18.11/0013-net-ena-fix-checksum-feature-flag.patch
+++ b/userspace/dpdk/18.11/0013-net-ena-fix-checksum-feature-flag.patch
@@ -1,7 +1,7 @@
 From 199fd19db0850be70555e7a591584e41856be865 Mon Sep 17 00:00:00 2001
 From: Michal Krawczyk <mk@semihalf.com>
 Date: Mon, 8 Apr 2019 12:27:44 +0200
-Subject: [PATCH 13/16] net/ena: fix checksum feature flag
+Subject: [PATCH 13/24] net/ena: fix checksum feature flag
 
 [ upstream commit ef538c1a7f565c9b58518375a500aa864445fd11 ]
 
@@ -18,7 +18,7 @@ Signed-off-by: Michal Krawczyk <mk@semihalf.com>
  1 file changed, 1 insertion(+), 1 deletion(-)
 
 diff --git a/drivers/net/ena/ena_ethdev.c b/drivers/net/ena/ena_ethdev.c
-index 4a816e259..e04441d26 100644
+index 4a816e259f..e04441d267 100644
 --- a/drivers/net/ena/ena_ethdev.c
 +++ b/drivers/net/ena/ena_ethdev.c
 @@ -1650,7 +1650,7 @@ static int eth_ena_dev_init(struct rte_eth_dev *eth_dev)

--- a/userspace/dpdk/18.11/0014-net-ena-fix-Rx-checksum-errors-statistics.patch
+++ b/userspace/dpdk/18.11/0014-net-ena-fix-Rx-checksum-errors-statistics.patch
@@ -1,7 +1,7 @@
 From 1526143b9b0184510c5c9b19e81f3dd8319cc3ac Mon Sep 17 00:00:00 2001
 From: Michal Krawczyk <mk@semihalf.com>
 Date: Tue, 28 May 2019 10:28:34 +0200
-Subject: [PATCH 14/16] net/ena: fix Rx checksum errors statistics
+Subject: [PATCH 14/24] net/ena: fix Rx checksum errors statistics
 
 [ upstream commit ef74b5f7b69b9502ddab81121611243efcfe1dde ]
 
@@ -21,7 +21,7 @@ Signed-off-by: Michal Krawczyk <mk@semihalf.com>
  1 file changed, 5 insertions(+), 4 deletions(-)
 
 diff --git a/drivers/net/ena/ena_ethdev.c b/drivers/net/ena/ena_ethdev.c
-index e04441d26..4e3f6d611 100644
+index e04441d267..4e3f6d6115 100644
 --- a/drivers/net/ena/ena_ethdev.c
 +++ b/drivers/net/ena/ena_ethdev.c
 @@ -1938,6 +1938,11 @@ static uint16_t eth_ena_recv_pkts(void *rx_queue, struct rte_mbuf **rx_pkts,

--- a/userspace/dpdk/18.11/0015-net-ena-fix-assigning-NUMA-node-to-IO-queue.patch
+++ b/userspace/dpdk/18.11/0015-net-ena-fix-assigning-NUMA-node-to-IO-queue.patch
@@ -1,7 +1,7 @@
 From 8532d00113a8b61eca1ef2dd3f1cf3cd5dfe6dd8 Mon Sep 17 00:00:00 2001
 From: Michal Krawczyk <mk@semihalf.com>
 Date: Tue, 4 Jun 2019 12:59:36 +0200
-Subject: [PATCH 15/16] net/ena: fix assigning NUMA node to IO queue
+Subject: [PATCH 15/24] net/ena: fix assigning NUMA node to IO queue
 
 [ upstream commit 4217cb0b7d2c5385f06f531af7f14b860927aba7 ]
 
@@ -23,7 +23,7 @@ Reviewed-by: David Marchand <david.marchand@redhat.com>
  2 files changed, 7 insertions(+), 20 deletions(-)
 
 diff --git a/drivers/net/ena/ena_ethdev.c b/drivers/net/ena/ena_ethdev.c
-index 4e3f6d611..0cb183ea0 100644
+index 4e3f6d6115..0cb183ea0b 100644
 --- a/drivers/net/ena/ena_ethdev.c
 +++ b/drivers/net/ena/ena_ethdev.c
 @@ -39,7 +39,6 @@
@@ -101,7 +101,7 @@ index 4e3f6d611..0cb183ea0 100644
  
  	rxq->rx_buffer_info = rte_zmalloc("rxq->buffer_info",
 diff --git a/drivers/net/ena/ena_ethdev.h b/drivers/net/ena/ena_ethdev.h
-index 982ad7854..2ce0eb79e 100644
+index 982ad7854e..2ce0eb79ec 100644
 --- a/drivers/net/ena/ena_ethdev.h
 +++ b/drivers/net/ena/ena_ethdev.h
 @@ -105,6 +105,8 @@ struct ena_ring {

--- a/userspace/dpdk/18.11/0016-net-ena-fix-admin-CQ-polling-for-32-bit.patch
+++ b/userspace/dpdk/18.11/0016-net-ena-fix-admin-CQ-polling-for-32-bit.patch
@@ -1,0 +1,37 @@
+From 7793cff600b344de680bc4200f4d3e9bf4277801 Mon Sep 17 00:00:00 2001
+From: David Harton <dharton@cisco.com>
+Date: Fri, 12 Jul 2019 13:35:43 -0400
+Subject: [PATCH 16/24] net/ena: fix admin CQ polling for 32-bit
+
+[ upstream commit 8190a843ef9bce3696b74ad2b057b5d86cc7b0df ]
+
+Recent modifications to admin command queue polling logic
+did not support 32-bit applications.  Updated the driver to
+work for 32 or 64 bit applications
+
+Fixes: 3adcba9a8987 ("net/ena: update HAL to the newer version")
+Cc: stable@dpdk.org
+
+Change-Id: I254d8d36af4208c713fbffcfbd0d241a88a972ce
+Signed-off-by: David Harton <dharton@cisco.com>
+Acked-by: Michal Krawczyk <mk@semihalf.com>
+---
+ drivers/net/ena/base/ena_com.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/drivers/net/ena/base/ena_com.c b/drivers/net/ena/base/ena_com.c
+index 4abf1a28a1..f22d67cd4d 100644
+--- a/drivers/net/ena/base/ena_com.c
++++ b/drivers/net/ena/base/ena_com.c
+@@ -526,7 +526,7 @@ static int ena_com_wait_and_process_admin_cq_polling(struct ena_comp_ctx *comp_c
+ 						     struct ena_com_admin_queue *admin_queue)
+ {
+ 	unsigned long flags = 0;
+-	unsigned long timeout;
++	uint64_t timeout;
+ 	int ret;
+ 
+ 	timeout = ENA_GET_SYSTEM_TIMEOUT(admin_queue->completion_timeout);
+-- 
+2.20.1
+

--- a/userspace/dpdk/18.11/0017-net-ena-fix-L4-checksum-Tx-offload.patch
+++ b/userspace/dpdk/18.11/0017-net-ena-fix-L4-checksum-Tx-offload.patch
@@ -1,0 +1,52 @@
+From 9aeb5d5e961085dbb29609a2526be61b102be3ae Mon Sep 17 00:00:00 2001
+From: Maciej Bielski <mba@semihalf.com>
+Date: Thu, 1 Aug 2019 13:45:36 +0200
+Subject: [PATCH 17/24] net/ena: fix L4 checksum Tx offload
+
+[ upstream commit 40e7c02155625f18a87faf5e6a8cec2e986146e8 ]
+
+During an if-condition evaluation, a 2-bit flag evaluates to 'true' for
+'0x1', '0x2' and '0x3'. Thus, from this perspective these flags are
+indistinguishable. To make them distinct, respective bits must be
+extracted with a mask and then checked for strict equality.
+
+Specifically here, even if `PKT_TX_UDP_CKSUM` (value '0x3') was set, the
+expression `mbuf->ol_flags & PKT_TX_TCP` (the second flag of value
+'0x1') is evaluated first and the result is 'true'. In consequence, for
+UDP packets the execution flow enters an incorrect branch.
+
+Fixes: 56b8b9b7e5d2 ("net/ena: convert to new Tx offloads API")
+Cc: stable@dpdk.org
+
+Change-Id: I7917b209856f24e5d0b6481a94b322d09266bc5b
+Reported-by: Eduard Serra <eserra@vmware.com>
+Signed-off-by: Maciej Bielski <mba@semihalf.com>
+Acked-by: Michal Krawczyk <mk@semihalf.com>
+---
+ drivers/net/ena/ena_ethdev.c | 7 ++++---
+ 1 file changed, 4 insertions(+), 3 deletions(-)
+
+diff --git a/drivers/net/ena/ena_ethdev.c b/drivers/net/ena/ena_ethdev.c
+index 0cb183ea0b..9137e3047b 100644
+--- a/drivers/net/ena/ena_ethdev.c
++++ b/drivers/net/ena/ena_ethdev.c
+@@ -337,12 +337,13 @@ static inline void ena_tx_mbuf_prepare(struct rte_mbuf *mbuf,
+ 		}
+ 
+ 		/* check if L4 checksum is needed */
+-		if ((mbuf->ol_flags & PKT_TX_TCP_CKSUM) &&
++		if (((mbuf->ol_flags & PKT_TX_L4_MASK) == PKT_TX_TCP_CKSUM) &&
+ 		    (queue_offloads & DEV_TX_OFFLOAD_TCP_CKSUM)) {
+ 			ena_tx_ctx->l4_proto = ENA_ETH_IO_L4_PROTO_TCP;
+ 			ena_tx_ctx->l4_csum_enable = true;
+-		} else if ((mbuf->ol_flags & PKT_TX_UDP_CKSUM) &&
+-			   (queue_offloads & DEV_TX_OFFLOAD_UDP_CKSUM)) {
++		} else if (((mbuf->ol_flags & PKT_TX_L4_MASK) ==
++				PKT_TX_UDP_CKSUM) &&
++				(queue_offloads & DEV_TX_OFFLOAD_UDP_CKSUM)) {
+ 			ena_tx_ctx->l4_proto = ENA_ETH_IO_L4_PROTO_UDP;
+ 			ena_tx_ctx->l4_csum_enable = true;
+ 		} else {
+-- 
+2.20.1
+

--- a/userspace/dpdk/18.11/0018-net-ena-fix-indication-of-bad-L4-Rx-checksums.patch
+++ b/userspace/dpdk/18.11/0018-net-ena-fix-indication-of-bad-L4-Rx-checksums.patch
@@ -1,0 +1,44 @@
+From 5585e59db1bf6187b2ede2a1e44a9d9a8f66d53e Mon Sep 17 00:00:00 2001
+From: Igor Chauskin <igorch@amazon.com>
+Date: Mon, 28 Oct 2019 11:23:33 +0100
+Subject: [PATCH 18/24] net/ena: fix indication of bad L4 Rx checksums
+
+[ upstream commit 05817057faba9356900ced61e24a22eef6bc4c87 ]
+
+Add checking of l4_csum_checked and frag flags before checking the
+l4_csum_error flag.
+
+In case of IP fragment/unchecked L4 csum - add PKT_RX_L4_CKSUM_UNKNOWN
+flag to the indicated mbuf.
+
+Fixes: 1173fca25af9 ("ena: add polling-mode driver")
+Cc: stable@dpdk.org
+
+Change-Id: I9f1414741eb44ca289a8bfd11d7e66110c95040e
+Signed-off-by: Igor Chauskin <igorch@amazon.com>
+Reviewed-by: Maciej Bielski <mba@semihalf.com>
+Reviewed-by: Michal Krawczyk <mk@semihalf.com>
+---
+ drivers/net/ena/ena_ethdev.c | 5 ++++-
+ 1 file changed, 4 insertions(+), 1 deletion(-)
+
+diff --git a/drivers/net/ena/ena_ethdev.c b/drivers/net/ena/ena_ethdev.c
+index 9137e3047b..bc9611be42 100644
+--- a/drivers/net/ena/ena_ethdev.c
++++ b/drivers/net/ena/ena_ethdev.c
+@@ -294,8 +294,11 @@ static inline void ena_rx_mbuf_prepare(struct rte_mbuf *mbuf,
+ 	else if (ena_rx_ctx->l3_proto == ENA_ETH_IO_L3_PROTO_IPV6)
+ 		packet_type |= RTE_PTYPE_L3_IPV6;
+ 
+-	if (unlikely(ena_rx_ctx->l4_csum_err))
++	if (unlikely(ena_rx_ctx->l4_csum_err) && !ena_rx_ctx->frag)
+ 		ol_flags |= PKT_RX_L4_CKSUM_BAD;
++	else
++		ol_flags |= PKT_RX_L4_CKSUM_UNKNOWN;
++
+ 	if (unlikely(ena_rx_ctx->l3_csum_err))
+ 		ol_flags |= PKT_RX_IP_CKSUM_BAD;
+ 
+-- 
+2.20.1
+

--- a/userspace/dpdk/18.11/0019-net-ena-ensure-Rx-buffer-size-is-at-least-1400B.patch
+++ b/userspace/dpdk/18.11/0019-net-ena-ensure-Rx-buffer-size-is-at-least-1400B.patch
@@ -1,0 +1,84 @@
+From 545a0d7755b4c558c3156b5899a0bdd3a50bfe28 Mon Sep 17 00:00:00 2001
+From: Michal Krawczyk <mk@semihalf.com>
+Date: Wed, 8 Apr 2020 10:28:52 +0200
+Subject: [PATCH 19/24] net/ena: ensure Rx buffer size is at least 1400B
+
+[ upstream commit 38364c2687ead97b99402310087c27131a97748c ]
+
+Some of the ENA devices can't handle buffers which are smaller than a
+1400B. Because of this limitation, size of the buffer is being checked
+and limited during the Rx queue setup.
+
+If it's below the allowed value, PMD won't finish it's configuration
+successfully..
+
+Change-Id: Ib402d3bfad98a3fc4f91095d5c6f90c6069da021
+Signed-off-by: Michal Krawczyk <mk@semihalf.com>
+Reviewed-by: Igor Chauskin <igorch@amazon.com>
+Reviewed-by: Guy Tzalik <gtzalik@amazon.com>
+---
+ drivers/net/ena/ena_ethdev.c | 12 +++++++++++-
+ drivers/net/ena/ena_ethdev.h |  3 ++-
+ 2 files changed, 13 insertions(+), 2 deletions(-)
+
+diff --git a/drivers/net/ena/ena_ethdev.c b/drivers/net/ena/ena_ethdev.c
+index bc9611be42..9b62f6ab06 100644
+--- a/drivers/net/ena/ena_ethdev.c
++++ b/drivers/net/ena/ena_ethdev.c
+@@ -1,7 +1,7 @@
+ /*-
+ * BSD LICENSE
+ *
+-* Copyright (c) 2015-2016 Amazon.com, Inc. or its affiliates.
++* Copyright (c) 2015-2020 Amazon.com, Inc. or its affiliates.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+@@ -1241,6 +1241,7 @@ static int ena_rx_queue_setup(struct rte_eth_dev *dev,
+ 	struct ena_adapter *adapter =
+ 		(struct ena_adapter *)(dev->data->dev_private);
+ 	struct ena_ring *rxq = NULL;
++	size_t buffer_size;
+ 	int i;
+ 
+ 	rxq = &adapter->rx_ring[queue_idx];
+@@ -1265,6 +1266,15 @@ static int ena_rx_queue_setup(struct rte_eth_dev *dev,
+ 		return -EINVAL;
+ 	}
+ 
++	/* ENA isn't supporting buffers smaller than 1400 bytes */
++	buffer_size = rte_pktmbuf_data_room_size(mp) - RTE_PKTMBUF_HEADROOM;
++	if (buffer_size < ENA_RX_BUF_MIN_SIZE) {
++		PMD_DRV_LOG(ERR,
++			"Unsupported size of RX buffer: %zu (min size: %d)\n",
++			buffer_size, ENA_RX_BUF_MIN_SIZE);
++		return -EINVAL;
++	}
++
+ 	rxq->port_id = dev->data->port_id;
+ 	rxq->next_to_clean = 0;
+ 	rxq->next_to_use = 0;
+diff --git a/drivers/net/ena/ena_ethdev.h b/drivers/net/ena/ena_ethdev.h
+index 2ce0eb79ec..9d887d4b5b 100644
+--- a/drivers/net/ena/ena_ethdev.h
++++ b/drivers/net/ena/ena_ethdev.h
+@@ -1,7 +1,7 @@
+ /*-
+ * BSD LICENSE
+ *
+-* Copyright (c) 2015-2016 Amazon.com, Inc. or its affiliates.
++* Copyright (c) 2015-2020 Amazon.com, Inc. or its affiliates.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+@@ -49,6 +49,7 @@
+ #define ENA_MIN_FRAME_LEN	64
+ #define ENA_NAME_MAX_LEN	20
+ #define ENA_PKT_MAX_BUFS	17
++#define ENA_RX_BUF_MIN_SIZE	1400
+ 
+ #define ENA_MIN_MTU		128
+ 
+-- 
+2.20.1
+

--- a/userspace/dpdk/18.11/0020-net-ena-base-make-allocation-macros-thread-safe.patch
+++ b/userspace/dpdk/18.11/0020-net-ena-base-make-allocation-macros-thread-safe.patch
@@ -1,0 +1,80 @@
+From edcfaf885e2501e96b26ff9c27ae8ca6d79aec07 Mon Sep 17 00:00:00 2001
+From: Igor Chauskin <igorch@amazon.com>
+Date: Wed, 8 Apr 2020 10:28:53 +0200
+Subject: [PATCH 20/24] net/ena/base: make allocation macros thread-safe
+
+[ upstream commit b14fcac035fd8514851c9140a4e26d765b61c532 ]
+
+Memory allocation region id could possibly be non-unique
+due to non-atomic increment, causing allocation failure.
+
+Fixes: 9ba7981ec992 ("ena: add communication layer for DPDK")
+Cc: stable@dpdk.org
+
+Change-Id: Ib9207aaae4e5e7ecdf1a99a0f23a508a53af631d
+Signed-off-by: Igor Chauskin <igorch@amazon.com>
+Reviewed-by: Michal Krawczyk <mk@semihalf.com>
+Reviewed-by: Guy Tzalik <gtzalik@amazon.com>
+---
+ drivers/net/ena/base/ena_plat_dpdk.h | 10 ++++++----
+ drivers/net/ena/ena_ethdev.c         |  2 +-
+ 2 files changed, 7 insertions(+), 5 deletions(-)
+
+diff --git a/drivers/net/ena/base/ena_plat_dpdk.h b/drivers/net/ena/base/ena_plat_dpdk.h
+index 900ba1a6b0..ac2c281297 100644
+--- a/drivers/net/ena/base/ena_plat_dpdk.h
++++ b/drivers/net/ena/base/ena_plat_dpdk.h
+@@ -1,7 +1,7 @@
+ /*-
+ * BSD LICENSE
+ *
+-* Copyright (c) 2015-2016 Amazon.com, Inc. or its affiliates.
++* Copyright (c) 2015-2020 Amazon.com, Inc. or its affiliates.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+@@ -201,7 +201,7 @@ do {                                                                   \
+  * Each rte_memzone should have unique name.
+  * To satisfy it, count number of allocations and add it to name.
+  */
+-extern uint32_t ena_alloc_cnt;
++extern rte_atomic32_t ena_alloc_cnt;
+ 
+ #define ENA_MEM_ALLOC_COHERENT(dmadev, size, virt, phys, handle)	\
+ 	do {								\
+@@ -209,7 +209,8 @@ extern uint32_t ena_alloc_cnt;
+ 		char z_name[RTE_MEMZONE_NAMESIZE];			\
+ 		ENA_TOUCH(dmadev); ENA_TOUCH(handle);			\
+ 		snprintf(z_name, sizeof(z_name),			\
+-				"ena_alloc_%d", ena_alloc_cnt++);	\
++			 "ena_alloc_%d",				\
++			 rte_atomic32_add_return(&ena_alloc_cnt, 1));	\
+ 		mz = rte_memzone_reserve(z_name, size, SOCKET_ID_ANY,	\
+ 				RTE_MEMZONE_IOVA_CONTIG);		\
+ 		handle = mz;						\
+@@ -234,7 +235,8 @@ extern uint32_t ena_alloc_cnt;
+ 		char z_name[RTE_MEMZONE_NAMESIZE];			\
+ 		ENA_TOUCH(dmadev); ENA_TOUCH(dev_node);			\
+ 		snprintf(z_name, sizeof(z_name),			\
+-				"ena_alloc_%d", ena_alloc_cnt++);	\
++			 "ena_alloc_%d",				\
++			 rte_atomic32_add_return(&ena_alloc_cnt, 1));	\
+ 		mz = rte_memzone_reserve(z_name, size, node,		\
+ 				RTE_MEMZONE_IOVA_CONTIG);		\
+ 		mem_handle = mz;					\
+diff --git a/drivers/net/ena/ena_ethdev.c b/drivers/net/ena/ena_ethdev.c
+index 9b62f6ab06..a38f3a3ea2 100644
+--- a/drivers/net/ena/ena_ethdev.c
++++ b/drivers/net/ena/ena_ethdev.c
+@@ -120,7 +120,7 @@ struct ena_stats {
+  * Each rte_memzone should have unique name.
+  * To satisfy it, count number of allocation and add it to name.
+  */
+-uint32_t ena_alloc_cnt;
++rte_atomic32_t ena_alloc_cnt;
+ 
+ static const struct ena_stats ena_stats_global_strings[] = {
+ 	ENA_STAT_GLOBAL_ENTRY(tx_timeout),
+-- 
+2.20.1
+

--- a/userspace/dpdk/18.11/0021-net-ena-base-prevent-allocation-of-zero-sized-memory.patch
+++ b/userspace/dpdk/18.11/0021-net-ena-base-prevent-allocation-of-zero-sized-memory.patch
@@ -1,0 +1,77 @@
+From 8e6de69b04e2c28cfe2a03a9eaf5ae9b1be23e90 Mon Sep 17 00:00:00 2001
+From: Igor Chauskin <igorch@amazon.com>
+Date: Wed, 8 Apr 2020 10:28:54 +0200
+Subject: [PATCH 21/24] net/ena/base: prevent allocation of zero sized memory
+
+[ upstream commit 29dc10d9424ccf26a346387b0a707185e2432400 ]
+
+rte_memzone_reserve() will reserve the biggest contiguous memzone
+available if received 0 as size param.
+
+Fixes: 9ba7981ec992 ("ena: add communication layer for DPDK")
+Cc: stable@dpdk.org
+
+Change-Id: I2f71119e93c5e9addd8c538820093f030066d690
+Signed-off-by: Igor Chauskin <igorch@amazon.com>
+Reviewed-by: Michal Krawczyk <mk@semihalf.com>
+Reviewed-by: Guy Tzalik <gtzalik@amazon.com>
+---
+ drivers/net/ena/base/ena_plat_dpdk.h | 29 ++++++++++++++++------------
+ 1 file changed, 17 insertions(+), 12 deletions(-)
+
+diff --git a/drivers/net/ena/base/ena_plat_dpdk.h b/drivers/net/ena/base/ena_plat_dpdk.h
+index ac2c281297..57cf5078ea 100644
+--- a/drivers/net/ena/base/ena_plat_dpdk.h
++++ b/drivers/net/ena/base/ena_plat_dpdk.h
+@@ -205,15 +205,18 @@ extern rte_atomic32_t ena_alloc_cnt;
+ 
+ #define ENA_MEM_ALLOC_COHERENT(dmadev, size, virt, phys, handle)	\
+ 	do {								\
+-		const struct rte_memzone *mz;				\
+-		char z_name[RTE_MEMZONE_NAMESIZE];			\
++		const struct rte_memzone *mz = NULL;			\
+ 		ENA_TOUCH(dmadev); ENA_TOUCH(handle);			\
+-		snprintf(z_name, sizeof(z_name),			\
++		if (size > 0) {						\
++			char z_name[RTE_MEMZONE_NAMESIZE];		\
++			snprintf(z_name, sizeof(z_name),		\
+ 			 "ena_alloc_%d",				\
+ 			 rte_atomic32_add_return(&ena_alloc_cnt, 1));	\
+-		mz = rte_memzone_reserve(z_name, size, SOCKET_ID_ANY,	\
+-				RTE_MEMZONE_IOVA_CONTIG);		\
+-		handle = mz;						\
++			mz = rte_memzone_reserve(z_name, size,		\
++					SOCKET_ID_ANY,			\
++					RTE_MEMZONE_IOVA_CONTIG);	\
++			handle = mz;					\
++		}							\
+ 		if (mz == NULL) {					\
+ 			virt = NULL;					\
+ 			phys = 0;					\
+@@ -231,15 +234,17 @@ extern rte_atomic32_t ena_alloc_cnt;
+ #define ENA_MEM_ALLOC_COHERENT_NODE(					\
+ 	dmadev, size, virt, phys, mem_handle, node, dev_node)		\
+ 	do {								\
+-		const struct rte_memzone *mz;				\
+-		char z_name[RTE_MEMZONE_NAMESIZE];			\
++		const struct rte_memzone *mz = NULL;			\
+ 		ENA_TOUCH(dmadev); ENA_TOUCH(dev_node);			\
+-		snprintf(z_name, sizeof(z_name),			\
++		if (size > 0) {						\
++			char z_name[RTE_MEMZONE_NAMESIZE];		\
++			snprintf(z_name, sizeof(z_name),		\
+ 			 "ena_alloc_%d",				\
+-			 rte_atomic32_add_return(&ena_alloc_cnt, 1));	\
+-		mz = rte_memzone_reserve(z_name, size, node,		\
++			 rte_atomic32_add_return(&ena_alloc_cnt, 1));   \
++			mz = rte_memzone_reserve(z_name, size, node,	\
+ 				RTE_MEMZONE_IOVA_CONTIG);		\
+-		mem_handle = mz;					\
++			mem_handle = mz;				\
++		}							\
+ 		if (mz == NULL) {					\
+ 			virt = NULL;					\
+ 			phys = 0;					\
+-- 
+2.20.1
+

--- a/userspace/dpdk/18.11/0022-net-ena-set-IO-ring-size-to-valid-value.patch
+++ b/userspace/dpdk/18.11/0022-net-ena-set-IO-ring-size-to-valid-value.patch
@@ -1,0 +1,49 @@
+From d7570104bf0e3e5cde89809ee76e45563b957ec7 Mon Sep 17 00:00:00 2001
+From: Michal Krawczyk <mk@semihalf.com>
+Date: Wed, 8 Apr 2020 10:29:08 +0200
+Subject: [PATCH 22/24] net/ena: set IO ring size to valid value
+
+[ upstream commit badc3a6aa133a886a61b9e3ad666e5675f7ec3d3 ]
+
+IO rings were configured with the maximum allowed size for the Tx/Rx
+rings. However, the application could decide to create smaller rings.
+
+This patch is using value stored in the ring instead of the value from
+the adapter which is indicating the maximum allowed value.
+
+Fixes: df238f84c0a2 ("net/ena: recreate HW IO rings on start and stop")
+Cc: stable@dpdk.org
+
+Change-Id: Icf9102e2aa4e7413b6620b36dd232673239b7291
+Signed-off-by: Michal Krawczyk <mk@semihalf.com>
+Reviewed-by: Igor Chauskin <igorch@amazon.com>
+Reviewed-by: Guy Tzalik <gtzalik@amazon.com>
+---
+ drivers/net/ena/ena_ethdev.c | 3 +--
+ 1 file changed, 1 insertion(+), 2 deletions(-)
+
+diff --git a/drivers/net/ena/ena_ethdev.c b/drivers/net/ena/ena_ethdev.c
+index a38f3a3ea2..3333b43747 100644
+--- a/drivers/net/ena/ena_ethdev.c
++++ b/drivers/net/ena/ena_ethdev.c
+@@ -1054,16 +1054,15 @@ static int ena_create_io_queue(struct ena_ring *ring)
+ 		ena_qid = ENA_IO_TXQ_IDX(ring->id);
+ 		ctx.direction = ENA_COM_IO_QUEUE_DIRECTION_TX;
+ 		ctx.mem_queue_type = ena_dev->tx_mem_queue_type;
+-		ctx.queue_size = adapter->tx_ring_size;
+ 		for (i = 0; i < ring->ring_size; i++)
+ 			ring->empty_tx_reqs[i] = i;
+ 	} else {
+ 		ena_qid = ENA_IO_RXQ_IDX(ring->id);
+ 		ctx.direction = ENA_COM_IO_QUEUE_DIRECTION_RX;
+-		ctx.queue_size = adapter->rx_ring_size;
+ 		for (i = 0; i < ring->ring_size; i++)
+ 			ring->empty_rx_reqs[i] = i;
+ 	}
++	ctx.queue_size = ring->ring_size;
+ 	ctx.qid = ena_qid;
+ 	ctx.msix_vector = -1; /* interrupts not used */
+ 	ctx.numa_node = ring->numa_socket_id;
+-- 
+2.20.1
+

--- a/userspace/dpdk/18.11/0023-net-ena-limit-refill-threshold-by-fixed-value.patch
+++ b/userspace/dpdk/18.11/0023-net-ena-limit-refill-threshold-by-fixed-value.patch
@@ -1,0 +1,118 @@
+From f534649d7967ebb1998bc35212110be8caf1214a Mon Sep 17 00:00:00 2001
+From: Michal Krawczyk <mk@semihalf.com>
+Date: Wed, 8 Apr 2020 10:29:16 +0200
+Subject: [PATCH 23/24] net/ena: limit refill threshold by fixed value
+
+[ upstream commit 7755060798de9c0146df8809926030ed47fc9086 ]
+
+Divider used for both Tx and Rx cleanup/refill threshold can cause too
+big delay in case of the really big rings - for example if the 8k Rx
+ring will be used, the refill won't trigger unless 1024 threshold will
+be reached. It will also cause driver to try to allocate that much
+descriptors.
+
+Limiting it by fixed value - 256 in that case, would limit maximum
+time spent in repopulate function.
+
+Change-Id: Ia8659e6ddf179ff612a780adc6fe55d13eeac6e9
+Signed-off-by: Michal Krawczyk <mk@semihalf.com>
+Reviewed-by: Igor Chauskin <igorch@amazon.com>
+Reviewed-by: Guy Tzalik <gtzalik@amazon.com>
+---
+ drivers/net/ena/ena_ethdev.c | 26 ++++++++++++++------------
+ drivers/net/ena/ena_ethdev.h | 10 ++++++++++
+ 2 files changed, 24 insertions(+), 12 deletions(-)
+
+diff --git a/drivers/net/ena/ena_ethdev.c b/drivers/net/ena/ena_ethdev.c
+index 3333b43747..31fddcd5d1 100644
+--- a/drivers/net/ena/ena_ethdev.c
++++ b/drivers/net/ena/ena_ethdev.c
+@@ -61,14 +61,6 @@
+ /*reverse version of ENA_IO_RXQ_IDX*/
+ #define ENA_IO_RXQ_IDX_REV(q)	((q - 1) / 2)
+ 
+-/* While processing submitted and completed descriptors (rx and tx path
+- * respectively) in a loop it is desired to:
+- *  - perform batch submissions while populating sumbissmion queue
+- *  - avoid blocking transmission of other packets during cleanup phase
+- * Hence the utilization ratio of 1/8 of a queue size.
+- */
+-#define ENA_RING_DESCS_RATIO(ring_size)	(ring_size / 8)
+-
+ #define __MERGE_64B_H_L(h, l) (((uint64_t)h << 32) | l)
+ #define TEST_BIT(val, bit_shift) (val & (1UL << bit_shift))
+ 
+@@ -1854,6 +1846,8 @@ static uint16_t eth_ena_recv_pkts(void *rx_queue, struct rte_mbuf **rx_pkts,
+ 	struct ena_ring *rx_ring = (struct ena_ring *)(rx_queue);
+ 	unsigned int ring_size = rx_ring->ring_size;
+ 	unsigned int ring_mask = ring_size - 1;
++	unsigned int free_queue_entries;
++	unsigned int refill_threshold;
+ 	uint16_t next_to_clean = rx_ring->next_to_clean;
+ 	uint16_t desc_in_use = 0;
+ 	uint16_t req_id;
+@@ -1950,11 +1944,15 @@ static uint16_t eth_ena_recv_pkts(void *rx_queue, struct rte_mbuf **rx_pkts,
+ 
+ 	rx_ring->next_to_clean = next_to_clean;
+ 
+-	desc_in_use = desc_in_use - completed + 1;
++	free_queue_entries = ena_com_sq_empty_space(rx_ring->ena_com_io_sq);
++	refill_threshold =
++		RTE_MIN(ring_size / ENA_REFILL_THRESH_DIVIDER,
++		(unsigned int)ENA_REFILL_THRESH_PACKET);
++
+ 	/* Burst refill to save doorbells, memory barriers, const interval */
+-	if (ring_size - desc_in_use > ENA_RING_DESCS_RATIO(ring_size)) {
++	if (free_queue_entries > refill_threshold) {
+ 		ena_com_update_dev_comp_head(rx_ring->ena_com_io_cq);
+-		ena_populate_rx_queue(rx_ring, ring_size - desc_in_use);
++		ena_populate_rx_queue(rx_ring, free_queue_entries);
+ 	}
+ 
+ 	return recv_idx;
+@@ -2079,6 +2077,7 @@ static uint16_t eth_ena_xmit_pkts(void *tx_queue, struct rte_mbuf **tx_pkts,
+ 	struct rte_mbuf *mbuf;
+ 	unsigned int ring_size = tx_ring->ring_size;
+ 	unsigned int ring_mask = ring_size - 1;
++	unsigned int cleanup_budget;
+ 	struct ena_com_tx_ctx ena_tx_ctx;
+ 	struct ena_tx_buffer *tx_info;
+ 	struct ena_com_buf *ebuf;
+@@ -2193,9 +2192,12 @@ static uint16_t eth_ena_xmit_pkts(void *tx_queue, struct rte_mbuf **tx_pkts,
+ 		/* Put back descriptor to the ring for reuse */
+ 		tx_ring->empty_tx_reqs[next_to_clean & ring_mask] = req_id;
+ 		next_to_clean++;
++		cleanup_budget =
++			RTE_MIN(ring_size / ENA_REFILL_THRESH_DIVIDER,
++			(unsigned int)ENA_REFILL_THRESH_PACKET);
+ 
+ 		/* If too many descs to clean, leave it for another run */
+-		if (unlikely(total_tx_descs > ENA_RING_DESCS_RATIO(ring_size)))
++		if (unlikely(total_tx_descs > cleanup_budget))
+ 			break;
+ 	}
+ 
+diff --git a/drivers/net/ena/ena_ethdev.h b/drivers/net/ena/ena_ethdev.h
+index 9d887d4b5b..b11a9cb122 100644
+--- a/drivers/net/ena/ena_ethdev.h
++++ b/drivers/net/ena/ena_ethdev.h
+@@ -58,6 +58,16 @@
+ #define ENA_WD_TIMEOUT_SEC	3
+ #define ENA_DEVICE_KALIVE_TIMEOUT (ENA_WD_TIMEOUT_SEC * rte_get_timer_hz())
+ 
++/* While processing submitted and completed descriptors (rx and tx path
++ * respectively) in a loop it is desired to:
++ *  - perform batch submissions while populating sumbissmion queue
++ *  - avoid blocking transmission of other packets during cleanup phase
++ * Hence the utilization ratio of 1/8 of a queue size or max value if the size
++ * of the ring is very big - like 8k Rx rings.
++ */
++#define ENA_REFILL_THRESH_DIVIDER      8
++#define ENA_REFILL_THRESH_PACKET       256
++
+ struct ena_adapter;
+ 
+ enum ena_ring_type {
+-- 
+2.20.1
+

--- a/userspace/dpdk/18.11/0024-net-ena-fix-build-for-O1-optimization.patch
+++ b/userspace/dpdk/18.11/0024-net-ena-fix-build-for-O1-optimization.patch
@@ -1,0 +1,47 @@
+From cc61c7347e76ebfcdbffb4c375e21c3670731522 Mon Sep 17 00:00:00 2001
+From: Ferruh Yigit <ferruh.yigit@intel.com>
+Date: Mon, 11 May 2020 17:07:24 +0100
+Subject: [PATCH 24/24] net/ena: fix build for O1 optimization
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+[ upstream commit 5f267cb01b41def2af37b8fa56828e75ae91add0 ]
+
+Can be reproduced with "make EXTRA_CFLAGS='-O1'" command using
+gcc (GCC) 9.3.1 20200408 (Red Hat 9.3.1-2)
+
+Build error:
+.../drivers/net/ena/ena_ethdev.c: In function ‘eth_ena_dev_init’:
+.../drivers/net/ena/ena_ethdev.c:1815:20:
+    error: ‘wd_state’ may be used uninitialized in this function
+           [-Werror=maybe-uninitialized]
+ 1815 |  adapter->wd_state = wd_state;
+      |  ~~~~~~~~~~~~~~~~~~^~~~~~~~~~
+
+This looks like false positive, fixing by assigning initial value to
+'wd_state' variable.
+
+Change-Id: I68bd21d4e2a4b41466e670e282856d4f072dadc0
+Signed-off-by: Ferruh Yigit <ferruh.yigit@intel.com>
+Acked-by: Michal Krawczyk <mk@semihalf.com>
+---
+ drivers/net/ena/ena_ethdev.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/drivers/net/ena/ena_ethdev.c b/drivers/net/ena/ena_ethdev.c
+index 31fddcd5d1..d605d536a5 100644
+--- a/drivers/net/ena/ena_ethdev.c
++++ b/drivers/net/ena/ena_ethdev.c
+@@ -1560,7 +1560,7 @@ static int eth_ena_dev_init(struct rte_eth_dev *eth_dev)
+ 	u16 tx_sgl_size = 0;
+ 
+ 	static int adapters_found;
+-	bool wd_state;
++	bool wd_state = false;
+ 
+ 	eth_dev->dev_ops = &ena_dev_ops;
+ 	eth_dev->rx_pkt_burst = &eth_ena_recv_pkts;
+-- 
+2.20.1
+

--- a/userspace/dpdk/19.02/0001-net-ena-get-device-info-statically.patch
+++ b/userspace/dpdk/19.02/0001-net-ena-get-device-info-statically.patch
@@ -1,7 +1,7 @@
 From 5433ba938e996f8309cdbc45284e1f54f16c081e Mon Sep 17 00:00:00 2001
 From: Michal Krawczyk <mk@semihalf.com>
 Date: Fri, 15 Feb 2019 09:36:39 +0100
-Subject: [PATCH 1/6] net/ena: get device info statically
+Subject: [PATCH 01/15] net/ena: get device info statically
 
 [ upstream commit 117ba4a60488a0f96a5737f38ddba6d0f9a728b6 ]
 
@@ -22,7 +22,7 @@ Signed-off-by: Michal Krawczyk <mk@semihalf.com>
  2 files changed, 19 insertions(+), 20 deletions(-)
 
 diff --git a/drivers/net/ena/ena_ethdev.c b/drivers/net/ena/ena_ethdev.c
-index 8bb05caa2..08b1ab195 100644
+index 8bb05caa21..08b1ab1959 100644
 --- a/drivers/net/ena/ena_ethdev.c
 +++ b/drivers/net/ena/ena_ethdev.c
 @@ -1804,9 +1804,14 @@ static int eth_ena_dev_init(struct rte_eth_dev *eth_dev)
@@ -93,7 +93,7 @@ index 8bb05caa2..08b1ab195 100644
  		}
  
 diff --git a/drivers/net/ena/ena_ethdev.h b/drivers/net/ena/ena_ethdev.h
-index 309b92f65..221760c62 100644
+index 309b92f65c..221760c62c 100644
 --- a/drivers/net/ena/ena_ethdev.h
 +++ b/drivers/net/ena/ena_ethdev.h
 @@ -167,6 +167,12 @@ struct ena_stats_dev {

--- a/userspace/dpdk/19.02/0002-net-ena-fix-checksum-feature-flag.patch
+++ b/userspace/dpdk/19.02/0002-net-ena-fix-checksum-feature-flag.patch
@@ -1,7 +1,7 @@
 From 0d73961d8e76dd5d64eb6e785f55bdef0a17b4f1 Mon Sep 17 00:00:00 2001
 From: Michal Krawczyk <mk@semihalf.com>
 Date: Mon, 8 Apr 2019 12:27:44 +0200
-Subject: [PATCH 2/6] net/ena: fix checksum feature flag
+Subject: [PATCH 02/15] net/ena: fix checksum feature flag
 
 [ upstream commit ef538c1a7f565c9b58518375a500aa864445fd11 ]
 
@@ -18,7 +18,7 @@ Signed-off-by: Michal Krawczyk <mk@semihalf.com>
  1 file changed, 1 insertion(+), 1 deletion(-)
 
 diff --git a/drivers/net/ena/ena_ethdev.c b/drivers/net/ena/ena_ethdev.c
-index 08b1ab195..ca391ec4a 100644
+index 08b1ab1959..ca391ec4af 100644
 --- a/drivers/net/ena/ena_ethdev.c
 +++ b/drivers/net/ena/ena_ethdev.c
 @@ -1809,7 +1809,7 @@ static int eth_ena_dev_init(struct rte_eth_dev *eth_dev)

--- a/userspace/dpdk/19.02/0003-net-ena-fix-Tx-statistics.patch
+++ b/userspace/dpdk/19.02/0003-net-ena-fix-Tx-statistics.patch
@@ -1,7 +1,7 @@
 From b3bfc9ce1a047aa1690daf0d9c8c0ad0bda5bbf8 Mon Sep 17 00:00:00 2001
 From: Rafal Kozik <rk@semihalf.com>
 Date: Tue, 14 May 2019 13:11:26 +0200
-Subject: [PATCH 3/6] net/ena: fix Tx statistics
+Subject: [PATCH 03/15] net/ena: fix Tx statistics
 
 [ upstream commit 5673e285a63347068e51dbd191915348f6a580b0 ]
 
@@ -19,7 +19,7 @@ Acked-by: Michal Krawczyk <mk@semihalf.com>
  1 file changed, 1 insertion(+), 1 deletion(-)
 
 diff --git a/drivers/net/ena/ena_ethdev.c b/drivers/net/ena/ena_ethdev.c
-index ca391ec4a..b948517d2 100644
+index ca391ec4af..b948517d20 100644
 --- a/drivers/net/ena/ena_ethdev.c
 +++ b/drivers/net/ena/ena_ethdev.c
 @@ -2392,7 +2392,7 @@ static uint16_t eth_ena_xmit_pkts(void *tx_queue, struct rte_mbuf **tx_pkts,

--- a/userspace/dpdk/19.02/0004-net-ena-fix-Rx-checksum-errors-statistics.patch
+++ b/userspace/dpdk/19.02/0004-net-ena-fix-Rx-checksum-errors-statistics.patch
@@ -1,7 +1,7 @@
 From 4d807ac597171d80ce0d4131cecef2950be2b20a Mon Sep 17 00:00:00 2001
 From: Michal Krawczyk <mk@semihalf.com>
 Date: Tue, 28 May 2019 10:28:34 +0200
-Subject: [PATCH 4/6] net/ena: fix Rx checksum errors statistics
+Subject: [PATCH 04/15] net/ena: fix Rx checksum errors statistics
 
 [ upstream commit ef74b5f7b69b9502ddab81121611243efcfe1dde ]
 
@@ -21,7 +21,7 @@ Signed-off-by: Michal Krawczyk <mk@semihalf.com>
  1 file changed, 3 insertions(+), 5 deletions(-)
 
 diff --git a/drivers/net/ena/ena_ethdev.c b/drivers/net/ena/ena_ethdev.c
-index b948517d2..94c2bad14 100644
+index b948517d20..94c2bad146 100644
 --- a/drivers/net/ena/ena_ethdev.c
 +++ b/drivers/net/ena/ena_ethdev.c
 @@ -2105,8 +2105,10 @@ static uint16_t eth_ena_recv_pkts(void *rx_queue, struct rte_mbuf **rx_pkts,

--- a/userspace/dpdk/19.02/0005-net-ena-fix-assigning-NUMA-node-to-IO-queue.patch
+++ b/userspace/dpdk/19.02/0005-net-ena-fix-assigning-NUMA-node-to-IO-queue.patch
@@ -1,7 +1,7 @@
 From 3adc0484592c907640663ba836924bcd77b59002 Mon Sep 17 00:00:00 2001
 From: Michal Krawczyk <mk@semihalf.com>
 Date: Tue, 4 Jun 2019 12:59:36 +0200
-Subject: [PATCH 5/6] net/ena: fix assigning NUMA node to IO queue
+Subject: [PATCH 05/15] net/ena: fix assigning NUMA node to IO queue
 
 [ upstream commit 4217cb0b7d2c5385f06f531af7f14b860927aba7 ]
 
@@ -23,7 +23,7 @@ Reviewed-by: David Marchand <david.marchand@redhat.com>
  2 files changed, 7 insertions(+), 20 deletions(-)
 
 diff --git a/drivers/net/ena/ena_ethdev.c b/drivers/net/ena/ena_ethdev.c
-index 94c2bad14..ad7d8fed4 100644
+index 94c2bad146..ad7d8fed43 100644
 --- a/drivers/net/ena/ena_ethdev.c
 +++ b/drivers/net/ena/ena_ethdev.c
 @@ -39,7 +39,6 @@
@@ -101,7 +101,7 @@ index 94c2bad14..ad7d8fed4 100644
  
  	rxq->rx_buffer_info = rte_zmalloc("rxq->buffer_info",
 diff --git a/drivers/net/ena/ena_ethdev.h b/drivers/net/ena/ena_ethdev.h
-index 221760c62..fafaed428 100644
+index 221760c62c..fafaed428e 100644
 --- a/drivers/net/ena/ena_ethdev.h
 +++ b/drivers/net/ena/ena_ethdev.h
 @@ -143,6 +143,8 @@ struct ena_ring {

--- a/userspace/dpdk/19.02/0006-net-ena-fix-admin-CQ-polling-for-32-bit.patch
+++ b/userspace/dpdk/19.02/0006-net-ena-fix-admin-CQ-polling-for-32-bit.patch
@@ -1,0 +1,37 @@
+From 6394601c3c5f664bea4b2f360e456889aca3021f Mon Sep 17 00:00:00 2001
+From: David Harton <dharton@cisco.com>
+Date: Fri, 12 Jul 2019 13:35:43 -0400
+Subject: [PATCH 06/15] net/ena: fix admin CQ polling for 32-bit
+
+[ upstream commit 8190a843ef9bce3696b74ad2b057b5d86cc7b0df ]
+
+Recent modifications to admin command queue polling logic
+did not support 32-bit applications.  Updated the driver to
+work for 32 or 64 bit applications
+
+Fixes: 3adcba9a8987 ("net/ena: update HAL to the newer version")
+Cc: stable@dpdk.org
+
+Change-Id: I254d8d36af4208c713fbffcfbd0d241a88a972ce
+Signed-off-by: David Harton <dharton@cisco.com>
+Acked-by: Michal Krawczyk <mk@semihalf.com>
+---
+ drivers/net/ena/base/ena_com.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/drivers/net/ena/base/ena_com.c b/drivers/net/ena/base/ena_com.c
+index b688067f77..e9b9be28dc 100644
+--- a/drivers/net/ena/base/ena_com.c
++++ b/drivers/net/ena/base/ena_com.c
+@@ -547,7 +547,7 @@ static int ena_com_wait_and_process_admin_cq_polling(struct ena_comp_ctx *comp_c
+ 						     struct ena_com_admin_queue *admin_queue)
+ {
+ 	unsigned long flags = 0;
+-	unsigned long timeout;
++	uint64_t timeout;
+ 	int ret;
+ 
+ 	timeout = ENA_GET_SYSTEM_TIMEOUT(admin_queue->completion_timeout);
+-- 
+2.20.1
+

--- a/userspace/dpdk/19.02/0007-net-ena-fix-L4-checksum-Tx-offload.patch
+++ b/userspace/dpdk/19.02/0007-net-ena-fix-L4-checksum-Tx-offload.patch
@@ -1,0 +1,52 @@
+From b2a6c5056f01b863dc83eab7d792b33731553825 Mon Sep 17 00:00:00 2001
+From: Maciej Bielski <mba@semihalf.com>
+Date: Thu, 1 Aug 2019 13:45:36 +0200
+Subject: [PATCH 07/15] net/ena: fix L4 checksum Tx offload
+
+[ upstream commit 40e7c02155625f18a87faf5e6a8cec2e986146e8 ]
+
+During an if-condition evaluation, a 2-bit flag evaluates to 'true' for
+'0x1', '0x2' and '0x3'. Thus, from this perspective these flags are
+indistinguishable. To make them distinct, respective bits must be
+extracted with a mask and then checked for strict equality.
+
+Specifically here, even if `PKT_TX_UDP_CKSUM` (value '0x3') was set, the
+expression `mbuf->ol_flags & PKT_TX_TCP` (the second flag of value
+'0x1') is evaluated first and the result is 'true'. In consequence, for
+UDP packets the execution flow enters an incorrect branch.
+
+Fixes: 56b8b9b7e5d2 ("net/ena: convert to new Tx offloads API")
+Cc: stable@dpdk.org
+
+Change-Id: I7917b209856f24e5d0b6481a94b322d09266bc5b
+Reported-by: Eduard Serra <eserra@vmware.com>
+Signed-off-by: Maciej Bielski <mba@semihalf.com>
+Acked-by: Michal Krawczyk <mk@semihalf.com>
+---
+ drivers/net/ena/ena_ethdev.c | 7 ++++---
+ 1 file changed, 4 insertions(+), 3 deletions(-)
+
+diff --git a/drivers/net/ena/ena_ethdev.c b/drivers/net/ena/ena_ethdev.c
+index ad7d8fed43..345b6c45ee 100644
+--- a/drivers/net/ena/ena_ethdev.c
++++ b/drivers/net/ena/ena_ethdev.c
+@@ -329,12 +329,13 @@ static inline void ena_tx_mbuf_prepare(struct rte_mbuf *mbuf,
+ 		}
+ 
+ 		/* check if L4 checksum is needed */
+-		if ((mbuf->ol_flags & PKT_TX_TCP_CKSUM) &&
++		if (((mbuf->ol_flags & PKT_TX_L4_MASK) == PKT_TX_TCP_CKSUM) &&
+ 		    (queue_offloads & DEV_TX_OFFLOAD_TCP_CKSUM)) {
+ 			ena_tx_ctx->l4_proto = ENA_ETH_IO_L4_PROTO_TCP;
+ 			ena_tx_ctx->l4_csum_enable = true;
+-		} else if ((mbuf->ol_flags & PKT_TX_UDP_CKSUM) &&
+-			   (queue_offloads & DEV_TX_OFFLOAD_UDP_CKSUM)) {
++		} else if (((mbuf->ol_flags & PKT_TX_L4_MASK) ==
++				PKT_TX_UDP_CKSUM) &&
++				(queue_offloads & DEV_TX_OFFLOAD_UDP_CKSUM)) {
+ 			ena_tx_ctx->l4_proto = ENA_ETH_IO_L4_PROTO_UDP;
+ 			ena_tx_ctx->l4_csum_enable = true;
+ 		} else {
+-- 
+2.20.1
+

--- a/userspace/dpdk/19.02/0008-net-ena-fix-indication-of-bad-L4-Rx-checksums.patch
+++ b/userspace/dpdk/19.02/0008-net-ena-fix-indication-of-bad-L4-Rx-checksums.patch
@@ -1,0 +1,48 @@
+From 0ad5c67f3a95707ef518a3d4df46addc03a9c1eb Mon Sep 17 00:00:00 2001
+From: Igor Chauskin <igorch@amazon.com>
+Date: Mon, 28 Oct 2019 11:23:33 +0100
+Subject: [PATCH 08/15] net/ena: fix indication of bad L4 Rx checksums
+
+[ upstream commit 05817057faba9356900ced61e24a22eef6bc4c87 ]
+
+Add checking of l4_csum_checked and frag flags before checking the
+l4_csum_error flag.
+
+In case of IP fragment/unchecked L4 csum - add PKT_RX_L4_CKSUM_UNKNOWN
+flag to the indicated mbuf.
+
+Fixes: 1173fca25af9 ("ena: add polling-mode driver")
+Cc: stable@dpdk.org
+
+Change-Id: I9f1414741eb44ca289a8bfd11d7e66110c95040e
+Signed-off-by: Igor Chauskin <igorch@amazon.com>
+Reviewed-by: Maciej Bielski <mba@semihalf.com>
+Reviewed-by: Michal Krawczyk <mk@semihalf.com>
+---
+ drivers/net/ena/ena_ethdev.c | 10 ++++++++--
+ 1 file changed, 8 insertions(+), 2 deletions(-)
+
+diff --git a/drivers/net/ena/ena_ethdev.c b/drivers/net/ena/ena_ethdev.c
+index 345b6c45ee..0b6f377d93 100644
+--- a/drivers/net/ena/ena_ethdev.c
++++ b/drivers/net/ena/ena_ethdev.c
+@@ -286,8 +286,14 @@ static inline void ena_rx_mbuf_prepare(struct rte_mbuf *mbuf,
+ 	else if (ena_rx_ctx->l3_proto == ENA_ETH_IO_L3_PROTO_IPV6)
+ 		packet_type |= RTE_PTYPE_L3_IPV6;
+ 
+-	if (unlikely(ena_rx_ctx->l4_csum_err))
+-		ol_flags |= PKT_RX_L4_CKSUM_BAD;
++	if (!ena_rx_ctx->l4_csum_checked)
++		ol_flags |= PKT_RX_L4_CKSUM_UNKNOWN;
++	else
++		if (unlikely(ena_rx_ctx->l4_csum_err) && !ena_rx_ctx->frag)
++			ol_flags |= PKT_RX_L4_CKSUM_BAD;
++		else
++			ol_flags |= PKT_RX_L4_CKSUM_UNKNOWN;
++
+ 	if (unlikely(ena_rx_ctx->l3_csum_err))
+ 		ol_flags |= PKT_RX_IP_CKSUM_BAD;
+ 
+-- 
+2.20.1
+

--- a/userspace/dpdk/19.02/0009-net-ena-ensure-Rx-buffer-size-is-at-least-1400B.patch
+++ b/userspace/dpdk/19.02/0009-net-ena-ensure-Rx-buffer-size-is-at-least-1400B.patch
@@ -1,0 +1,84 @@
+From 40b8c0385c9a8512edbcfb84823dc4ca7e2216c0 Mon Sep 17 00:00:00 2001
+From: Michal Krawczyk <mk@semihalf.com>
+Date: Wed, 8 Apr 2020 10:28:52 +0200
+Subject: [PATCH 09/15] net/ena: ensure Rx buffer size is at least 1400B
+
+[ upstream commit 38364c2687ead97b99402310087c27131a97748c ]
+
+Some of the ENA devices can't handle buffers which are smaller than a
+1400B. Because of this limitation, size of the buffer is being checked
+and limited during the Rx queue setup.
+
+If it's below the allowed value, PMD won't finish it's configuration
+successfully..
+
+Change-Id: Ib402d3bfad98a3fc4f91095d5c6f90c6069da021
+Signed-off-by: Michal Krawczyk <mk@semihalf.com>
+Reviewed-by: Igor Chauskin <igorch@amazon.com>
+Reviewed-by: Guy Tzalik <gtzalik@amazon.com>
+---
+ drivers/net/ena/ena_ethdev.c | 12 +++++++++++-
+ drivers/net/ena/ena_ethdev.h |  3 ++-
+ 2 files changed, 13 insertions(+), 2 deletions(-)
+
+diff --git a/drivers/net/ena/ena_ethdev.c b/drivers/net/ena/ena_ethdev.c
+index 0b6f377d93..b48d22584b 100644
+--- a/drivers/net/ena/ena_ethdev.c
++++ b/drivers/net/ena/ena_ethdev.c
+@@ -1,7 +1,7 @@
+ /*-
+ * BSD LICENSE
+ *
+-* Copyright (c) 2015-2016 Amazon.com, Inc. or its affiliates.
++* Copyright (c) 2015-2020 Amazon.com, Inc. or its affiliates.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+@@ -1308,6 +1308,7 @@ static int ena_rx_queue_setup(struct rte_eth_dev *dev,
+ 	struct ena_adapter *adapter =
+ 		(struct ena_adapter *)(dev->data->dev_private);
+ 	struct ena_ring *rxq = NULL;
++	size_t buffer_size;
+ 	int i;
+ 
+ 	rxq = &adapter->rx_ring[queue_idx];
+@@ -1335,6 +1336,15 @@ static int ena_rx_queue_setup(struct rte_eth_dev *dev,
+ 		return -EINVAL;
+ 	}
+ 
++	/* ENA isn't supporting buffers smaller than 1400 bytes */
++	buffer_size = rte_pktmbuf_data_room_size(mp) - RTE_PKTMBUF_HEADROOM;
++	if (buffer_size < ENA_RX_BUF_MIN_SIZE) {
++		PMD_DRV_LOG(ERR,
++			"Unsupported size of RX buffer: %zu (min size: %d)\n",
++			buffer_size, ENA_RX_BUF_MIN_SIZE);
++		return -EINVAL;
++	}
++
+ 	rxq->port_id = dev->data->port_id;
+ 	rxq->next_to_clean = 0;
+ 	rxq->next_to_use = 0;
+diff --git a/drivers/net/ena/ena_ethdev.h b/drivers/net/ena/ena_ethdev.h
+index fafaed428e..3e2ed177e5 100644
+--- a/drivers/net/ena/ena_ethdev.h
++++ b/drivers/net/ena/ena_ethdev.h
+@@ -1,7 +1,7 @@
+ /*-
+ * BSD LICENSE
+ *
+-* Copyright (c) 2015-2016 Amazon.com, Inc. or its affiliates.
++* Copyright (c) 2015-2020 Amazon.com, Inc. or its affiliates.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+@@ -48,6 +48,7 @@
+ #define ENA_MIN_FRAME_LEN	64
+ #define ENA_NAME_MAX_LEN	20
+ #define ENA_PKT_MAX_BUFS	17
++#define ENA_RX_BUF_MIN_SIZE	1400
+ 
+ #define ENA_MIN_MTU		128
+ 
+-- 
+2.20.1
+

--- a/userspace/dpdk/19.02/0010-net-ena-base-make-allocation-macros-thread-safe.patch
+++ b/userspace/dpdk/19.02/0010-net-ena-base-make-allocation-macros-thread-safe.patch
@@ -1,0 +1,80 @@
+From abf3484e5b491e5abcfdde1aa85446fd6ab8d6e9 Mon Sep 17 00:00:00 2001
+From: Igor Chauskin <igorch@amazon.com>
+Date: Wed, 8 Apr 2020 10:28:53 +0200
+Subject: [PATCH 10/15] net/ena/base: make allocation macros thread-safe
+
+[ upstream commit b14fcac035fd8514851c9140a4e26d765b61c532 ]
+
+Memory allocation region id could possibly be non-unique
+due to non-atomic increment, causing allocation failure.
+
+Fixes: 9ba7981ec992 ("ena: add communication layer for DPDK")
+Cc: stable@dpdk.org
+
+Change-Id: Ib9207aaae4e5e7ecdf1a99a0f23a508a53af631d
+Signed-off-by: Igor Chauskin <igorch@amazon.com>
+Reviewed-by: Michal Krawczyk <mk@semihalf.com>
+Reviewed-by: Guy Tzalik <gtzalik@amazon.com>
+---
+ drivers/net/ena/base/ena_plat_dpdk.h | 10 ++++++----
+ drivers/net/ena/ena_ethdev.c         |  2 +-
+ 2 files changed, 7 insertions(+), 5 deletions(-)
+
+diff --git a/drivers/net/ena/base/ena_plat_dpdk.h b/drivers/net/ena/base/ena_plat_dpdk.h
+index 902d91efbe..870764d239 100644
+--- a/drivers/net/ena/base/ena_plat_dpdk.h
++++ b/drivers/net/ena/base/ena_plat_dpdk.h
+@@ -1,7 +1,7 @@
+ /*-
+ * BSD LICENSE
+ *
+-* Copyright (c) 2015-2016 Amazon.com, Inc. or its affiliates.
++* Copyright (c) 2015-2020 Amazon.com, Inc. or its affiliates.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+@@ -204,7 +204,7 @@ do {                                                                   \
+  * Each rte_memzone should have unique name.
+  * To satisfy it, count number of allocations and add it to name.
+  */
+-extern uint32_t ena_alloc_cnt;
++extern rte_atomic32_t ena_alloc_cnt;
+ 
+ #define ENA_MEM_ALLOC_COHERENT(dmadev, size, virt, phys, handle)	\
+ 	do {								\
+@@ -212,7 +212,8 @@ extern uint32_t ena_alloc_cnt;
+ 		char z_name[RTE_MEMZONE_NAMESIZE];			\
+ 		ENA_TOUCH(dmadev); ENA_TOUCH(handle);			\
+ 		snprintf(z_name, sizeof(z_name),			\
+-				"ena_alloc_%d", ena_alloc_cnt++);	\
++			 "ena_alloc_%d",				\
++			 rte_atomic32_add_return(&ena_alloc_cnt, 1));	\
+ 		mz = rte_memzone_reserve(z_name, size, SOCKET_ID_ANY,	\
+ 				RTE_MEMZONE_IOVA_CONTIG);		\
+ 		handle = mz;						\
+@@ -237,7 +238,8 @@ extern uint32_t ena_alloc_cnt;
+ 		char z_name[RTE_MEMZONE_NAMESIZE];			\
+ 		ENA_TOUCH(dmadev); ENA_TOUCH(dev_node);			\
+ 		snprintf(z_name, sizeof(z_name),			\
+-				"ena_alloc_%d", ena_alloc_cnt++);	\
++			 "ena_alloc_%d",				\
++			 rte_atomic32_add_return(&ena_alloc_cnt, 1));	\
+ 		mz = rte_memzone_reserve(z_name, size, node,		\
+ 				RTE_MEMZONE_IOVA_CONTIG);		\
+ 		mem_handle = mz;					\
+diff --git a/drivers/net/ena/ena_ethdev.c b/drivers/net/ena/ena_ethdev.c
+index b48d22584b..b8b765f95f 100644
+--- a/drivers/net/ena/ena_ethdev.c
++++ b/drivers/net/ena/ena_ethdev.c
+@@ -116,7 +116,7 @@ struct ena_stats {
+  * Each rte_memzone should have unique name.
+  * To satisfy it, count number of allocation and add it to name.
+  */
+-uint32_t ena_alloc_cnt;
++rte_atomic32_t ena_alloc_cnt;
+ 
+ static const struct ena_stats ena_stats_global_strings[] = {
+ 	ENA_STAT_GLOBAL_ENTRY(wd_expired),
+-- 
+2.20.1
+

--- a/userspace/dpdk/19.02/0011-net-ena-base-prevent-allocation-of-zero-sized-memory.patch
+++ b/userspace/dpdk/19.02/0011-net-ena-base-prevent-allocation-of-zero-sized-memory.patch
@@ -1,0 +1,77 @@
+From 92d5ef3d2712edcdb6fd99986b49c5493d2ddaf5 Mon Sep 17 00:00:00 2001
+From: Igor Chauskin <igorch@amazon.com>
+Date: Wed, 8 Apr 2020 10:28:54 +0200
+Subject: [PATCH 11/15] net/ena/base: prevent allocation of zero sized memory
+
+[ upstream commit 29dc10d9424ccf26a346387b0a707185e2432400 ]
+
+rte_memzone_reserve() will reserve the biggest contiguous memzone
+available if received 0 as size param.
+
+Fixes: 9ba7981ec992 ("ena: add communication layer for DPDK")
+Cc: stable@dpdk.org
+
+Change-Id: I2f71119e93c5e9addd8c538820093f030066d690
+Signed-off-by: Igor Chauskin <igorch@amazon.com>
+Reviewed-by: Michal Krawczyk <mk@semihalf.com>
+Reviewed-by: Guy Tzalik <gtzalik@amazon.com>
+---
+ drivers/net/ena/base/ena_plat_dpdk.h | 29 ++++++++++++++++------------
+ 1 file changed, 17 insertions(+), 12 deletions(-)
+
+diff --git a/drivers/net/ena/base/ena_plat_dpdk.h b/drivers/net/ena/base/ena_plat_dpdk.h
+index 870764d239..3b783471bd 100644
+--- a/drivers/net/ena/base/ena_plat_dpdk.h
++++ b/drivers/net/ena/base/ena_plat_dpdk.h
+@@ -208,15 +208,18 @@ extern rte_atomic32_t ena_alloc_cnt;
+ 
+ #define ENA_MEM_ALLOC_COHERENT(dmadev, size, virt, phys, handle)	\
+ 	do {								\
+-		const struct rte_memzone *mz;				\
+-		char z_name[RTE_MEMZONE_NAMESIZE];			\
++		const struct rte_memzone *mz = NULL;			\
+ 		ENA_TOUCH(dmadev); ENA_TOUCH(handle);			\
+-		snprintf(z_name, sizeof(z_name),			\
++		if (size > 0) {						\
++			char z_name[RTE_MEMZONE_NAMESIZE];		\
++			snprintf(z_name, sizeof(z_name),		\
+ 			 "ena_alloc_%d",				\
+ 			 rte_atomic32_add_return(&ena_alloc_cnt, 1));	\
+-		mz = rte_memzone_reserve(z_name, size, SOCKET_ID_ANY,	\
+-				RTE_MEMZONE_IOVA_CONTIG);		\
+-		handle = mz;						\
++			mz = rte_memzone_reserve(z_name, size,		\
++					SOCKET_ID_ANY,			\
++					RTE_MEMZONE_IOVA_CONTIG);	\
++			handle = mz;					\
++		}							\
+ 		if (mz == NULL) {					\
+ 			virt = NULL;					\
+ 			phys = 0;					\
+@@ -234,15 +237,17 @@ extern rte_atomic32_t ena_alloc_cnt;
+ #define ENA_MEM_ALLOC_COHERENT_NODE(					\
+ 	dmadev, size, virt, phys, mem_handle, node, dev_node)		\
+ 	do {								\
+-		const struct rte_memzone *mz;				\
+-		char z_name[RTE_MEMZONE_NAMESIZE];			\
++		const struct rte_memzone *mz = NULL;			\
+ 		ENA_TOUCH(dmadev); ENA_TOUCH(dev_node);			\
+-		snprintf(z_name, sizeof(z_name),			\
++		if (size > 0) {						\
++			char z_name[RTE_MEMZONE_NAMESIZE];		\
++			snprintf(z_name, sizeof(z_name),		\
+ 			 "ena_alloc_%d",				\
+-			 rte_atomic32_add_return(&ena_alloc_cnt, 1));	\
+-		mz = rte_memzone_reserve(z_name, size, node,		\
++			 rte_atomic32_add_return(&ena_alloc_cnt, 1));   \
++			mz = rte_memzone_reserve(z_name, size, node,	\
+ 				RTE_MEMZONE_IOVA_CONTIG);		\
+-		mem_handle = mz;					\
++			mem_handle = mz;				\
++		}							\
+ 		if (mz == NULL) {					\
+ 			virt = NULL;					\
+ 			phys = 0;					\
+-- 
+2.20.1
+

--- a/userspace/dpdk/19.02/0012-net-ena-set-IO-ring-size-to-valid-value.patch
+++ b/userspace/dpdk/19.02/0012-net-ena-set-IO-ring-size-to-valid-value.patch
@@ -1,0 +1,49 @@
+From 18807c77f51805517cf24af910ac7eeb649ab964 Mon Sep 17 00:00:00 2001
+From: Michal Krawczyk <mk@semihalf.com>
+Date: Wed, 8 Apr 2020 10:29:08 +0200
+Subject: [PATCH 12/15] net/ena: set IO ring size to valid value
+
+[ upstream commit badc3a6aa133a886a61b9e3ad666e5675f7ec3d3 ]
+
+IO rings were configured with the maximum allowed size for the Tx/Rx
+rings. However, the application could decide to create smaller rings.
+
+This patch is using value stored in the ring instead of the value from
+the adapter which is indicating the maximum allowed value.
+
+Fixes: df238f84c0a2 ("net/ena: recreate HW IO rings on start and stop")
+Cc: stable@dpdk.org
+
+Change-Id: Icf9102e2aa4e7413b6620b36dd232673239b7291
+Signed-off-by: Michal Krawczyk <mk@semihalf.com>
+Reviewed-by: Igor Chauskin <igorch@amazon.com>
+Reviewed-by: Guy Tzalik <gtzalik@amazon.com>
+---
+ drivers/net/ena/ena_ethdev.c | 3 +--
+ 1 file changed, 1 insertion(+), 2 deletions(-)
+
+diff --git a/drivers/net/ena/ena_ethdev.c b/drivers/net/ena/ena_ethdev.c
+index b8b765f95f..a12f175263 100644
+--- a/drivers/net/ena/ena_ethdev.c
++++ b/drivers/net/ena/ena_ethdev.c
+@@ -1105,16 +1105,15 @@ static int ena_create_io_queue(struct ena_ring *ring)
+ 		ena_qid = ENA_IO_TXQ_IDX(ring->id);
+ 		ctx.direction = ENA_COM_IO_QUEUE_DIRECTION_TX;
+ 		ctx.mem_queue_type = ena_dev->tx_mem_queue_type;
+-		ctx.queue_size = adapter->tx_ring_size;
+ 		for (i = 0; i < ring->ring_size; i++)
+ 			ring->empty_tx_reqs[i] = i;
+ 	} else {
+ 		ena_qid = ENA_IO_RXQ_IDX(ring->id);
+ 		ctx.direction = ENA_COM_IO_QUEUE_DIRECTION_RX;
+-		ctx.queue_size = adapter->rx_ring_size;
+ 		for (i = 0; i < ring->ring_size; i++)
+ 			ring->empty_rx_reqs[i] = i;
+ 	}
++	ctx.queue_size = ring->ring_size;
+ 	ctx.qid = ena_qid;
+ 	ctx.msix_vector = -1; /* interrupts not used */
+ 	ctx.numa_node = ring->numa_socket_id;
+-- 
+2.20.1
+

--- a/userspace/dpdk/19.02/0013-net-ena-remove-memory-barriers-before-doorbells.patch
+++ b/userspace/dpdk/19.02/0013-net-ena-remove-memory-barriers-before-doorbells.patch
@@ -1,0 +1,56 @@
+From 782712594bbc99897df30141c23b0bb5086d1906 Mon Sep 17 00:00:00 2001
+From: Michal Krawczyk <mk@semihalf.com>
+Date: Wed, 8 Apr 2020 10:29:11 +0200
+Subject: [PATCH 13/15] net/ena: remove memory barriers before doorbells
+
+[ upstream commit 38faa87eb8873e04ccef8fcaea4aaf3ad125fc83 ]
+
+The doorbell code is already issuing the doorbell by using rte_write.
+Because of that, there is no need to do that before calling the
+function.
+
+Change-Id: Ia9c348e485987bc618bc7e89bf7fa057cc240617
+Signed-off-by: Michal Krawczyk <mk@semihalf.com>
+Reviewed-by: Igor Chauskin <igorch@amazon.com>
+Reviewed-by: Guy Tzalik <gtzalik@amazon.com>
+---
+ drivers/net/ena/ena_ethdev.c | 9 +--------
+ 1 file changed, 1 insertion(+), 8 deletions(-)
+
+diff --git a/drivers/net/ena/ena_ethdev.c b/drivers/net/ena/ena_ethdev.c
+index a12f175263..a2a034e8f1 100644
+--- a/drivers/net/ena/ena_ethdev.c
++++ b/drivers/net/ena/ena_ethdev.c
+@@ -1455,12 +1455,7 @@ static int ena_populate_rx_queue(struct ena_ring *rxq, unsigned int count)
+ 
+ 	/* When we submitted free recources to device... */
+ 	if (likely(i > 0)) {
+-		/* ...let HW know that it can fill buffers with data
+-		 *
+-		 * Add memory barrier to make sure the desc were written before
+-		 * issue a doorbell
+-		 */
+-		rte_wmb();
++		/* ...let HW know that it can fill buffers with data. */
+ 		ena_com_write_sq_doorbell(rxq->ena_com_io_sq);
+ 
+ 		rxq->next_to_use = next_to_use;
+@@ -2377,7 +2372,6 @@ static uint16_t eth_ena_xmit_pkts(void *tx_queue, struct rte_mbuf **tx_pkts,
+ 			RTE_LOG(DEBUG, PMD, "llq tx max burst size of queue %d"
+ 				" achieved, writing doorbell to send burst\n",
+ 				tx_ring->id);
+-			rte_wmb();
+ 			ena_com_write_sq_doorbell(tx_ring->ena_com_io_sq);
+ 		}
+ 
+@@ -2400,7 +2394,6 @@ static uint16_t eth_ena_xmit_pkts(void *tx_queue, struct rte_mbuf **tx_pkts,
+ 	/* If there are ready packets to be xmitted... */
+ 	if (sent_idx > 0) {
+ 		/* ...let HW do its best :-) */
+-		rte_wmb();
+ 		ena_com_write_sq_doorbell(tx_ring->ena_com_io_sq);
+ 		tx_ring->tx_stats.doorbells++;
+ 		tx_ring->next_to_use = next_to_use;
+-- 
+2.20.1
+

--- a/userspace/dpdk/19.02/0014-net-ena-limit-refill-threshold-by-fixed-value.patch
+++ b/userspace/dpdk/19.02/0014-net-ena-limit-refill-threshold-by-fixed-value.patch
@@ -1,0 +1,118 @@
+From 32477b9f0325da8beb4ee99a8e5084b1104a0863 Mon Sep 17 00:00:00 2001
+From: Michal Krawczyk <mk@semihalf.com>
+Date: Wed, 8 Apr 2020 10:29:16 +0200
+Subject: [PATCH 14/15] net/ena: limit refill threshold by fixed value
+
+[ upstream commit 7755060798de9c0146df8809926030ed47fc9086 ]
+
+Divider used for both Tx and Rx cleanup/refill threshold can cause too
+big delay in case of the really big rings - for example if the 8k Rx
+ring will be used, the refill won't trigger unless 1024 threshold will
+be reached. It will also cause driver to try to allocate that much
+descriptors.
+
+Limiting it by fixed value - 256 in that case, would limit maximum
+time spent in repopulate function.
+
+Change-Id: Ia8659e6ddf179ff612a780adc6fe55d13eeac6e9
+Signed-off-by: Michal Krawczyk <mk@semihalf.com>
+Reviewed-by: Igor Chauskin <igorch@amazon.com>
+Reviewed-by: Guy Tzalik <gtzalik@amazon.com>
+---
+ drivers/net/ena/ena_ethdev.c | 26 ++++++++++++++------------
+ drivers/net/ena/ena_ethdev.h | 10 ++++++++++
+ 2 files changed, 24 insertions(+), 12 deletions(-)
+
+diff --git a/drivers/net/ena/ena_ethdev.c b/drivers/net/ena/ena_ethdev.c
+index a2a034e8f1..d812b14d54 100644
+--- a/drivers/net/ena/ena_ethdev.c
++++ b/drivers/net/ena/ena_ethdev.c
+@@ -61,14 +61,6 @@
+ /*reverse version of ENA_IO_RXQ_IDX*/
+ #define ENA_IO_RXQ_IDX_REV(q)	((q - 1) / 2)
+ 
+-/* While processing submitted and completed descriptors (rx and tx path
+- * respectively) in a loop it is desired to:
+- *  - perform batch submissions while populating sumbissmion queue
+- *  - avoid blocking transmission of other packets during cleanup phase
+- * Hence the utilization ratio of 1/8 of a queue size.
+- */
+-#define ENA_RING_DESCS_RATIO(ring_size)	(ring_size / 8)
+-
+ #define __MERGE_64B_H_L(h, l) (((uint64_t)h << 32) | l)
+ #define TEST_BIT(val, bit_shift) (val & (1UL << bit_shift))
+ 
+@@ -2016,6 +2008,8 @@ static uint16_t eth_ena_recv_pkts(void *rx_queue, struct rte_mbuf **rx_pkts,
+ 	struct ena_ring *rx_ring = (struct ena_ring *)(rx_queue);
+ 	unsigned int ring_size = rx_ring->ring_size;
+ 	unsigned int ring_mask = ring_size - 1;
++	unsigned int free_queue_entries;
++	unsigned int refill_threshold;
+ 	uint16_t next_to_clean = rx_ring->next_to_clean;
+ 	uint16_t desc_in_use = 0;
+ 	uint16_t req_id;
+@@ -2117,11 +2111,15 @@ static uint16_t eth_ena_recv_pkts(void *rx_queue, struct rte_mbuf **rx_pkts,
+ 	rx_ring->rx_stats.cnt += recv_idx;
+ 	rx_ring->next_to_clean = next_to_clean;
+ 
+-	desc_in_use = desc_in_use - completed + 1;
++	free_queue_entries = ena_com_free_desc(rx_ring->ena_com_io_sq);
++	refill_threshold =
++		RTE_MIN(ring_size / ENA_REFILL_THRESH_DIVIDER,
++		(unsigned int)ENA_REFILL_THRESH_PACKET);
++
+ 	/* Burst refill to save doorbells, memory barriers, const interval */
+-	if (ring_size - desc_in_use > ENA_RING_DESCS_RATIO(ring_size)) {
++	if (free_queue_entries > refill_threshold) {
+ 		ena_com_update_dev_comp_head(rx_ring->ena_com_io_cq);
+-		ena_populate_rx_queue(rx_ring, ring_size - desc_in_use);
++		ena_populate_rx_queue(rx_ring, free_queue_entries);
+ 	}
+ 
+ 	return recv_idx;
+@@ -2260,6 +2258,7 @@ static uint16_t eth_ena_xmit_pkts(void *tx_queue, struct rte_mbuf **tx_pkts,
+ 	uint16_t seg_len;
+ 	unsigned int ring_size = tx_ring->ring_size;
+ 	unsigned int ring_mask = ring_size - 1;
++	unsigned int cleanup_budget;
+ 	struct ena_com_tx_ctx ena_tx_ctx;
+ 	struct ena_tx_buffer *tx_info;
+ 	struct ena_com_buf *ebuf;
+@@ -2417,9 +2416,12 @@ static uint16_t eth_ena_xmit_pkts(void *tx_queue, struct rte_mbuf **tx_pkts,
+ 		/* Put back descriptor to the ring for reuse */
+ 		tx_ring->empty_tx_reqs[next_to_clean & ring_mask] = req_id;
+ 		next_to_clean++;
++		cleanup_budget =
++			RTE_MIN(ring_size / ENA_REFILL_THRESH_DIVIDER,
++			(unsigned int)ENA_REFILL_THRESH_PACKET);
+ 
+ 		/* If too many descs to clean, leave it for another run */
+-		if (unlikely(total_tx_descs > ENA_RING_DESCS_RATIO(ring_size)))
++		if (unlikely(total_tx_descs > cleanup_budget))
+ 			break;
+ 	}
+ 	tx_ring->tx_stats.available_desc =
+diff --git a/drivers/net/ena/ena_ethdev.h b/drivers/net/ena/ena_ethdev.h
+index 3e2ed177e5..8a7de86805 100644
+--- a/drivers/net/ena/ena_ethdev.h
++++ b/drivers/net/ena/ena_ethdev.h
+@@ -57,6 +57,16 @@
+ #define ENA_WD_TIMEOUT_SEC	3
+ #define ENA_DEVICE_KALIVE_TIMEOUT (ENA_WD_TIMEOUT_SEC * rte_get_timer_hz())
+ 
++/* While processing submitted and completed descriptors (rx and tx path
++ * respectively) in a loop it is desired to:
++ *  - perform batch submissions while populating sumbissmion queue
++ *  - avoid blocking transmission of other packets during cleanup phase
++ * Hence the utilization ratio of 1/8 of a queue size or max value if the size
++ * of the ring is very big - like 8k Rx rings.
++ */
++#define ENA_REFILL_THRESH_DIVIDER      8
++#define ENA_REFILL_THRESH_PACKET       256
++
+ struct ena_adapter;
+ 
+ enum ena_ring_type {
+-- 
+2.20.1
+

--- a/userspace/dpdk/19.02/0015-net-ena-fix-build-for-O1-optimization.patch
+++ b/userspace/dpdk/19.02/0015-net-ena-fix-build-for-O1-optimization.patch
@@ -1,0 +1,47 @@
+From 6d99050fb74aa57cfa9e4d177a135aaee9fac86a Mon Sep 17 00:00:00 2001
+From: Ferruh Yigit <ferruh.yigit@intel.com>
+Date: Mon, 11 May 2020 17:07:24 +0100
+Subject: [PATCH 15/15] net/ena: fix build for O1 optimization
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+[ upstream commit 5f267cb01b41def2af37b8fa56828e75ae91add0 ]
+
+Can be reproduced with "make EXTRA_CFLAGS='-O1'" command using
+gcc (GCC) 9.3.1 20200408 (Red Hat 9.3.1-2)
+
+Build error:
+.../drivers/net/ena/ena_ethdev.c: In function ‘eth_ena_dev_init’:
+.../drivers/net/ena/ena_ethdev.c:1815:20:
+    error: ‘wd_state’ may be used uninitialized in this function
+           [-Werror=maybe-uninitialized]
+ 1815 |  adapter->wd_state = wd_state;
+      |  ~~~~~~~~~~~~~~~~~~^~~~~~~~~~
+
+This looks like false positive, fixing by assigning initial value to
+'wd_state' variable.
+
+Change-Id: I68bd21d4e2a4b41466e670e282856d4f072dadc0
+Signed-off-by: Ferruh Yigit <ferruh.yigit@intel.com>
+Acked-by: Michal Krawczyk <mk@semihalf.com>
+---
+ drivers/net/ena/ena_ethdev.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/drivers/net/ena/ena_ethdev.c b/drivers/net/ena/ena_ethdev.c
+index d812b14d54..b1cf6c136e 100644
+--- a/drivers/net/ena/ena_ethdev.c
++++ b/drivers/net/ena/ena_ethdev.c
+@@ -1701,7 +1701,7 @@ static int eth_ena_dev_init(struct rte_eth_dev *eth_dev)
+ 	int rc;
+ 
+ 	static int adapters_found;
+-	bool wd_state;
++	bool wd_state = false;
+ 
+ 	eth_dev->dev_ops = &ena_dev_ops;
+ 	eth_dev->rx_pkt_burst = &eth_ena_recv_pkts;
+-- 
+2.20.1
+

--- a/userspace/dpdk/19.05/0001-net-ena-fix-Tx-statistics.patch
+++ b/userspace/dpdk/19.05/0001-net-ena-fix-Tx-statistics.patch
@@ -1,7 +1,7 @@
 From 760b83027274fee51de1a948fd9aac44b863d86f Mon Sep 17 00:00:00 2001
 From: Rafal Kozik <rk@semihalf.com>
 Date: Tue, 14 May 2019 13:11:26 +0200
-Subject: [PATCH 1/4] net/ena: fix Tx statistics
+Subject: [PATCH 01/13] net/ena: fix Tx statistics
 
 [ upstream commit 5673e285a63347068e51dbd191915348f6a580b0 ]
 
@@ -19,7 +19,7 @@ Acked-by: Michal Krawczyk <mk@semihalf.com>
  1 file changed, 1 insertion(+), 1 deletion(-)
 
 diff --git a/drivers/net/ena/ena_ethdev.c b/drivers/net/ena/ena_ethdev.c
-index 3eb38165c..178c23031 100644
+index 3eb38165cc..178c230311 100644
 --- a/drivers/net/ena/ena_ethdev.c
 +++ b/drivers/net/ena/ena_ethdev.c
 @@ -2391,7 +2391,7 @@ static uint16_t eth_ena_xmit_pkts(void *tx_queue, struct rte_mbuf **tx_pkts,

--- a/userspace/dpdk/19.05/0002-net-ena-fix-Rx-checksum-errors-statistics.patch
+++ b/userspace/dpdk/19.05/0002-net-ena-fix-Rx-checksum-errors-statistics.patch
@@ -1,7 +1,7 @@
 From 160fbf354dee3ecaedb8c68f98d0cc5a08882d6b Mon Sep 17 00:00:00 2001
 From: Michal Krawczyk <mk@semihalf.com>
 Date: Tue, 28 May 2019 10:28:34 +0200
-Subject: [PATCH 2/4] net/ena: fix Rx checksum errors statistics
+Subject: [PATCH 02/13] net/ena: fix Rx checksum errors statistics
 
 [ upstream commit ef74b5f7b69b9502ddab81121611243efcfe1dde ]
 
@@ -21,7 +21,7 @@ Signed-off-by: Michal Krawczyk <mk@semihalf.com>
  1 file changed, 3 insertions(+), 5 deletions(-)
 
 diff --git a/drivers/net/ena/ena_ethdev.c b/drivers/net/ena/ena_ethdev.c
-index 178c23031..69740baf1 100644
+index 178c230311..69740baf1b 100644
 --- a/drivers/net/ena/ena_ethdev.c
 +++ b/drivers/net/ena/ena_ethdev.c
 @@ -2104,8 +2104,10 @@ static uint16_t eth_ena_recv_pkts(void *rx_queue, struct rte_mbuf **rx_pkts,

--- a/userspace/dpdk/19.05/0003-net-ena-fix-assigning-NUMA-node-to-IO-queue.patch
+++ b/userspace/dpdk/19.05/0003-net-ena-fix-assigning-NUMA-node-to-IO-queue.patch
@@ -1,7 +1,7 @@
 From 944243bb6ded8a169bb91dbd25968ddd49e5109b Mon Sep 17 00:00:00 2001
 From: Michal Krawczyk <mk@semihalf.com>
 Date: Tue, 4 Jun 2019 12:59:36 +0200
-Subject: [PATCH 3/4] net/ena: fix assigning NUMA node to IO queue
+Subject: [PATCH 03/13] net/ena: fix assigning NUMA node to IO queue
 
 [ upstream commit 4217cb0b7d2c5385f06f531af7f14b860927aba7 ]
 
@@ -23,7 +23,7 @@ Reviewed-by: David Marchand <david.marchand@redhat.com>
  2 files changed, 7 insertions(+), 20 deletions(-)
 
 diff --git a/drivers/net/ena/ena_ethdev.c b/drivers/net/ena/ena_ethdev.c
-index 69740baf1..4def70c4b 100644
+index 69740baf1b..4def70c4bc 100644
 --- a/drivers/net/ena/ena_ethdev.c
 +++ b/drivers/net/ena/ena_ethdev.c
 @@ -40,7 +40,6 @@
@@ -101,7 +101,7 @@ index 69740baf1..4def70c4b 100644
  
  	rxq->rx_buffer_info = rte_zmalloc("rxq->buffer_info",
 diff --git a/drivers/net/ena/ena_ethdev.h b/drivers/net/ena/ena_ethdev.h
-index 221760c62..fafaed428 100644
+index 221760c62c..fafaed428e 100644
 --- a/drivers/net/ena/ena_ethdev.h
 +++ b/drivers/net/ena/ena_ethdev.h
 @@ -143,6 +143,8 @@ struct ena_ring {

--- a/userspace/dpdk/19.05/0004-net-ena-fix-admin-CQ-polling-for-32-bit.patch
+++ b/userspace/dpdk/19.05/0004-net-ena-fix-admin-CQ-polling-for-32-bit.patch
@@ -1,0 +1,37 @@
+From 2742134ffc05e3a935305438b7541ca6c53de4bc Mon Sep 17 00:00:00 2001
+From: David Harton <dharton@cisco.com>
+Date: Fri, 12 Jul 2019 13:35:43 -0400
+Subject: [PATCH 04/13] net/ena: fix admin CQ polling for 32-bit
+
+[ upstream commit 8190a843ef9bce3696b74ad2b057b5d86cc7b0df ]
+
+Recent modifications to admin command queue polling logic
+did not support 32-bit applications.  Updated the driver to
+work for 32 or 64 bit applications
+
+Fixes: 3adcba9a8987 ("net/ena: update HAL to the newer version")
+Cc: stable@dpdk.org
+
+Change-Id: I254d8d36af4208c713fbffcfbd0d241a88a972ce
+Signed-off-by: David Harton <dharton@cisco.com>
+Acked-by: Michal Krawczyk <mk@semihalf.com>
+---
+ drivers/net/ena/base/ena_com.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/drivers/net/ena/base/ena_com.c b/drivers/net/ena/base/ena_com.c
+index b688067f77..e9b9be28dc 100644
+--- a/drivers/net/ena/base/ena_com.c
++++ b/drivers/net/ena/base/ena_com.c
+@@ -547,7 +547,7 @@ static int ena_com_wait_and_process_admin_cq_polling(struct ena_comp_ctx *comp_c
+ 						     struct ena_com_admin_queue *admin_queue)
+ {
+ 	unsigned long flags = 0;
+-	unsigned long timeout;
++	uint64_t timeout;
+ 	int ret;
+ 
+ 	timeout = ENA_GET_SYSTEM_TIMEOUT(admin_queue->completion_timeout);
+-- 
+2.20.1
+

--- a/userspace/dpdk/19.05/0005-net-ena-fix-L4-checksum-Tx-offload.patch
+++ b/userspace/dpdk/19.05/0005-net-ena-fix-L4-checksum-Tx-offload.patch
@@ -1,0 +1,52 @@
+From f0da412bee927e5d4baf711444e424e04331f182 Mon Sep 17 00:00:00 2001
+From: Maciej Bielski <mba@semihalf.com>
+Date: Thu, 1 Aug 2019 13:45:36 +0200
+Subject: [PATCH 05/13] net/ena: fix L4 checksum Tx offload
+
+[ upstream commit 40e7c02155625f18a87faf5e6a8cec2e986146e8 ]
+
+During an if-condition evaluation, a 2-bit flag evaluates to 'true' for
+'0x1', '0x2' and '0x3'. Thus, from this perspective these flags are
+indistinguishable. To make them distinct, respective bits must be
+extracted with a mask and then checked for strict equality.
+
+Specifically here, even if `PKT_TX_UDP_CKSUM` (value '0x3') was set, the
+expression `mbuf->ol_flags & PKT_TX_TCP` (the second flag of value
+'0x1') is evaluated first and the result is 'true'. In consequence, for
+UDP packets the execution flow enters an incorrect branch.
+
+Fixes: 56b8b9b7e5d2 ("net/ena: convert to new Tx offloads API")
+Cc: stable@dpdk.org
+
+Change-Id: I7917b209856f24e5d0b6481a94b322d09266bc5b
+Reported-by: Eduard Serra <eserra@vmware.com>
+Signed-off-by: Maciej Bielski <mba@semihalf.com>
+Acked-by: Michal Krawczyk <mk@semihalf.com>
+---
+ drivers/net/ena/ena_ethdev.c | 7 ++++---
+ 1 file changed, 4 insertions(+), 3 deletions(-)
+
+diff --git a/drivers/net/ena/ena_ethdev.c b/drivers/net/ena/ena_ethdev.c
+index 4def70c4bc..e49edfa79a 100644
+--- a/drivers/net/ena/ena_ethdev.c
++++ b/drivers/net/ena/ena_ethdev.c
+@@ -330,12 +330,13 @@ static inline void ena_tx_mbuf_prepare(struct rte_mbuf *mbuf,
+ 		}
+ 
+ 		/* check if L4 checksum is needed */
+-		if ((mbuf->ol_flags & PKT_TX_TCP_CKSUM) &&
++		if (((mbuf->ol_flags & PKT_TX_L4_MASK) == PKT_TX_TCP_CKSUM) &&
+ 		    (queue_offloads & DEV_TX_OFFLOAD_TCP_CKSUM)) {
+ 			ena_tx_ctx->l4_proto = ENA_ETH_IO_L4_PROTO_TCP;
+ 			ena_tx_ctx->l4_csum_enable = true;
+-		} else if ((mbuf->ol_flags & PKT_TX_UDP_CKSUM) &&
+-			   (queue_offloads & DEV_TX_OFFLOAD_UDP_CKSUM)) {
++		} else if (((mbuf->ol_flags & PKT_TX_L4_MASK) ==
++				PKT_TX_UDP_CKSUM) &&
++				(queue_offloads & DEV_TX_OFFLOAD_UDP_CKSUM)) {
+ 			ena_tx_ctx->l4_proto = ENA_ETH_IO_L4_PROTO_UDP;
+ 			ena_tx_ctx->l4_csum_enable = true;
+ 		} else {
+-- 
+2.20.1
+

--- a/userspace/dpdk/19.05/0006-net-ena-fix-indication-of-bad-L4-Rx-checksums.patch
+++ b/userspace/dpdk/19.05/0006-net-ena-fix-indication-of-bad-L4-Rx-checksums.patch
@@ -1,0 +1,48 @@
+From cdb71cf985115b647da7ca344563733cea4f5513 Mon Sep 17 00:00:00 2001
+From: Igor Chauskin <igorch@amazon.com>
+Date: Mon, 28 Oct 2019 11:23:33 +0100
+Subject: [PATCH 06/13] net/ena: fix indication of bad L4 Rx checksums
+
+[ upstream commit 05817057faba9356900ced61e24a22eef6bc4c87 ]
+
+Add checking of l4_csum_checked and frag flags before checking the
+l4_csum_error flag.
+
+In case of IP fragment/unchecked L4 csum - add PKT_RX_L4_CKSUM_UNKNOWN
+flag to the indicated mbuf.
+
+Fixes: 1173fca25af9 ("ena: add polling-mode driver")
+Cc: stable@dpdk.org
+
+Change-Id: I9f1414741eb44ca289a8bfd11d7e66110c95040e
+Signed-off-by: Igor Chauskin <igorch@amazon.com>
+Reviewed-by: Maciej Bielski <mba@semihalf.com>
+Reviewed-by: Michal Krawczyk <mk@semihalf.com>
+---
+ drivers/net/ena/ena_ethdev.c | 10 ++++++++--
+ 1 file changed, 8 insertions(+), 2 deletions(-)
+
+diff --git a/drivers/net/ena/ena_ethdev.c b/drivers/net/ena/ena_ethdev.c
+index e49edfa79a..4f0618a16e 100644
+--- a/drivers/net/ena/ena_ethdev.c
++++ b/drivers/net/ena/ena_ethdev.c
+@@ -287,8 +287,14 @@ static inline void ena_rx_mbuf_prepare(struct rte_mbuf *mbuf,
+ 	else if (ena_rx_ctx->l3_proto == ENA_ETH_IO_L3_PROTO_IPV6)
+ 		packet_type |= RTE_PTYPE_L3_IPV6;
+ 
+-	if (unlikely(ena_rx_ctx->l4_csum_err))
+-		ol_flags |= PKT_RX_L4_CKSUM_BAD;
++	if (!ena_rx_ctx->l4_csum_checked)
++		ol_flags |= PKT_RX_L4_CKSUM_UNKNOWN;
++	else
++		if (unlikely(ena_rx_ctx->l4_csum_err) && !ena_rx_ctx->frag)
++			ol_flags |= PKT_RX_L4_CKSUM_BAD;
++		else
++			ol_flags |= PKT_RX_L4_CKSUM_UNKNOWN;
++
+ 	if (unlikely(ena_rx_ctx->l3_csum_err))
+ 		ol_flags |= PKT_RX_IP_CKSUM_BAD;
+ 
+-- 
+2.20.1
+

--- a/userspace/dpdk/19.05/0007-net-ena-ensure-Rx-buffer-size-is-at-least-1400B.patch
+++ b/userspace/dpdk/19.05/0007-net-ena-ensure-Rx-buffer-size-is-at-least-1400B.patch
@@ -1,0 +1,84 @@
+From aa6431c024376df78bb556420808917487bca982 Mon Sep 17 00:00:00 2001
+From: Michal Krawczyk <mk@semihalf.com>
+Date: Wed, 8 Apr 2020 10:28:52 +0200
+Subject: [PATCH 07/13] net/ena: ensure Rx buffer size is at least 1400B
+
+[ upstream commit 38364c2687ead97b99402310087c27131a97748c ]
+
+Some of the ENA devices can't handle buffers which are smaller than a
+1400B. Because of this limitation, size of the buffer is being checked
+and limited during the Rx queue setup.
+
+If it's below the allowed value, PMD won't finish it's configuration
+successfully..
+
+Change-Id: Ib402d3bfad98a3fc4f91095d5c6f90c6069da021
+Signed-off-by: Michal Krawczyk <mk@semihalf.com>
+Reviewed-by: Igor Chauskin <igorch@amazon.com>
+Reviewed-by: Guy Tzalik <gtzalik@amazon.com>
+---
+ drivers/net/ena/ena_ethdev.c | 12 +++++++++++-
+ drivers/net/ena/ena_ethdev.h |  3 ++-
+ 2 files changed, 13 insertions(+), 2 deletions(-)
+
+diff --git a/drivers/net/ena/ena_ethdev.c b/drivers/net/ena/ena_ethdev.c
+index 4f0618a16e..a01c0a0d46 100644
+--- a/drivers/net/ena/ena_ethdev.c
++++ b/drivers/net/ena/ena_ethdev.c
+@@ -1,7 +1,7 @@
+ /*-
+ * BSD LICENSE
+ *
+-* Copyright (c) 2015-2016 Amazon.com, Inc. or its affiliates.
++* Copyright (c) 2015-2020 Amazon.com, Inc. or its affiliates.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+@@ -1307,6 +1307,7 @@ static int ena_rx_queue_setup(struct rte_eth_dev *dev,
+ 	struct ena_adapter *adapter =
+ 		(struct ena_adapter *)(dev->data->dev_private);
+ 	struct ena_ring *rxq = NULL;
++	size_t buffer_size;
+ 	int i;
+ 
+ 	rxq = &adapter->rx_ring[queue_idx];
+@@ -1334,6 +1335,15 @@ static int ena_rx_queue_setup(struct rte_eth_dev *dev,
+ 		return -EINVAL;
+ 	}
+ 
++	/* ENA isn't supporting buffers smaller than 1400 bytes */
++	buffer_size = rte_pktmbuf_data_room_size(mp) - RTE_PKTMBUF_HEADROOM;
++	if (buffer_size < ENA_RX_BUF_MIN_SIZE) {
++		PMD_DRV_LOG(ERR,
++			"Unsupported size of RX buffer: %zu (min size: %d)\n",
++			buffer_size, ENA_RX_BUF_MIN_SIZE);
++		return -EINVAL;
++	}
++
+ 	rxq->port_id = dev->data->port_id;
+ 	rxq->next_to_clean = 0;
+ 	rxq->next_to_use = 0;
+diff --git a/drivers/net/ena/ena_ethdev.h b/drivers/net/ena/ena_ethdev.h
+index fafaed428e..3e2ed177e5 100644
+--- a/drivers/net/ena/ena_ethdev.h
++++ b/drivers/net/ena/ena_ethdev.h
+@@ -1,7 +1,7 @@
+ /*-
+ * BSD LICENSE
+ *
+-* Copyright (c) 2015-2016 Amazon.com, Inc. or its affiliates.
++* Copyright (c) 2015-2020 Amazon.com, Inc. or its affiliates.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+@@ -48,6 +48,7 @@
+ #define ENA_MIN_FRAME_LEN	64
+ #define ENA_NAME_MAX_LEN	20
+ #define ENA_PKT_MAX_BUFS	17
++#define ENA_RX_BUF_MIN_SIZE	1400
+ 
+ #define ENA_MIN_MTU		128
+ 
+-- 
+2.20.1
+

--- a/userspace/dpdk/19.05/0008-net-ena-base-make-allocation-macros-thread-safe.patch
+++ b/userspace/dpdk/19.05/0008-net-ena-base-make-allocation-macros-thread-safe.patch
@@ -1,0 +1,80 @@
+From 409268b6742eca24aad5d962be98e7e6882f2dab Mon Sep 17 00:00:00 2001
+From: Igor Chauskin <igorch@amazon.com>
+Date: Wed, 8 Apr 2020 10:28:53 +0200
+Subject: [PATCH 08/13] net/ena/base: make allocation macros thread-safe
+
+[ upstream commit b14fcac035fd8514851c9140a4e26d765b61c532 ]
+
+Memory allocation region id could possibly be non-unique
+due to non-atomic increment, causing allocation failure.
+
+Fixes: 9ba7981ec992 ("ena: add communication layer for DPDK")
+Cc: stable@dpdk.org
+
+Change-Id: Ib9207aaae4e5e7ecdf1a99a0f23a508a53af631d
+Signed-off-by: Igor Chauskin <igorch@amazon.com>
+Reviewed-by: Michal Krawczyk <mk@semihalf.com>
+Reviewed-by: Guy Tzalik <gtzalik@amazon.com>
+---
+ drivers/net/ena/base/ena_plat_dpdk.h | 10 ++++++----
+ drivers/net/ena/ena_ethdev.c         |  2 +-
+ 2 files changed, 7 insertions(+), 5 deletions(-)
+
+diff --git a/drivers/net/ena/base/ena_plat_dpdk.h b/drivers/net/ena/base/ena_plat_dpdk.h
+index 902d91efbe..870764d239 100644
+--- a/drivers/net/ena/base/ena_plat_dpdk.h
++++ b/drivers/net/ena/base/ena_plat_dpdk.h
+@@ -1,7 +1,7 @@
+ /*-
+ * BSD LICENSE
+ *
+-* Copyright (c) 2015-2016 Amazon.com, Inc. or its affiliates.
++* Copyright (c) 2015-2020 Amazon.com, Inc. or its affiliates.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+@@ -204,7 +204,7 @@ do {                                                                   \
+  * Each rte_memzone should have unique name.
+  * To satisfy it, count number of allocations and add it to name.
+  */
+-extern uint32_t ena_alloc_cnt;
++extern rte_atomic32_t ena_alloc_cnt;
+ 
+ #define ENA_MEM_ALLOC_COHERENT(dmadev, size, virt, phys, handle)	\
+ 	do {								\
+@@ -212,7 +212,8 @@ extern uint32_t ena_alloc_cnt;
+ 		char z_name[RTE_MEMZONE_NAMESIZE];			\
+ 		ENA_TOUCH(dmadev); ENA_TOUCH(handle);			\
+ 		snprintf(z_name, sizeof(z_name),			\
+-				"ena_alloc_%d", ena_alloc_cnt++);	\
++			 "ena_alloc_%d",				\
++			 rte_atomic32_add_return(&ena_alloc_cnt, 1));	\
+ 		mz = rte_memzone_reserve(z_name, size, SOCKET_ID_ANY,	\
+ 				RTE_MEMZONE_IOVA_CONTIG);		\
+ 		handle = mz;						\
+@@ -237,7 +238,8 @@ extern uint32_t ena_alloc_cnt;
+ 		char z_name[RTE_MEMZONE_NAMESIZE];			\
+ 		ENA_TOUCH(dmadev); ENA_TOUCH(dev_node);			\
+ 		snprintf(z_name, sizeof(z_name),			\
+-				"ena_alloc_%d", ena_alloc_cnt++);	\
++			 "ena_alloc_%d",				\
++			 rte_atomic32_add_return(&ena_alloc_cnt, 1));	\
+ 		mz = rte_memzone_reserve(z_name, size, node,		\
+ 				RTE_MEMZONE_IOVA_CONTIG);		\
+ 		mem_handle = mz;					\
+diff --git a/drivers/net/ena/ena_ethdev.c b/drivers/net/ena/ena_ethdev.c
+index a01c0a0d46..f9c45f60c2 100644
+--- a/drivers/net/ena/ena_ethdev.c
++++ b/drivers/net/ena/ena_ethdev.c
+@@ -117,7 +117,7 @@ struct ena_stats {
+  * Each rte_memzone should have unique name.
+  * To satisfy it, count number of allocation and add it to name.
+  */
+-uint32_t ena_alloc_cnt;
++rte_atomic32_t ena_alloc_cnt;
+ 
+ static const struct ena_stats ena_stats_global_strings[] = {
+ 	ENA_STAT_GLOBAL_ENTRY(wd_expired),
+-- 
+2.20.1
+

--- a/userspace/dpdk/19.05/0009-net-ena-base-prevent-allocation-of-zero-sized-memory.patch
+++ b/userspace/dpdk/19.05/0009-net-ena-base-prevent-allocation-of-zero-sized-memory.patch
@@ -1,0 +1,77 @@
+From 0d7d1102aa9b283d6f1c7410d331a4f442ef8642 Mon Sep 17 00:00:00 2001
+From: Igor Chauskin <igorch@amazon.com>
+Date: Wed, 8 Apr 2020 10:28:54 +0200
+Subject: [PATCH 09/13] net/ena/base: prevent allocation of zero sized memory
+
+[ upstream commit 29dc10d9424ccf26a346387b0a707185e2432400 ]
+
+rte_memzone_reserve() will reserve the biggest contiguous memzone
+available if received 0 as size param.
+
+Fixes: 9ba7981ec992 ("ena: add communication layer for DPDK")
+Cc: stable@dpdk.org
+
+Change-Id: I2f71119e93c5e9addd8c538820093f030066d690
+Signed-off-by: Igor Chauskin <igorch@amazon.com>
+Reviewed-by: Michal Krawczyk <mk@semihalf.com>
+Reviewed-by: Guy Tzalik <gtzalik@amazon.com>
+---
+ drivers/net/ena/base/ena_plat_dpdk.h | 29 ++++++++++++++++------------
+ 1 file changed, 17 insertions(+), 12 deletions(-)
+
+diff --git a/drivers/net/ena/base/ena_plat_dpdk.h b/drivers/net/ena/base/ena_plat_dpdk.h
+index 870764d239..3b783471bd 100644
+--- a/drivers/net/ena/base/ena_plat_dpdk.h
++++ b/drivers/net/ena/base/ena_plat_dpdk.h
+@@ -208,15 +208,18 @@ extern rte_atomic32_t ena_alloc_cnt;
+ 
+ #define ENA_MEM_ALLOC_COHERENT(dmadev, size, virt, phys, handle)	\
+ 	do {								\
+-		const struct rte_memzone *mz;				\
+-		char z_name[RTE_MEMZONE_NAMESIZE];			\
++		const struct rte_memzone *mz = NULL;			\
+ 		ENA_TOUCH(dmadev); ENA_TOUCH(handle);			\
+-		snprintf(z_name, sizeof(z_name),			\
++		if (size > 0) {						\
++			char z_name[RTE_MEMZONE_NAMESIZE];		\
++			snprintf(z_name, sizeof(z_name),		\
+ 			 "ena_alloc_%d",				\
+ 			 rte_atomic32_add_return(&ena_alloc_cnt, 1));	\
+-		mz = rte_memzone_reserve(z_name, size, SOCKET_ID_ANY,	\
+-				RTE_MEMZONE_IOVA_CONTIG);		\
+-		handle = mz;						\
++			mz = rte_memzone_reserve(z_name, size,		\
++					SOCKET_ID_ANY,			\
++					RTE_MEMZONE_IOVA_CONTIG);	\
++			handle = mz;					\
++		}							\
+ 		if (mz == NULL) {					\
+ 			virt = NULL;					\
+ 			phys = 0;					\
+@@ -234,15 +237,17 @@ extern rte_atomic32_t ena_alloc_cnt;
+ #define ENA_MEM_ALLOC_COHERENT_NODE(					\
+ 	dmadev, size, virt, phys, mem_handle, node, dev_node)		\
+ 	do {								\
+-		const struct rte_memzone *mz;				\
+-		char z_name[RTE_MEMZONE_NAMESIZE];			\
++		const struct rte_memzone *mz = NULL;			\
+ 		ENA_TOUCH(dmadev); ENA_TOUCH(dev_node);			\
+-		snprintf(z_name, sizeof(z_name),			\
++		if (size > 0) {						\
++			char z_name[RTE_MEMZONE_NAMESIZE];		\
++			snprintf(z_name, sizeof(z_name),		\
+ 			 "ena_alloc_%d",				\
+-			 rte_atomic32_add_return(&ena_alloc_cnt, 1));	\
+-		mz = rte_memzone_reserve(z_name, size, node,		\
++			 rte_atomic32_add_return(&ena_alloc_cnt, 1));   \
++			mz = rte_memzone_reserve(z_name, size, node,	\
+ 				RTE_MEMZONE_IOVA_CONTIG);		\
+-		mem_handle = mz;					\
++			mem_handle = mz;				\
++		}							\
+ 		if (mz == NULL) {					\
+ 			virt = NULL;					\
+ 			phys = 0;					\
+-- 
+2.20.1
+

--- a/userspace/dpdk/19.05/0010-net-ena-set-IO-ring-size-to-valid-value.patch
+++ b/userspace/dpdk/19.05/0010-net-ena-set-IO-ring-size-to-valid-value.patch
@@ -1,0 +1,49 @@
+From 8560b499fddf1c6d5330d85c442fd0dedcc98c48 Mon Sep 17 00:00:00 2001
+From: Michal Krawczyk <mk@semihalf.com>
+Date: Wed, 8 Apr 2020 10:29:08 +0200
+Subject: [PATCH 10/13] net/ena: set IO ring size to valid value
+
+[ upstream commit badc3a6aa133a886a61b9e3ad666e5675f7ec3d3 ]
+
+IO rings were configured with the maximum allowed size for the Tx/Rx
+rings. However, the application could decide to create smaller rings.
+
+This patch is using value stored in the ring instead of the value from
+the adapter which is indicating the maximum allowed value.
+
+Fixes: df238f84c0a2 ("net/ena: recreate HW IO rings on start and stop")
+Cc: stable@dpdk.org
+
+Change-Id: Icf9102e2aa4e7413b6620b36dd232673239b7291
+Signed-off-by: Michal Krawczyk <mk@semihalf.com>
+Reviewed-by: Igor Chauskin <igorch@amazon.com>
+Reviewed-by: Guy Tzalik <gtzalik@amazon.com>
+---
+ drivers/net/ena/ena_ethdev.c | 3 +--
+ 1 file changed, 1 insertion(+), 2 deletions(-)
+
+diff --git a/drivers/net/ena/ena_ethdev.c b/drivers/net/ena/ena_ethdev.c
+index f9c45f60c2..81ce943cea 100644
+--- a/drivers/net/ena/ena_ethdev.c
++++ b/drivers/net/ena/ena_ethdev.c
+@@ -1104,16 +1104,15 @@ static int ena_create_io_queue(struct ena_ring *ring)
+ 		ena_qid = ENA_IO_TXQ_IDX(ring->id);
+ 		ctx.direction = ENA_COM_IO_QUEUE_DIRECTION_TX;
+ 		ctx.mem_queue_type = ena_dev->tx_mem_queue_type;
+-		ctx.queue_size = adapter->tx_ring_size;
+ 		for (i = 0; i < ring->ring_size; i++)
+ 			ring->empty_tx_reqs[i] = i;
+ 	} else {
+ 		ena_qid = ENA_IO_RXQ_IDX(ring->id);
+ 		ctx.direction = ENA_COM_IO_QUEUE_DIRECTION_RX;
+-		ctx.queue_size = adapter->rx_ring_size;
+ 		for (i = 0; i < ring->ring_size; i++)
+ 			ring->empty_rx_reqs[i] = i;
+ 	}
++	ctx.queue_size = ring->ring_size;
+ 	ctx.qid = ena_qid;
+ 	ctx.msix_vector = -1; /* interrupts not used */
+ 	ctx.numa_node = ring->numa_socket_id;
+-- 
+2.20.1
+

--- a/userspace/dpdk/19.05/0011-net-ena-remove-memory-barriers-before-doorbells.patch
+++ b/userspace/dpdk/19.05/0011-net-ena-remove-memory-barriers-before-doorbells.patch
@@ -1,0 +1,56 @@
+From 8038953a6e9ecdc7aad7832f22a5f7af273f161a Mon Sep 17 00:00:00 2001
+From: Michal Krawczyk <mk@semihalf.com>
+Date: Wed, 8 Apr 2020 10:29:11 +0200
+Subject: [PATCH 11/13] net/ena: remove memory barriers before doorbells
+
+[ upstream commit 38faa87eb8873e04ccef8fcaea4aaf3ad125fc83 ]
+
+The doorbell code is already issuing the doorbell by using rte_write.
+Because of that, there is no need to do that before calling the
+function.
+
+Change-Id: Ia9c348e485987bc618bc7e89bf7fa057cc240617
+Signed-off-by: Michal Krawczyk <mk@semihalf.com>
+Reviewed-by: Igor Chauskin <igorch@amazon.com>
+Reviewed-by: Guy Tzalik <gtzalik@amazon.com>
+---
+ drivers/net/ena/ena_ethdev.c | 9 +--------
+ 1 file changed, 1 insertion(+), 8 deletions(-)
+
+diff --git a/drivers/net/ena/ena_ethdev.c b/drivers/net/ena/ena_ethdev.c
+index 81ce943cea..b4759ff7ff 100644
+--- a/drivers/net/ena/ena_ethdev.c
++++ b/drivers/net/ena/ena_ethdev.c
+@@ -1454,12 +1454,7 @@ static int ena_populate_rx_queue(struct ena_ring *rxq, unsigned int count)
+ 
+ 	/* When we submitted free recources to device... */
+ 	if (likely(i > 0)) {
+-		/* ...let HW know that it can fill buffers with data
+-		 *
+-		 * Add memory barrier to make sure the desc were written before
+-		 * issue a doorbell
+-		 */
+-		rte_wmb();
++		/* ...let HW know that it can fill buffers with data. */
+ 		ena_com_write_sq_doorbell(rxq->ena_com_io_sq);
+ 
+ 		rxq->next_to_use = next_to_use;
+@@ -2376,7 +2371,6 @@ static uint16_t eth_ena_xmit_pkts(void *tx_queue, struct rte_mbuf **tx_pkts,
+ 			RTE_LOG(DEBUG, PMD, "llq tx max burst size of queue %d"
+ 				" achieved, writing doorbell to send burst\n",
+ 				tx_ring->id);
+-			rte_wmb();
+ 			ena_com_write_sq_doorbell(tx_ring->ena_com_io_sq);
+ 		}
+ 
+@@ -2399,7 +2393,6 @@ static uint16_t eth_ena_xmit_pkts(void *tx_queue, struct rte_mbuf **tx_pkts,
+ 	/* If there are ready packets to be xmitted... */
+ 	if (sent_idx > 0) {
+ 		/* ...let HW do its best :-) */
+-		rte_wmb();
+ 		ena_com_write_sq_doorbell(tx_ring->ena_com_io_sq);
+ 		tx_ring->tx_stats.doorbells++;
+ 		tx_ring->next_to_use = next_to_use;
+-- 
+2.20.1
+

--- a/userspace/dpdk/19.05/0012-net-ena-limit-refill-threshold-by-fixed-value.patch
+++ b/userspace/dpdk/19.05/0012-net-ena-limit-refill-threshold-by-fixed-value.patch
@@ -1,0 +1,118 @@
+From 2cf3e6fb32cfff1a5ed676c12d9f42bfe5cc2d61 Mon Sep 17 00:00:00 2001
+From: Michal Krawczyk <mk@semihalf.com>
+Date: Wed, 8 Apr 2020 10:29:16 +0200
+Subject: [PATCH 12/13] net/ena: limit refill threshold by fixed value
+
+[ upstream commit 7755060798de9c0146df8809926030ed47fc9086 ]
+
+Divider used for both Tx and Rx cleanup/refill threshold can cause too
+big delay in case of the really big rings - for example if the 8k Rx
+ring will be used, the refill won't trigger unless 1024 threshold will
+be reached. It will also cause driver to try to allocate that much
+descriptors.
+
+Limiting it by fixed value - 256 in that case, would limit maximum
+time spent in repopulate function.
+
+Change-Id: Ia8659e6ddf179ff612a780adc6fe55d13eeac6e9
+Signed-off-by: Michal Krawczyk <mk@semihalf.com>
+Reviewed-by: Igor Chauskin <igorch@amazon.com>
+Reviewed-by: Guy Tzalik <gtzalik@amazon.com>
+---
+ drivers/net/ena/ena_ethdev.c | 26 ++++++++++++++------------
+ drivers/net/ena/ena_ethdev.h | 10 ++++++++++
+ 2 files changed, 24 insertions(+), 12 deletions(-)
+
+diff --git a/drivers/net/ena/ena_ethdev.c b/drivers/net/ena/ena_ethdev.c
+index b4759ff7ff..8c8ea50271 100644
+--- a/drivers/net/ena/ena_ethdev.c
++++ b/drivers/net/ena/ena_ethdev.c
+@@ -62,14 +62,6 @@
+ /*reverse version of ENA_IO_RXQ_IDX*/
+ #define ENA_IO_RXQ_IDX_REV(q)	((q - 1) / 2)
+ 
+-/* While processing submitted and completed descriptors (rx and tx path
+- * respectively) in a loop it is desired to:
+- *  - perform batch submissions while populating sumbissmion queue
+- *  - avoid blocking transmission of other packets during cleanup phase
+- * Hence the utilization ratio of 1/8 of a queue size.
+- */
+-#define ENA_RING_DESCS_RATIO(ring_size)	(ring_size / 8)
+-
+ #define __MERGE_64B_H_L(h, l) (((uint64_t)h << 32) | l)
+ #define TEST_BIT(val, bit_shift) (val & (1UL << bit_shift))
+ 
+@@ -2015,6 +2007,8 @@ static uint16_t eth_ena_recv_pkts(void *rx_queue, struct rte_mbuf **rx_pkts,
+ 	struct ena_ring *rx_ring = (struct ena_ring *)(rx_queue);
+ 	unsigned int ring_size = rx_ring->ring_size;
+ 	unsigned int ring_mask = ring_size - 1;
++	unsigned int free_queue_entries;
++	unsigned int refill_threshold;
+ 	uint16_t next_to_clean = rx_ring->next_to_clean;
+ 	uint16_t desc_in_use = 0;
+ 	uint16_t req_id;
+@@ -2116,11 +2110,15 @@ static uint16_t eth_ena_recv_pkts(void *rx_queue, struct rte_mbuf **rx_pkts,
+ 	rx_ring->rx_stats.cnt += recv_idx;
+ 	rx_ring->next_to_clean = next_to_clean;
+ 
+-	desc_in_use = desc_in_use - completed + 1;
++	free_queue_entries = ena_com_free_desc(rx_ring->ena_com_io_sq);
++	refill_threshold =
++		RTE_MIN(ring_size / ENA_REFILL_THRESH_DIVIDER,
++		(unsigned int)ENA_REFILL_THRESH_PACKET);
++
+ 	/* Burst refill to save doorbells, memory barriers, const interval */
+-	if (ring_size - desc_in_use > ENA_RING_DESCS_RATIO(ring_size)) {
++	if (free_queue_entries > refill_threshold) {
+ 		ena_com_update_dev_comp_head(rx_ring->ena_com_io_cq);
+-		ena_populate_rx_queue(rx_ring, ring_size - desc_in_use);
++		ena_populate_rx_queue(rx_ring, free_queue_entries);
+ 	}
+ 
+ 	return recv_idx;
+@@ -2259,6 +2257,7 @@ static uint16_t eth_ena_xmit_pkts(void *tx_queue, struct rte_mbuf **tx_pkts,
+ 	uint16_t seg_len;
+ 	unsigned int ring_size = tx_ring->ring_size;
+ 	unsigned int ring_mask = ring_size - 1;
++	unsigned int cleanup_budget;
+ 	struct ena_com_tx_ctx ena_tx_ctx;
+ 	struct ena_tx_buffer *tx_info;
+ 	struct ena_com_buf *ebuf;
+@@ -2416,9 +2415,12 @@ static uint16_t eth_ena_xmit_pkts(void *tx_queue, struct rte_mbuf **tx_pkts,
+ 		/* Put back descriptor to the ring for reuse */
+ 		tx_ring->empty_tx_reqs[next_to_clean & ring_mask] = req_id;
+ 		next_to_clean++;
++		cleanup_budget =
++			RTE_MIN(ring_size / ENA_REFILL_THRESH_DIVIDER,
++			(unsigned int)ENA_REFILL_THRESH_PACKET);
+ 
+ 		/* If too many descs to clean, leave it for another run */
+-		if (unlikely(total_tx_descs > ENA_RING_DESCS_RATIO(ring_size)))
++		if (unlikely(total_tx_descs > cleanup_budget))
+ 			break;
+ 	}
+ 	tx_ring->tx_stats.available_desc =
+diff --git a/drivers/net/ena/ena_ethdev.h b/drivers/net/ena/ena_ethdev.h
+index 3e2ed177e5..8a7de86805 100644
+--- a/drivers/net/ena/ena_ethdev.h
++++ b/drivers/net/ena/ena_ethdev.h
+@@ -57,6 +57,16 @@
+ #define ENA_WD_TIMEOUT_SEC	3
+ #define ENA_DEVICE_KALIVE_TIMEOUT (ENA_WD_TIMEOUT_SEC * rte_get_timer_hz())
+ 
++/* While processing submitted and completed descriptors (rx and tx path
++ * respectively) in a loop it is desired to:
++ *  - perform batch submissions while populating sumbissmion queue
++ *  - avoid blocking transmission of other packets during cleanup phase
++ * Hence the utilization ratio of 1/8 of a queue size or max value if the size
++ * of the ring is very big - like 8k Rx rings.
++ */
++#define ENA_REFILL_THRESH_DIVIDER      8
++#define ENA_REFILL_THRESH_PACKET       256
++
+ struct ena_adapter;
+ 
+ enum ena_ring_type {
+-- 
+2.20.1
+

--- a/userspace/dpdk/19.05/0013-net-ena-fix-build-for-O1-optimization.patch
+++ b/userspace/dpdk/19.05/0013-net-ena-fix-build-for-O1-optimization.patch
@@ -1,0 +1,47 @@
+From 8b9af923431273866282415e0903b597e011f6d4 Mon Sep 17 00:00:00 2001
+From: Ferruh Yigit <ferruh.yigit@intel.com>
+Date: Mon, 11 May 2020 17:07:24 +0100
+Subject: [PATCH 13/13] net/ena: fix build for O1 optimization
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+[ upstream commit 5f267cb01b41def2af37b8fa56828e75ae91add0 ]
+
+Can be reproduced with "make EXTRA_CFLAGS='-O1'" command using
+gcc (GCC) 9.3.1 20200408 (Red Hat 9.3.1-2)
+
+Build error:
+.../drivers/net/ena/ena_ethdev.c: In function ‘eth_ena_dev_init’:
+.../drivers/net/ena/ena_ethdev.c:1815:20:
+    error: ‘wd_state’ may be used uninitialized in this function
+           [-Werror=maybe-uninitialized]
+ 1815 |  adapter->wd_state = wd_state;
+      |  ~~~~~~~~~~~~~~~~~~^~~~~~~~~~
+
+This looks like false positive, fixing by assigning initial value to
+'wd_state' variable.
+
+Change-Id: I68bd21d4e2a4b41466e670e282856d4f072dadc0
+Signed-off-by: Ferruh Yigit <ferruh.yigit@intel.com>
+Acked-by: Michal Krawczyk <mk@semihalf.com>
+---
+ drivers/net/ena/ena_ethdev.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/drivers/net/ena/ena_ethdev.c b/drivers/net/ena/ena_ethdev.c
+index 8c8ea50271..a340a45b32 100644
+--- a/drivers/net/ena/ena_ethdev.c
++++ b/drivers/net/ena/ena_ethdev.c
+@@ -1700,7 +1700,7 @@ static int eth_ena_dev_init(struct rte_eth_dev *eth_dev)
+ 	int rc;
+ 
+ 	static int adapters_found;
+-	bool wd_state;
++	bool wd_state = false;
+ 
+ 	eth_dev->dev_ops = &ena_dev_ops;
+ 	eth_dev->rx_pkt_burst = &eth_ena_recv_pkts;
+-- 
+2.20.1
+

--- a/userspace/dpdk/19.08/0001-net-ena-fix-indication-of-bad-L4-Rx-checksums.patch
+++ b/userspace/dpdk/19.08/0001-net-ena-fix-indication-of-bad-L4-Rx-checksums.patch
@@ -1,0 +1,48 @@
+From bcc4e42dd44dad1040f3a94c97e01869ee644cac Mon Sep 17 00:00:00 2001
+From: Igor Chauskin <igorch@amazon.com>
+Date: Mon, 28 Oct 2019 11:23:33 +0100
+Subject: [PATCH 1/8] net/ena: fix indication of bad L4 Rx checksums
+
+[ upstream commit 05817057faba9356900ced61e24a22eef6bc4c87 ]
+
+Add checking of l4_csum_checked and frag flags before checking the
+l4_csum_error flag.
+
+In case of IP fragment/unchecked L4 csum - add PKT_RX_L4_CKSUM_UNKNOWN
+flag to the indicated mbuf.
+
+Fixes: 1173fca25af9 ("ena: add polling-mode driver")
+Cc: stable@dpdk.org
+
+Change-Id: I9f1414741eb44ca289a8bfd11d7e66110c95040e
+Signed-off-by: Igor Chauskin <igorch@amazon.com>
+Reviewed-by: Maciej Bielski <mba@semihalf.com>
+Reviewed-by: Michal Krawczyk <mk@semihalf.com>
+---
+ drivers/net/ena/ena_ethdev.c | 10 ++++++++--
+ 1 file changed, 8 insertions(+), 2 deletions(-)
+
+diff --git a/drivers/net/ena/ena_ethdev.c b/drivers/net/ena/ena_ethdev.c
+index 7d4a3b225e..7a0b750541 100644
+--- a/drivers/net/ena/ena_ethdev.c
++++ b/drivers/net/ena/ena_ethdev.c
+@@ -287,8 +287,14 @@ static inline void ena_rx_mbuf_prepare(struct rte_mbuf *mbuf,
+ 	else if (ena_rx_ctx->l3_proto == ENA_ETH_IO_L3_PROTO_IPV6)
+ 		packet_type |= RTE_PTYPE_L3_IPV6;
+ 
+-	if (unlikely(ena_rx_ctx->l4_csum_err))
+-		ol_flags |= PKT_RX_L4_CKSUM_BAD;
++	if (!ena_rx_ctx->l4_csum_checked)
++		ol_flags |= PKT_RX_L4_CKSUM_UNKNOWN;
++	else
++		if (unlikely(ena_rx_ctx->l4_csum_err) && !ena_rx_ctx->frag)
++			ol_flags |= PKT_RX_L4_CKSUM_BAD;
++		else
++			ol_flags |= PKT_RX_L4_CKSUM_UNKNOWN;
++
+ 	if (unlikely(ena_rx_ctx->l3_csum_err))
+ 		ol_flags |= PKT_RX_IP_CKSUM_BAD;
+ 
+-- 
+2.20.1
+

--- a/userspace/dpdk/19.08/0002-net-ena-ensure-Rx-buffer-size-is-at-least-1400B.patch
+++ b/userspace/dpdk/19.08/0002-net-ena-ensure-Rx-buffer-size-is-at-least-1400B.patch
@@ -1,0 +1,84 @@
+From f9cb9e25690aac459329e31bd8986badbefd1380 Mon Sep 17 00:00:00 2001
+From: Michal Krawczyk <mk@semihalf.com>
+Date: Wed, 8 Apr 2020 10:28:52 +0200
+Subject: [PATCH 2/8] net/ena: ensure Rx buffer size is at least 1400B
+
+[ upstream commit 38364c2687ead97b99402310087c27131a97748c ]
+
+Some of the ENA devices can't handle buffers which are smaller than a
+1400B. Because of this limitation, size of the buffer is being checked
+and limited during the Rx queue setup.
+
+If it's below the allowed value, PMD won't finish it's configuration
+successfully..
+
+Change-Id: Ib402d3bfad98a3fc4f91095d5c6f90c6069da021
+Signed-off-by: Michal Krawczyk <mk@semihalf.com>
+Reviewed-by: Igor Chauskin <igorch@amazon.com>
+Reviewed-by: Guy Tzalik <gtzalik@amazon.com>
+---
+ drivers/net/ena/ena_ethdev.c | 12 +++++++++++-
+ drivers/net/ena/ena_ethdev.h |  3 ++-
+ 2 files changed, 13 insertions(+), 2 deletions(-)
+
+diff --git a/drivers/net/ena/ena_ethdev.c b/drivers/net/ena/ena_ethdev.c
+index 7a0b750541..3c8bc91a97 100644
+--- a/drivers/net/ena/ena_ethdev.c
++++ b/drivers/net/ena/ena_ethdev.c
+@@ -1,7 +1,7 @@
+ /*-
+ * BSD LICENSE
+ *
+-* Copyright (c) 2015-2016 Amazon.com, Inc. or its affiliates.
++* Copyright (c) 2015-2020 Amazon.com, Inc. or its affiliates.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+@@ -1294,6 +1294,7 @@ static int ena_rx_queue_setup(struct rte_eth_dev *dev,
+ {
+ 	struct ena_adapter *adapter = dev->data->dev_private;
+ 	struct ena_ring *rxq = NULL;
++	size_t buffer_size;
+ 	int i;
+ 
+ 	rxq = &adapter->rx_ring[queue_idx];
+@@ -1321,6 +1322,15 @@ static int ena_rx_queue_setup(struct rte_eth_dev *dev,
+ 		return -EINVAL;
+ 	}
+ 
++	/* ENA isn't supporting buffers smaller than 1400 bytes */
++	buffer_size = rte_pktmbuf_data_room_size(mp) - RTE_PKTMBUF_HEADROOM;
++	if (buffer_size < ENA_RX_BUF_MIN_SIZE) {
++		PMD_DRV_LOG(ERR,
++			"Unsupported size of RX buffer: %zu (min size: %d)\n",
++			buffer_size, ENA_RX_BUF_MIN_SIZE);
++		return -EINVAL;
++	}
++
+ 	rxq->port_id = dev->data->port_id;
+ 	rxq->next_to_clean = 0;
+ 	rxq->next_to_use = 0;
+diff --git a/drivers/net/ena/ena_ethdev.h b/drivers/net/ena/ena_ethdev.h
+index 9067e9007f..dd87e11397 100644
+--- a/drivers/net/ena/ena_ethdev.h
++++ b/drivers/net/ena/ena_ethdev.h
+@@ -1,7 +1,7 @@
+ /*-
+ * BSD LICENSE
+ *
+-* Copyright (c) 2015-2016 Amazon.com, Inc. or its affiliates.
++* Copyright (c) 2015-2020 Amazon.com, Inc. or its affiliates.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+@@ -48,6 +48,7 @@
+ #define ENA_MIN_FRAME_LEN	64
+ #define ENA_NAME_MAX_LEN	20
+ #define ENA_PKT_MAX_BUFS	17
++#define ENA_RX_BUF_MIN_SIZE	1400
+ 
+ #define ENA_MIN_MTU		128
+ 
+-- 
+2.20.1
+

--- a/userspace/dpdk/19.08/0003-net-ena-base-make-allocation-macros-thread-safe.patch
+++ b/userspace/dpdk/19.08/0003-net-ena-base-make-allocation-macros-thread-safe.patch
@@ -1,0 +1,80 @@
+From d6a97360bf3c2653112865335862c087871d978f Mon Sep 17 00:00:00 2001
+From: Igor Chauskin <igorch@amazon.com>
+Date: Wed, 8 Apr 2020 10:28:53 +0200
+Subject: [PATCH 3/8] net/ena/base: make allocation macros thread-safe
+
+[ upstream commit b14fcac035fd8514851c9140a4e26d765b61c532 ]
+
+Memory allocation region id could possibly be non-unique
+due to non-atomic increment, causing allocation failure.
+
+Fixes: 9ba7981ec992 ("ena: add communication layer for DPDK")
+Cc: stable@dpdk.org
+
+Change-Id: Ib9207aaae4e5e7ecdf1a99a0f23a508a53af631d
+Signed-off-by: Igor Chauskin <igorch@amazon.com>
+Reviewed-by: Michal Krawczyk <mk@semihalf.com>
+Reviewed-by: Guy Tzalik <gtzalik@amazon.com>
+---
+ drivers/net/ena/base/ena_plat_dpdk.h | 10 ++++++----
+ drivers/net/ena/ena_ethdev.c         |  2 +-
+ 2 files changed, 7 insertions(+), 5 deletions(-)
+
+diff --git a/drivers/net/ena/base/ena_plat_dpdk.h b/drivers/net/ena/base/ena_plat_dpdk.h
+index 902d91efbe..870764d239 100644
+--- a/drivers/net/ena/base/ena_plat_dpdk.h
++++ b/drivers/net/ena/base/ena_plat_dpdk.h
+@@ -1,7 +1,7 @@
+ /*-
+ * BSD LICENSE
+ *
+-* Copyright (c) 2015-2016 Amazon.com, Inc. or its affiliates.
++* Copyright (c) 2015-2020 Amazon.com, Inc. or its affiliates.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+@@ -204,7 +204,7 @@ do {                                                                   \
+  * Each rte_memzone should have unique name.
+  * To satisfy it, count number of allocations and add it to name.
+  */
+-extern uint32_t ena_alloc_cnt;
++extern rte_atomic32_t ena_alloc_cnt;
+ 
+ #define ENA_MEM_ALLOC_COHERENT(dmadev, size, virt, phys, handle)	\
+ 	do {								\
+@@ -212,7 +212,8 @@ extern uint32_t ena_alloc_cnt;
+ 		char z_name[RTE_MEMZONE_NAMESIZE];			\
+ 		ENA_TOUCH(dmadev); ENA_TOUCH(handle);			\
+ 		snprintf(z_name, sizeof(z_name),			\
+-				"ena_alloc_%d", ena_alloc_cnt++);	\
++			 "ena_alloc_%d",				\
++			 rte_atomic32_add_return(&ena_alloc_cnt, 1));	\
+ 		mz = rte_memzone_reserve(z_name, size, SOCKET_ID_ANY,	\
+ 				RTE_MEMZONE_IOVA_CONTIG);		\
+ 		handle = mz;						\
+@@ -237,7 +238,8 @@ extern uint32_t ena_alloc_cnt;
+ 		char z_name[RTE_MEMZONE_NAMESIZE];			\
+ 		ENA_TOUCH(dmadev); ENA_TOUCH(dev_node);			\
+ 		snprintf(z_name, sizeof(z_name),			\
+-				"ena_alloc_%d", ena_alloc_cnt++);	\
++			 "ena_alloc_%d",				\
++			 rte_atomic32_add_return(&ena_alloc_cnt, 1));	\
+ 		mz = rte_memzone_reserve(z_name, size, node,		\
+ 				RTE_MEMZONE_IOVA_CONTIG);		\
+ 		mem_handle = mz;					\
+diff --git a/drivers/net/ena/ena_ethdev.c b/drivers/net/ena/ena_ethdev.c
+index 3c8bc91a97..deaad54fc7 100644
+--- a/drivers/net/ena/ena_ethdev.c
++++ b/drivers/net/ena/ena_ethdev.c
+@@ -117,7 +117,7 @@ struct ena_stats {
+  * Each rte_memzone should have unique name.
+  * To satisfy it, count number of allocation and add it to name.
+  */
+-uint32_t ena_alloc_cnt;
++rte_atomic32_t ena_alloc_cnt;
+ 
+ static const struct ena_stats ena_stats_global_strings[] = {
+ 	ENA_STAT_GLOBAL_ENTRY(wd_expired),
+-- 
+2.20.1
+

--- a/userspace/dpdk/19.08/0004-net-ena-base-prevent-allocation-of-zero-sized-memory.patch
+++ b/userspace/dpdk/19.08/0004-net-ena-base-prevent-allocation-of-zero-sized-memory.patch
@@ -1,0 +1,77 @@
+From 79b924cef785dd11cc48e534e4896f558a2a259c Mon Sep 17 00:00:00 2001
+From: Igor Chauskin <igorch@amazon.com>
+Date: Wed, 8 Apr 2020 10:28:54 +0200
+Subject: [PATCH 4/8] net/ena/base: prevent allocation of zero sized memory
+
+[ upstream commit 29dc10d9424ccf26a346387b0a707185e2432400 ]
+
+rte_memzone_reserve() will reserve the biggest contiguous memzone
+available if received 0 as size param.
+
+Fixes: 9ba7981ec992 ("ena: add communication layer for DPDK")
+Cc: stable@dpdk.org
+
+Change-Id: I2f71119e93c5e9addd8c538820093f030066d690
+Signed-off-by: Igor Chauskin <igorch@amazon.com>
+Reviewed-by: Michal Krawczyk <mk@semihalf.com>
+Reviewed-by: Guy Tzalik <gtzalik@amazon.com>
+---
+ drivers/net/ena/base/ena_plat_dpdk.h | 29 ++++++++++++++++------------
+ 1 file changed, 17 insertions(+), 12 deletions(-)
+
+diff --git a/drivers/net/ena/base/ena_plat_dpdk.h b/drivers/net/ena/base/ena_plat_dpdk.h
+index 870764d239..3b783471bd 100644
+--- a/drivers/net/ena/base/ena_plat_dpdk.h
++++ b/drivers/net/ena/base/ena_plat_dpdk.h
+@@ -208,15 +208,18 @@ extern rte_atomic32_t ena_alloc_cnt;
+ 
+ #define ENA_MEM_ALLOC_COHERENT(dmadev, size, virt, phys, handle)	\
+ 	do {								\
+-		const struct rte_memzone *mz;				\
+-		char z_name[RTE_MEMZONE_NAMESIZE];			\
++		const struct rte_memzone *mz = NULL;			\
+ 		ENA_TOUCH(dmadev); ENA_TOUCH(handle);			\
+-		snprintf(z_name, sizeof(z_name),			\
++		if (size > 0) {						\
++			char z_name[RTE_MEMZONE_NAMESIZE];		\
++			snprintf(z_name, sizeof(z_name),		\
+ 			 "ena_alloc_%d",				\
+ 			 rte_atomic32_add_return(&ena_alloc_cnt, 1));	\
+-		mz = rte_memzone_reserve(z_name, size, SOCKET_ID_ANY,	\
+-				RTE_MEMZONE_IOVA_CONTIG);		\
+-		handle = mz;						\
++			mz = rte_memzone_reserve(z_name, size,		\
++					SOCKET_ID_ANY,			\
++					RTE_MEMZONE_IOVA_CONTIG);	\
++			handle = mz;					\
++		}							\
+ 		if (mz == NULL) {					\
+ 			virt = NULL;					\
+ 			phys = 0;					\
+@@ -234,15 +237,17 @@ extern rte_atomic32_t ena_alloc_cnt;
+ #define ENA_MEM_ALLOC_COHERENT_NODE(					\
+ 	dmadev, size, virt, phys, mem_handle, node, dev_node)		\
+ 	do {								\
+-		const struct rte_memzone *mz;				\
+-		char z_name[RTE_MEMZONE_NAMESIZE];			\
++		const struct rte_memzone *mz = NULL;			\
+ 		ENA_TOUCH(dmadev); ENA_TOUCH(dev_node);			\
+-		snprintf(z_name, sizeof(z_name),			\
++		if (size > 0) {						\
++			char z_name[RTE_MEMZONE_NAMESIZE];		\
++			snprintf(z_name, sizeof(z_name),		\
+ 			 "ena_alloc_%d",				\
+-			 rte_atomic32_add_return(&ena_alloc_cnt, 1));	\
+-		mz = rte_memzone_reserve(z_name, size, node,		\
++			 rte_atomic32_add_return(&ena_alloc_cnt, 1));   \
++			mz = rte_memzone_reserve(z_name, size, node,	\
+ 				RTE_MEMZONE_IOVA_CONTIG);		\
+-		mem_handle = mz;					\
++			mem_handle = mz;				\
++		}							\
+ 		if (mz == NULL) {					\
+ 			virt = NULL;					\
+ 			phys = 0;					\
+-- 
+2.20.1
+

--- a/userspace/dpdk/19.08/0005-net-ena-set-IO-ring-size-to-valid-value.patch
+++ b/userspace/dpdk/19.08/0005-net-ena-set-IO-ring-size-to-valid-value.patch
@@ -1,0 +1,49 @@
+From 50f4f29f8bb2ed84096e3a16915970a99e167c65 Mon Sep 17 00:00:00 2001
+From: Michal Krawczyk <mk@semihalf.com>
+Date: Wed, 8 Apr 2020 10:29:08 +0200
+Subject: [PATCH 5/8] net/ena: set IO ring size to valid value
+
+[ upstream commit badc3a6aa133a886a61b9e3ad666e5675f7ec3d3 ]
+
+IO rings were configured with the maximum allowed size for the Tx/Rx
+rings. However, the application could decide to create smaller rings.
+
+This patch is using value stored in the ring instead of the value from
+the adapter which is indicating the maximum allowed value.
+
+Fixes: df238f84c0a2 ("net/ena: recreate HW IO rings on start and stop")
+Cc: stable@dpdk.org
+
+Change-Id: Icf9102e2aa4e7413b6620b36dd232673239b7291
+Signed-off-by: Michal Krawczyk <mk@semihalf.com>
+Reviewed-by: Igor Chauskin <igorch@amazon.com>
+Reviewed-by: Guy Tzalik <gtzalik@amazon.com>
+---
+ drivers/net/ena/ena_ethdev.c | 3 +--
+ 1 file changed, 1 insertion(+), 2 deletions(-)
+
+diff --git a/drivers/net/ena/ena_ethdev.c b/drivers/net/ena/ena_ethdev.c
+index deaad54fc7..10398b4d21 100644
+--- a/drivers/net/ena/ena_ethdev.c
++++ b/drivers/net/ena/ena_ethdev.c
+@@ -1094,16 +1094,15 @@ static int ena_create_io_queue(struct ena_ring *ring)
+ 		ena_qid = ENA_IO_TXQ_IDX(ring->id);
+ 		ctx.direction = ENA_COM_IO_QUEUE_DIRECTION_TX;
+ 		ctx.mem_queue_type = ena_dev->tx_mem_queue_type;
+-		ctx.queue_size = adapter->tx_ring_size;
+ 		for (i = 0; i < ring->ring_size; i++)
+ 			ring->empty_tx_reqs[i] = i;
+ 	} else {
+ 		ena_qid = ENA_IO_RXQ_IDX(ring->id);
+ 		ctx.direction = ENA_COM_IO_QUEUE_DIRECTION_RX;
+-		ctx.queue_size = adapter->rx_ring_size;
+ 		for (i = 0; i < ring->ring_size; i++)
+ 			ring->empty_rx_reqs[i] = i;
+ 	}
++	ctx.queue_size = ring->ring_size;
+ 	ctx.qid = ena_qid;
+ 	ctx.msix_vector = -1; /* interrupts not used */
+ 	ctx.numa_node = ring->numa_socket_id;
+-- 
+2.20.1
+

--- a/userspace/dpdk/19.08/0006-net-ena-remove-memory-barriers-before-doorbells.patch
+++ b/userspace/dpdk/19.08/0006-net-ena-remove-memory-barriers-before-doorbells.patch
@@ -1,0 +1,56 @@
+From 39d5ae1ad22840f4d27aaf0694b7d8693d725091 Mon Sep 17 00:00:00 2001
+From: Michal Krawczyk <mk@semihalf.com>
+Date: Wed, 8 Apr 2020 10:29:11 +0200
+Subject: [PATCH 6/8] net/ena: remove memory barriers before doorbells
+
+[ upstream commit 38faa87eb8873e04ccef8fcaea4aaf3ad125fc83 ]
+
+The doorbell code is already issuing the doorbell by using rte_write.
+Because of that, there is no need to do that before calling the
+function.
+
+Change-Id: Ia9c348e485987bc618bc7e89bf7fa057cc240617
+Signed-off-by: Michal Krawczyk <mk@semihalf.com>
+Reviewed-by: Igor Chauskin <igorch@amazon.com>
+Reviewed-by: Guy Tzalik <gtzalik@amazon.com>
+---
+ drivers/net/ena/ena_ethdev.c | 9 +--------
+ 1 file changed, 1 insertion(+), 8 deletions(-)
+
+diff --git a/drivers/net/ena/ena_ethdev.c b/drivers/net/ena/ena_ethdev.c
+index 10398b4d21..8bbf72ac53 100644
+--- a/drivers/net/ena/ena_ethdev.c
++++ b/drivers/net/ena/ena_ethdev.c
+@@ -1441,12 +1441,7 @@ static int ena_populate_rx_queue(struct ena_ring *rxq, unsigned int count)
+ 
+ 	/* When we submitted free recources to device... */
+ 	if (likely(i > 0)) {
+-		/* ...let HW know that it can fill buffers with data
+-		 *
+-		 * Add memory barrier to make sure the desc were written before
+-		 * issue a doorbell
+-		 */
+-		rte_wmb();
++		/* ...let HW know that it can fill buffers with data. */
+ 		ena_com_write_sq_doorbell(rxq->ena_com_io_sq);
+ 
+ 		rxq->next_to_use = next_to_use;
+@@ -2361,7 +2356,6 @@ static uint16_t eth_ena_xmit_pkts(void *tx_queue, struct rte_mbuf **tx_pkts,
+ 			RTE_LOG(DEBUG, PMD, "llq tx max burst size of queue %d"
+ 				" achieved, writing doorbell to send burst\n",
+ 				tx_ring->id);
+-			rte_wmb();
+ 			ena_com_write_sq_doorbell(tx_ring->ena_com_io_sq);
+ 		}
+ 
+@@ -2384,7 +2378,6 @@ static uint16_t eth_ena_xmit_pkts(void *tx_queue, struct rte_mbuf **tx_pkts,
+ 	/* If there are ready packets to be xmitted... */
+ 	if (sent_idx > 0) {
+ 		/* ...let HW do its best :-) */
+-		rte_wmb();
+ 		ena_com_write_sq_doorbell(tx_ring->ena_com_io_sq);
+ 		tx_ring->tx_stats.doorbells++;
+ 		tx_ring->next_to_use = next_to_use;
+-- 
+2.20.1
+

--- a/userspace/dpdk/19.08/0007-net-ena-limit-refill-threshold-by-fixed-value.patch
+++ b/userspace/dpdk/19.08/0007-net-ena-limit-refill-threshold-by-fixed-value.patch
@@ -1,0 +1,118 @@
+From 37ff33f08c2fed7a38b401ae4ba7d21a265b78ad Mon Sep 17 00:00:00 2001
+From: Michal Krawczyk <mk@semihalf.com>
+Date: Wed, 8 Apr 2020 10:29:16 +0200
+Subject: [PATCH 7/8] net/ena: limit refill threshold by fixed value
+
+[ upstream commit 7755060798de9c0146df8809926030ed47fc9086 ]
+
+Divider used for both Tx and Rx cleanup/refill threshold can cause too
+big delay in case of the really big rings - for example if the 8k Rx
+ring will be used, the refill won't trigger unless 1024 threshold will
+be reached. It will also cause driver to try to allocate that much
+descriptors.
+
+Limiting it by fixed value - 256 in that case, would limit maximum
+time spent in repopulate function.
+
+Change-Id: Ia8659e6ddf179ff612a780adc6fe55d13eeac6e9
+Signed-off-by: Michal Krawczyk <mk@semihalf.com>
+Reviewed-by: Igor Chauskin <igorch@amazon.com>
+Reviewed-by: Guy Tzalik <gtzalik@amazon.com>
+---
+ drivers/net/ena/ena_ethdev.c | 26 ++++++++++++++------------
+ drivers/net/ena/ena_ethdev.h | 10 ++++++++++
+ 2 files changed, 24 insertions(+), 12 deletions(-)
+
+diff --git a/drivers/net/ena/ena_ethdev.c b/drivers/net/ena/ena_ethdev.c
+index 8bbf72ac53..c17dd3895b 100644
+--- a/drivers/net/ena/ena_ethdev.c
++++ b/drivers/net/ena/ena_ethdev.c
+@@ -62,14 +62,6 @@
+ /*reverse version of ENA_IO_RXQ_IDX*/
+ #define ENA_IO_RXQ_IDX_REV(q)	((q - 1) / 2)
+ 
+-/* While processing submitted and completed descriptors (rx and tx path
+- * respectively) in a loop it is desired to:
+- *  - perform batch submissions while populating sumbissmion queue
+- *  - avoid blocking transmission of other packets during cleanup phase
+- * Hence the utilization ratio of 1/8 of a queue size.
+- */
+-#define ENA_RING_DESCS_RATIO(ring_size)	(ring_size / 8)
+-
+ #define __MERGE_64B_H_L(h, l) (((uint64_t)h << 32) | l)
+ #define TEST_BIT(val, bit_shift) (val & (1UL << bit_shift))
+ 
+@@ -2000,6 +1992,8 @@ static uint16_t eth_ena_recv_pkts(void *rx_queue, struct rte_mbuf **rx_pkts,
+ 	struct ena_ring *rx_ring = (struct ena_ring *)(rx_queue);
+ 	unsigned int ring_size = rx_ring->ring_size;
+ 	unsigned int ring_mask = ring_size - 1;
++	unsigned int free_queue_entries;
++	unsigned int refill_threshold;
+ 	uint16_t next_to_clean = rx_ring->next_to_clean;
+ 	uint16_t desc_in_use = 0;
+ 	uint16_t req_id;
+@@ -2101,11 +2095,15 @@ static uint16_t eth_ena_recv_pkts(void *rx_queue, struct rte_mbuf **rx_pkts,
+ 	rx_ring->rx_stats.cnt += recv_idx;
+ 	rx_ring->next_to_clean = next_to_clean;
+ 
+-	desc_in_use = desc_in_use - completed + 1;
++	free_queue_entries = ena_com_free_desc(rx_ring->ena_com_io_sq);
++	refill_threshold =
++		RTE_MIN(ring_size / ENA_REFILL_THRESH_DIVIDER,
++		(unsigned int)ENA_REFILL_THRESH_PACKET);
++
+ 	/* Burst refill to save doorbells, memory barriers, const interval */
+-	if (ring_size - desc_in_use > ENA_RING_DESCS_RATIO(ring_size)) {
++	if (free_queue_entries > refill_threshold) {
+ 		ena_com_update_dev_comp_head(rx_ring->ena_com_io_cq);
+-		ena_populate_rx_queue(rx_ring, ring_size - desc_in_use);
++		ena_populate_rx_queue(rx_ring, free_queue_entries);
+ 	}
+ 
+ 	return recv_idx;
+@@ -2244,6 +2242,7 @@ static uint16_t eth_ena_xmit_pkts(void *tx_queue, struct rte_mbuf **tx_pkts,
+ 	uint16_t seg_len;
+ 	unsigned int ring_size = tx_ring->ring_size;
+ 	unsigned int ring_mask = ring_size - 1;
++	unsigned int cleanup_budget;
+ 	struct ena_com_tx_ctx ena_tx_ctx;
+ 	struct ena_tx_buffer *tx_info;
+ 	struct ena_com_buf *ebuf;
+@@ -2401,9 +2400,12 @@ static uint16_t eth_ena_xmit_pkts(void *tx_queue, struct rte_mbuf **tx_pkts,
+ 		/* Put back descriptor to the ring for reuse */
+ 		tx_ring->empty_tx_reqs[next_to_clean & ring_mask] = req_id;
+ 		next_to_clean++;
++		cleanup_budget =
++			RTE_MIN(ring_size / ENA_REFILL_THRESH_DIVIDER,
++			(unsigned int)ENA_REFILL_THRESH_PACKET);
+ 
+ 		/* If too many descs to clean, leave it for another run */
+-		if (unlikely(total_tx_descs > ENA_RING_DESCS_RATIO(ring_size)))
++		if (unlikely(total_tx_descs > cleanup_budget))
+ 			break;
+ 	}
+ 	tx_ring->tx_stats.available_desc =
+diff --git a/drivers/net/ena/ena_ethdev.h b/drivers/net/ena/ena_ethdev.h
+index dd87e11397..26a6ee87a2 100644
+--- a/drivers/net/ena/ena_ethdev.h
++++ b/drivers/net/ena/ena_ethdev.h
+@@ -57,6 +57,16 @@
+ #define ENA_WD_TIMEOUT_SEC	3
+ #define ENA_DEVICE_KALIVE_TIMEOUT (ENA_WD_TIMEOUT_SEC * rte_get_timer_hz())
+ 
++/* While processing submitted and completed descriptors (rx and tx path
++ * respectively) in a loop it is desired to:
++ *  - perform batch submissions while populating sumbissmion queue
++ *  - avoid blocking transmission of other packets during cleanup phase
++ * Hence the utilization ratio of 1/8 of a queue size or max value if the size
++ * of the ring is very big - like 8k Rx rings.
++ */
++#define ENA_REFILL_THRESH_DIVIDER      8
++#define ENA_REFILL_THRESH_PACKET       256
++
+ struct ena_adapter;
+ 
+ enum ena_ring_type {
+-- 
+2.20.1
+

--- a/userspace/dpdk/19.08/0008-net-ena-fix-build-for-O1-optimization.patch
+++ b/userspace/dpdk/19.08/0008-net-ena-fix-build-for-O1-optimization.patch
@@ -1,0 +1,47 @@
+From 7b6924e04156a44f19f0e8f9623d07a8b199893f Mon Sep 17 00:00:00 2001
+From: Ferruh Yigit <ferruh.yigit@intel.com>
+Date: Mon, 11 May 2020 17:07:24 +0100
+Subject: [PATCH 8/8] net/ena: fix build for O1 optimization
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+[ upstream commit 5f267cb01b41def2af37b8fa56828e75ae91add0 ]
+
+Can be reproduced with "make EXTRA_CFLAGS='-O1'" command using
+gcc (GCC) 9.3.1 20200408 (Red Hat 9.3.1-2)
+
+Build error:
+.../drivers/net/ena/ena_ethdev.c: In function ‘eth_ena_dev_init’:
+.../drivers/net/ena/ena_ethdev.c:1815:20:
+    error: ‘wd_state’ may be used uninitialized in this function
+           [-Werror=maybe-uninitialized]
+ 1815 |  adapter->wd_state = wd_state;
+      |  ~~~~~~~~~~~~~~~~~~^~~~~~~~~~
+
+This looks like false positive, fixing by assigning initial value to
+'wd_state' variable.
+
+Change-Id: I68bd21d4e2a4b41466e670e282856d4f072dadc0
+Signed-off-by: Ferruh Yigit <ferruh.yigit@intel.com>
+Acked-by: Michal Krawczyk <mk@semihalf.com>
+---
+ drivers/net/ena/ena_ethdev.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/drivers/net/ena/ena_ethdev.c b/drivers/net/ena/ena_ethdev.c
+index c17dd3895b..60df9e93e8 100644
+--- a/drivers/net/ena/ena_ethdev.c
++++ b/drivers/net/ena/ena_ethdev.c
+@@ -1686,7 +1686,7 @@ static int eth_ena_dev_init(struct rte_eth_dev *eth_dev)
+ 	int rc;
+ 
+ 	static int adapters_found;
+-	bool wd_state;
++	bool wd_state = false;
+ 
+ 	eth_dev->dev_ops = &ena_dev_ops;
+ 	eth_dev->rx_pkt_burst = &eth_ena_recv_pkts;
+-- 
+2.20.1
+

--- a/userspace/dpdk/19.11/0001-net-ena-ensure-Rx-buffer-size-is-at-least-1400B.patch
+++ b/userspace/dpdk/19.11/0001-net-ena-ensure-Rx-buffer-size-is-at-least-1400B.patch
@@ -1,0 +1,80 @@
+From 3a8dc4add1e0016f2339c43a2da304d74bd577b0 Mon Sep 17 00:00:00 2001
+From: Michal Krawczyk <mk@semihalf.com>
+Date: Wed, 8 Apr 2020 10:28:52 +0200
+Subject: [PATCH 1/7] net/ena: ensure Rx buffer size is at least 1400B
+
+[ upstream commit 38364c2687ead97b99402310087c27131a97748c ]
+
+Some of the ENA devices can't handle buffers which are smaller than a
+1400B. Because of this limitation, size of the buffer is being checked
+and limited during the Rx queue setup.
+
+If it's below the allowed value, PMD won't finish it's configuration
+successfully..
+
+Change-Id: Ib402d3bfad98a3fc4f91095d5c6f90c6069da021
+Signed-off-by: Michal Krawczyk <mk@semihalf.com>
+Reviewed-by: Igor Chauskin <igorch@amazon.com>
+Reviewed-by: Guy Tzalik <gtzalik@amazon.com>
+---
+ drivers/net/ena/ena_ethdev.c | 12 +++++++++++-
+ drivers/net/ena/ena_ethdev.h |  3 ++-
+ 2 files changed, 13 insertions(+), 2 deletions(-)
+
+diff --git a/drivers/net/ena/ena_ethdev.c b/drivers/net/ena/ena_ethdev.c
+index 8bbd80dfb3..ef57bdcec0 100644
+--- a/drivers/net/ena/ena_ethdev.c
++++ b/drivers/net/ena/ena_ethdev.c
+@@ -1,5 +1,5 @@
+ /* SPDX-License-Identifier: BSD-3-Clause
+- * Copyright (c) 2015-2019 Amazon.com, Inc. or its affiliates.
++ * Copyright (c) 2015-2020 Amazon.com, Inc. or its affiliates.
+  * All rights reserved.
+  */
+ 
+@@ -1279,6 +1279,7 @@ static int ena_rx_queue_setup(struct rte_eth_dev *dev,
+ {
+ 	struct ena_adapter *adapter = dev->data->dev_private;
+ 	struct ena_ring *rxq = NULL;
++	size_t buffer_size;
+ 	int i;
+ 
+ 	rxq = &adapter->rx_ring[queue_idx];
+@@ -1306,6 +1307,15 @@ static int ena_rx_queue_setup(struct rte_eth_dev *dev,
+ 		return -EINVAL;
+ 	}
+ 
++	/* ENA isn't supporting buffers smaller than 1400 bytes */
++	buffer_size = rte_pktmbuf_data_room_size(mp) - RTE_PKTMBUF_HEADROOM;
++	if (buffer_size < ENA_RX_BUF_MIN_SIZE) {
++		PMD_DRV_LOG(ERR,
++			"Unsupported size of RX buffer: %zu (min size: %d)\n",
++			buffer_size, ENA_RX_BUF_MIN_SIZE);
++		return -EINVAL;
++	}
++
+ 	rxq->port_id = dev->data->port_id;
+ 	rxq->next_to_clean = 0;
+ 	rxq->next_to_use = 0;
+diff --git a/drivers/net/ena/ena_ethdev.h b/drivers/net/ena/ena_ethdev.h
+index af5eeea280..e9b55dc029 100644
+--- a/drivers/net/ena/ena_ethdev.h
++++ b/drivers/net/ena/ena_ethdev.h
+@@ -1,5 +1,5 @@
+ /* SPDX-License-Identifier: BSD-3-Clause
+- * Copyright (c) 2015-2019 Amazon.com, Inc. or its affiliates.
++ * Copyright (c) 2015-2020 Amazon.com, Inc. or its affiliates.
+  * All rights reserved.
+  */
+ 
+@@ -20,6 +20,7 @@
+ #define ENA_MIN_FRAME_LEN	64
+ #define ENA_NAME_MAX_LEN	20
+ #define ENA_PKT_MAX_BUFS	17
++#define ENA_RX_BUF_MIN_SIZE	1400
+ 
+ #define ENA_MIN_MTU		128
+ 
+-- 
+2.20.1
+

--- a/userspace/dpdk/19.11/0002-net-ena-base-make-allocation-macros-thread-safe.patch
+++ b/userspace/dpdk/19.11/0002-net-ena-base-make-allocation-macros-thread-safe.patch
@@ -1,0 +1,78 @@
+From 5cb2b4e710ba1e3f5bd53de609fff11d2f495d05 Mon Sep 17 00:00:00 2001
+From: Igor Chauskin <igorch@amazon.com>
+Date: Wed, 8 Apr 2020 10:28:53 +0200
+Subject: [PATCH 2/7] net/ena/base: make allocation macros thread-safe
+
+[ upstream commit b14fcac035fd8514851c9140a4e26d765b61c532 ]
+
+Memory allocation region id could possibly be non-unique
+due to non-atomic increment, causing allocation failure.
+
+Fixes: 9ba7981ec992 ("ena: add communication layer for DPDK")
+Cc: stable@dpdk.org
+
+Change-Id: Ib9207aaae4e5e7ecdf1a99a0f23a508a53af631d
+Signed-off-by: Igor Chauskin <igorch@amazon.com>
+Reviewed-by: Michal Krawczyk <mk@semihalf.com>
+Reviewed-by: Guy Tzalik <gtzalik@amazon.com>
+---
+ drivers/net/ena/base/ena_plat_dpdk.h | 10 ++++++----
+ drivers/net/ena/ena_ethdev.c         |  2 +-
+ 2 files changed, 7 insertions(+), 5 deletions(-)
+
+diff --git a/drivers/net/ena/base/ena_plat_dpdk.h b/drivers/net/ena/base/ena_plat_dpdk.h
+index 9e1492cac4..db9d1bb36b 100644
+--- a/drivers/net/ena/base/ena_plat_dpdk.h
++++ b/drivers/net/ena/base/ena_plat_dpdk.h
+@@ -1,5 +1,5 @@
+ /* SPDX-License-Identifier: BSD-3-Clause
+- * Copyright (c) 2015-2019 Amazon.com, Inc. or its affiliates.
++ * Copyright (c) 2015-2020 Amazon.com, Inc. or its affiliates.
+  * All rights reserved.
+  */
+ 
+@@ -178,7 +178,7 @@ do {                                                                   \
+  * Each rte_memzone should have unique name.
+  * To satisfy it, count number of allocations and add it to name.
+  */
+-extern uint32_t ena_alloc_cnt;
++extern rte_atomic32_t ena_alloc_cnt;
+ 
+ #define ENA_MEM_ALLOC_COHERENT(dmadev, size, virt, phys, handle)	\
+ 	do {								\
+@@ -186,7 +186,8 @@ extern uint32_t ena_alloc_cnt;
+ 		char z_name[RTE_MEMZONE_NAMESIZE];			\
+ 		ENA_TOUCH(dmadev); ENA_TOUCH(handle);			\
+ 		snprintf(z_name, sizeof(z_name),			\
+-				"ena_alloc_%d", ena_alloc_cnt++);	\
++			 "ena_alloc_%d",				\
++			 rte_atomic32_add_return(&ena_alloc_cnt, 1));	\
+ 		mz = rte_memzone_reserve(z_name, size, SOCKET_ID_ANY,	\
+ 				RTE_MEMZONE_IOVA_CONTIG);		\
+ 		handle = mz;						\
+@@ -211,7 +212,8 @@ extern uint32_t ena_alloc_cnt;
+ 		char z_name[RTE_MEMZONE_NAMESIZE];			\
+ 		ENA_TOUCH(dmadev); ENA_TOUCH(dev_node);			\
+ 		snprintf(z_name, sizeof(z_name),			\
+-				"ena_alloc_%d", ena_alloc_cnt++);	\
++			 "ena_alloc_%d",				\
++			 rte_atomic32_add_return(&ena_alloc_cnt, 1));	\
+ 		mz = rte_memzone_reserve(z_name, size, node,		\
+ 				RTE_MEMZONE_IOVA_CONTIG);		\
+ 		mem_handle = mz;					\
+diff --git a/drivers/net/ena/ena_ethdev.c b/drivers/net/ena/ena_ethdev.c
+index ef57bdcec0..fce571e83a 100644
+--- a/drivers/net/ena/ena_ethdev.c
++++ b/drivers/net/ena/ena_ethdev.c
+@@ -89,7 +89,7 @@ struct ena_stats {
+  * Each rte_memzone should have unique name.
+  * To satisfy it, count number of allocation and add it to name.
+  */
+-uint32_t ena_alloc_cnt;
++rte_atomic32_t ena_alloc_cnt;
+ 
+ static const struct ena_stats ena_stats_global_strings[] = {
+ 	ENA_STAT_GLOBAL_ENTRY(wd_expired),
+-- 
+2.20.1
+

--- a/userspace/dpdk/19.11/0003-net-ena-base-prevent-allocation-of-zero-sized-memory.patch
+++ b/userspace/dpdk/19.11/0003-net-ena-base-prevent-allocation-of-zero-sized-memory.patch
@@ -1,0 +1,77 @@
+From e61661d957dea76bf249589f456adbefa8c80f6d Mon Sep 17 00:00:00 2001
+From: Igor Chauskin <igorch@amazon.com>
+Date: Wed, 8 Apr 2020 10:28:54 +0200
+Subject: [PATCH 3/7] net/ena/base: prevent allocation of zero sized memory
+
+[ upstream commit 29dc10d9424ccf26a346387b0a707185e2432400 ]
+
+rte_memzone_reserve() will reserve the biggest contiguous memzone
+available if received 0 as size param.
+
+Fixes: 9ba7981ec992 ("ena: add communication layer for DPDK")
+Cc: stable@dpdk.org
+
+Change-Id: I2f71119e93c5e9addd8c538820093f030066d690
+Signed-off-by: Igor Chauskin <igorch@amazon.com>
+Reviewed-by: Michal Krawczyk <mk@semihalf.com>
+Reviewed-by: Guy Tzalik <gtzalik@amazon.com>
+---
+ drivers/net/ena/base/ena_plat_dpdk.h | 29 ++++++++++++++++------------
+ 1 file changed, 17 insertions(+), 12 deletions(-)
+
+diff --git a/drivers/net/ena/base/ena_plat_dpdk.h b/drivers/net/ena/base/ena_plat_dpdk.h
+index db9d1bb36b..dddfe65403 100644
+--- a/drivers/net/ena/base/ena_plat_dpdk.h
++++ b/drivers/net/ena/base/ena_plat_dpdk.h
+@@ -182,15 +182,18 @@ extern rte_atomic32_t ena_alloc_cnt;
+ 
+ #define ENA_MEM_ALLOC_COHERENT(dmadev, size, virt, phys, handle)	\
+ 	do {								\
+-		const struct rte_memzone *mz;				\
+-		char z_name[RTE_MEMZONE_NAMESIZE];			\
++		const struct rte_memzone *mz = NULL;			\
+ 		ENA_TOUCH(dmadev); ENA_TOUCH(handle);			\
+-		snprintf(z_name, sizeof(z_name),			\
++		if (size > 0) {						\
++			char z_name[RTE_MEMZONE_NAMESIZE];		\
++			snprintf(z_name, sizeof(z_name),		\
+ 			 "ena_alloc_%d",				\
+ 			 rte_atomic32_add_return(&ena_alloc_cnt, 1));	\
+-		mz = rte_memzone_reserve(z_name, size, SOCKET_ID_ANY,	\
+-				RTE_MEMZONE_IOVA_CONTIG);		\
+-		handle = mz;						\
++			mz = rte_memzone_reserve(z_name, size,		\
++					SOCKET_ID_ANY,			\
++					RTE_MEMZONE_IOVA_CONTIG);	\
++			handle = mz;					\
++		}							\
+ 		if (mz == NULL) {					\
+ 			virt = NULL;					\
+ 			phys = 0;					\
+@@ -208,15 +211,17 @@ extern rte_atomic32_t ena_alloc_cnt;
+ #define ENA_MEM_ALLOC_COHERENT_NODE(					\
+ 	dmadev, size, virt, phys, mem_handle, node, dev_node)		\
+ 	do {								\
+-		const struct rte_memzone *mz;				\
+-		char z_name[RTE_MEMZONE_NAMESIZE];			\
++		const struct rte_memzone *mz = NULL;			\
+ 		ENA_TOUCH(dmadev); ENA_TOUCH(dev_node);			\
+-		snprintf(z_name, sizeof(z_name),			\
++		if (size > 0) {						\
++			char z_name[RTE_MEMZONE_NAMESIZE];		\
++			snprintf(z_name, sizeof(z_name),		\
+ 			 "ena_alloc_%d",				\
+-			 rte_atomic32_add_return(&ena_alloc_cnt, 1));	\
+-		mz = rte_memzone_reserve(z_name, size, node,		\
++			 rte_atomic32_add_return(&ena_alloc_cnt, 1));   \
++			mz = rte_memzone_reserve(z_name, size, node,	\
+ 				RTE_MEMZONE_IOVA_CONTIG);		\
+-		mem_handle = mz;					\
++			mem_handle = mz;				\
++		}							\
+ 		if (mz == NULL) {					\
+ 			virt = NULL;					\
+ 			phys = 0;					\
+-- 
+2.20.1
+

--- a/userspace/dpdk/19.11/0004-net-ena-set-IO-ring-size-to-valid-value.patch
+++ b/userspace/dpdk/19.11/0004-net-ena-set-IO-ring-size-to-valid-value.patch
@@ -1,0 +1,49 @@
+From ea4b5e50be766c03461b83d0f24e8ecbfb147c47 Mon Sep 17 00:00:00 2001
+From: Michal Krawczyk <mk@semihalf.com>
+Date: Wed, 8 Apr 2020 10:29:08 +0200
+Subject: [PATCH 4/7] net/ena: set IO ring size to valid value
+
+[ upstream commit badc3a6aa133a886a61b9e3ad666e5675f7ec3d3 ]
+
+IO rings were configured with the maximum allowed size for the Tx/Rx
+rings. However, the application could decide to create smaller rings.
+
+This patch is using value stored in the ring instead of the value from
+the adapter which is indicating the maximum allowed value.
+
+Fixes: df238f84c0a2 ("net/ena: recreate HW IO rings on start and stop")
+Cc: stable@dpdk.org
+
+Change-Id: Icf9102e2aa4e7413b6620b36dd232673239b7291
+Signed-off-by: Michal Krawczyk <mk@semihalf.com>
+Reviewed-by: Igor Chauskin <igorch@amazon.com>
+Reviewed-by: Guy Tzalik <gtzalik@amazon.com>
+---
+ drivers/net/ena/ena_ethdev.c | 3 +--
+ 1 file changed, 1 insertion(+), 2 deletions(-)
+
+diff --git a/drivers/net/ena/ena_ethdev.c b/drivers/net/ena/ena_ethdev.c
+index fce571e83a..fde5e6178a 100644
+--- a/drivers/net/ena/ena_ethdev.c
++++ b/drivers/net/ena/ena_ethdev.c
+@@ -1079,16 +1079,15 @@ static int ena_create_io_queue(struct ena_ring *ring)
+ 		ena_qid = ENA_IO_TXQ_IDX(ring->id);
+ 		ctx.direction = ENA_COM_IO_QUEUE_DIRECTION_TX;
+ 		ctx.mem_queue_type = ena_dev->tx_mem_queue_type;
+-		ctx.queue_size = adapter->tx_ring_size;
+ 		for (i = 0; i < ring->ring_size; i++)
+ 			ring->empty_tx_reqs[i] = i;
+ 	} else {
+ 		ena_qid = ENA_IO_RXQ_IDX(ring->id);
+ 		ctx.direction = ENA_COM_IO_QUEUE_DIRECTION_RX;
+-		ctx.queue_size = adapter->rx_ring_size;
+ 		for (i = 0; i < ring->ring_size; i++)
+ 			ring->empty_rx_reqs[i] = i;
+ 	}
++	ctx.queue_size = ring->ring_size;
+ 	ctx.qid = ena_qid;
+ 	ctx.msix_vector = -1; /* interrupts not used */
+ 	ctx.numa_node = ring->numa_socket_id;
+-- 
+2.20.1
+

--- a/userspace/dpdk/19.11/0005-net-ena-remove-memory-barriers-before-doorbells.patch
+++ b/userspace/dpdk/19.11/0005-net-ena-remove-memory-barriers-before-doorbells.patch
@@ -1,0 +1,56 @@
+From 21dade5232def5dbbf95e35e19139283dcf02462 Mon Sep 17 00:00:00 2001
+From: Michal Krawczyk <mk@semihalf.com>
+Date: Wed, 8 Apr 2020 10:29:11 +0200
+Subject: [PATCH 5/7] net/ena: remove memory barriers before doorbells
+
+[ upstream commit 38faa87eb8873e04ccef8fcaea4aaf3ad125fc83 ]
+
+The doorbell code is already issuing the doorbell by using rte_write.
+Because of that, there is no need to do that before calling the
+function.
+
+Change-Id: Ia9c348e485987bc618bc7e89bf7fa057cc240617
+Signed-off-by: Michal Krawczyk <mk@semihalf.com>
+Reviewed-by: Igor Chauskin <igorch@amazon.com>
+Reviewed-by: Guy Tzalik <gtzalik@amazon.com>
+---
+ drivers/net/ena/ena_ethdev.c | 9 +--------
+ 1 file changed, 1 insertion(+), 8 deletions(-)
+
+diff --git a/drivers/net/ena/ena_ethdev.c b/drivers/net/ena/ena_ethdev.c
+index fde5e6178a..b83766772d 100644
+--- a/drivers/net/ena/ena_ethdev.c
++++ b/drivers/net/ena/ena_ethdev.c
+@@ -1426,12 +1426,7 @@ static int ena_populate_rx_queue(struct ena_ring *rxq, unsigned int count)
+ 
+ 	/* When we submitted free recources to device... */
+ 	if (likely(i > 0)) {
+-		/* ...let HW know that it can fill buffers with data
+-		 *
+-		 * Add memory barrier to make sure the desc were written before
+-		 * issue a doorbell
+-		 */
+-		rte_wmb();
++		/* ...let HW know that it can fill buffers with data. */
+ 		ena_com_write_sq_doorbell(rxq->ena_com_io_sq);
+ 
+ 		rxq->next_to_use = next_to_use;
+@@ -2348,7 +2343,6 @@ static uint16_t eth_ena_xmit_pkts(void *tx_queue, struct rte_mbuf **tx_pkts,
+ 			PMD_DRV_LOG(DEBUG, "llq tx max burst size of queue %d"
+ 				" achieved, writing doorbell to send burst\n",
+ 				tx_ring->id);
+-			rte_wmb();
+ 			ena_com_write_sq_doorbell(tx_ring->ena_com_io_sq);
+ 		}
+ 
+@@ -2371,7 +2365,6 @@ static uint16_t eth_ena_xmit_pkts(void *tx_queue, struct rte_mbuf **tx_pkts,
+ 	/* If there are ready packets to be xmitted... */
+ 	if (sent_idx > 0) {
+ 		/* ...let HW do its best :-) */
+-		rte_wmb();
+ 		ena_com_write_sq_doorbell(tx_ring->ena_com_io_sq);
+ 		tx_ring->tx_stats.doorbells++;
+ 		tx_ring->next_to_use = next_to_use;
+-- 
+2.20.1
+

--- a/userspace/dpdk/19.11/0006-net-ena-limit-refill-threshold-by-fixed-value.patch
+++ b/userspace/dpdk/19.11/0006-net-ena-limit-refill-threshold-by-fixed-value.patch
@@ -1,0 +1,118 @@
+From 2ccd234358be45778c89b936f0762e2bbf3e1c65 Mon Sep 17 00:00:00 2001
+From: Michal Krawczyk <mk@semihalf.com>
+Date: Wed, 8 Apr 2020 10:29:16 +0200
+Subject: [PATCH 6/7] net/ena: limit refill threshold by fixed value
+
+[ upstream commit 7755060798de9c0146df8809926030ed47fc9086 ]
+
+Divider used for both Tx and Rx cleanup/refill threshold can cause too
+big delay in case of the really big rings - for example if the 8k Rx
+ring will be used, the refill won't trigger unless 1024 threshold will
+be reached. It will also cause driver to try to allocate that much
+descriptors.
+
+Limiting it by fixed value - 256 in that case, would limit maximum
+time spent in repopulate function.
+
+Change-Id: Ia8659e6ddf179ff612a780adc6fe55d13eeac6e9
+Signed-off-by: Michal Krawczyk <mk@semihalf.com>
+Reviewed-by: Igor Chauskin <igorch@amazon.com>
+Reviewed-by: Guy Tzalik <gtzalik@amazon.com>
+---
+ drivers/net/ena/ena_ethdev.c | 26 ++++++++++++++------------
+ drivers/net/ena/ena_ethdev.h | 10 ++++++++++
+ 2 files changed, 24 insertions(+), 12 deletions(-)
+
+diff --git a/drivers/net/ena/ena_ethdev.c b/drivers/net/ena/ena_ethdev.c
+index b83766772d..53cf6e4ae6 100644
+--- a/drivers/net/ena/ena_ethdev.c
++++ b/drivers/net/ena/ena_ethdev.c
+@@ -34,14 +34,6 @@
+ /*reverse version of ENA_IO_RXQ_IDX*/
+ #define ENA_IO_RXQ_IDX_REV(q)	((q - 1) / 2)
+ 
+-/* While processing submitted and completed descriptors (rx and tx path
+- * respectively) in a loop it is desired to:
+- *  - perform batch submissions while populating sumbissmion queue
+- *  - avoid blocking transmission of other packets during cleanup phase
+- * Hence the utilization ratio of 1/8 of a queue size.
+- */
+-#define ENA_RING_DESCS_RATIO(ring_size)	(ring_size / 8)
+-
+ #define __MERGE_64B_H_L(h, l) (((uint64_t)h << 32) | l)
+ #define TEST_BIT(val, bit_shift) (val & (1UL << bit_shift))
+ 
+@@ -1987,6 +1979,8 @@ static uint16_t eth_ena_recv_pkts(void *rx_queue, struct rte_mbuf **rx_pkts,
+ 	struct ena_ring *rx_ring = (struct ena_ring *)(rx_queue);
+ 	unsigned int ring_size = rx_ring->ring_size;
+ 	unsigned int ring_mask = ring_size - 1;
++	unsigned int free_queue_entries;
++	unsigned int refill_threshold;
+ 	uint16_t next_to_clean = rx_ring->next_to_clean;
+ 	uint16_t desc_in_use = 0;
+ 	uint16_t req_id;
+@@ -2088,11 +2082,15 @@ static uint16_t eth_ena_recv_pkts(void *rx_queue, struct rte_mbuf **rx_pkts,
+ 	rx_ring->rx_stats.cnt += recv_idx;
+ 	rx_ring->next_to_clean = next_to_clean;
+ 
+-	desc_in_use = desc_in_use - completed + 1;
++	free_queue_entries = ena_com_free_desc(rx_ring->ena_com_io_sq);
++	refill_threshold =
++		RTE_MIN(ring_size / ENA_REFILL_THRESH_DIVIDER,
++		(unsigned int)ENA_REFILL_THRESH_PACKET);
++
+ 	/* Burst refill to save doorbells, memory barriers, const interval */
+-	if (ring_size - desc_in_use > ENA_RING_DESCS_RATIO(ring_size)) {
++	if (free_queue_entries > refill_threshold) {
+ 		ena_com_update_dev_comp_head(rx_ring->ena_com_io_cq);
+-		ena_populate_rx_queue(rx_ring, ring_size - desc_in_use);
++		ena_populate_rx_queue(rx_ring, free_queue_entries);
+ 	}
+ 
+ 	return recv_idx;
+@@ -2231,6 +2229,7 @@ static uint16_t eth_ena_xmit_pkts(void *tx_queue, struct rte_mbuf **tx_pkts,
+ 	uint16_t seg_len;
+ 	unsigned int ring_size = tx_ring->ring_size;
+ 	unsigned int ring_mask = ring_size - 1;
++	unsigned int cleanup_budget;
+ 	struct ena_com_tx_ctx ena_tx_ctx;
+ 	struct ena_tx_buffer *tx_info;
+ 	struct ena_com_buf *ebuf;
+@@ -2388,9 +2387,12 @@ static uint16_t eth_ena_xmit_pkts(void *tx_queue, struct rte_mbuf **tx_pkts,
+ 		/* Put back descriptor to the ring for reuse */
+ 		tx_ring->empty_tx_reqs[next_to_clean & ring_mask] = req_id;
+ 		next_to_clean++;
++		cleanup_budget =
++			RTE_MIN(ring_size / ENA_REFILL_THRESH_DIVIDER,
++			(unsigned int)ENA_REFILL_THRESH_PACKET);
+ 
+ 		/* If too many descs to clean, leave it for another run */
+-		if (unlikely(total_tx_descs > ENA_RING_DESCS_RATIO(ring_size)))
++		if (unlikely(total_tx_descs > cleanup_budget))
+ 			break;
+ 	}
+ 	tx_ring->tx_stats.available_desc =
+diff --git a/drivers/net/ena/ena_ethdev.h b/drivers/net/ena/ena_ethdev.h
+index e9b55dc029..4b7e1ce3c0 100644
+--- a/drivers/net/ena/ena_ethdev.h
++++ b/drivers/net/ena/ena_ethdev.h
+@@ -29,6 +29,16 @@
+ #define ENA_WD_TIMEOUT_SEC	3
+ #define ENA_DEVICE_KALIVE_TIMEOUT (ENA_WD_TIMEOUT_SEC * rte_get_timer_hz())
+ 
++/* While processing submitted and completed descriptors (rx and tx path
++ * respectively) in a loop it is desired to:
++ *  - perform batch submissions while populating sumbissmion queue
++ *  - avoid blocking transmission of other packets during cleanup phase
++ * Hence the utilization ratio of 1/8 of a queue size or max value if the size
++ * of the ring is very big - like 8k Rx rings.
++ */
++#define ENA_REFILL_THRESH_DIVIDER      8
++#define ENA_REFILL_THRESH_PACKET       256
++
+ struct ena_adapter;
+ 
+ enum ena_ring_type {
+-- 
+2.20.1
+

--- a/userspace/dpdk/19.11/0007-net-ena-fix-build-for-O1-optimization.patch
+++ b/userspace/dpdk/19.11/0007-net-ena-fix-build-for-O1-optimization.patch
@@ -1,0 +1,47 @@
+From b4c2fdce2574b8031e27357b15d9c4fc7bc7ed28 Mon Sep 17 00:00:00 2001
+From: Ferruh Yigit <ferruh.yigit@intel.com>
+Date: Mon, 11 May 2020 17:07:24 +0100
+Subject: [PATCH 7/7] net/ena: fix build for O1 optimization
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+[ upstream commit 5f267cb01b41def2af37b8fa56828e75ae91add0 ]
+
+Can be reproduced with "make EXTRA_CFLAGS='-O1'" command using
+gcc (GCC) 9.3.1 20200408 (Red Hat 9.3.1-2)
+
+Build error:
+.../drivers/net/ena/ena_ethdev.c: In function ‘eth_ena_dev_init’:
+.../drivers/net/ena/ena_ethdev.c:1815:20:
+    error: ‘wd_state’ may be used uninitialized in this function
+           [-Werror=maybe-uninitialized]
+ 1815 |  adapter->wd_state = wd_state;
+      |  ~~~~~~~~~~~~~~~~~~^~~~~~~~~~
+
+This looks like false positive, fixing by assigning initial value to
+'wd_state' variable.
+
+Change-Id: I68bd21d4e2a4b41466e670e282856d4f072dadc0
+Signed-off-by: Ferruh Yigit <ferruh.yigit@intel.com>
+Acked-by: Michal Krawczyk <mk@semihalf.com>
+---
+ drivers/net/ena/ena_ethdev.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/drivers/net/ena/ena_ethdev.c b/drivers/net/ena/ena_ethdev.c
+index 53cf6e4ae6..bd4537eaa4 100644
+--- a/drivers/net/ena/ena_ethdev.c
++++ b/drivers/net/ena/ena_ethdev.c
+@@ -1671,7 +1671,7 @@ static int eth_ena_dev_init(struct rte_eth_dev *eth_dev)
+ 	int rc;
+ 
+ 	static int adapters_found;
+-	bool wd_state;
++	bool wd_state = false;
+ 
+ 	eth_dev->dev_ops = &ena_dev_ops;
+ 	eth_dev->rx_pkt_burst = &eth_ena_recv_pkts;
+-- 
+2.20.1
+

--- a/userspace/dpdk/20.02/0001-net-ena-ensure-Rx-buffer-size-is-at-least-1400B.patch
+++ b/userspace/dpdk/20.02/0001-net-ena-ensure-Rx-buffer-size-is-at-least-1400B.patch
@@ -1,0 +1,80 @@
+From 834c0955f6448171f7e6a07989326179d498aba7 Mon Sep 17 00:00:00 2001
+From: Michal Krawczyk <mk@semihalf.com>
+Date: Wed, 8 Apr 2020 10:28:52 +0200
+Subject: [PATCH 1/7] net/ena: ensure Rx buffer size is at least 1400B
+
+[ upstream commit 38364c2687ead97b99402310087c27131a97748c ]
+
+Some of the ENA devices can't handle buffers which are smaller than a
+1400B. Because of this limitation, size of the buffer is being checked
+and limited during the Rx queue setup.
+
+If it's below the allowed value, PMD won't finish it's configuration
+successfully..
+
+Change-Id: Ib402d3bfad98a3fc4f91095d5c6f90c6069da021
+Signed-off-by: Michal Krawczyk <mk@semihalf.com>
+Reviewed-by: Igor Chauskin <igorch@amazon.com>
+Reviewed-by: Guy Tzalik <gtzalik@amazon.com>
+---
+ drivers/net/ena/ena_ethdev.c | 12 +++++++++++-
+ drivers/net/ena/ena_ethdev.h |  3 ++-
+ 2 files changed, 13 insertions(+), 2 deletions(-)
+
+diff --git a/drivers/net/ena/ena_ethdev.c b/drivers/net/ena/ena_ethdev.c
+index 665afee4f0..64aabbbb19 100644
+--- a/drivers/net/ena/ena_ethdev.c
++++ b/drivers/net/ena/ena_ethdev.c
+@@ -1,5 +1,5 @@
+ /* SPDX-License-Identifier: BSD-3-Clause
+- * Copyright (c) 2015-2019 Amazon.com, Inc. or its affiliates.
++ * Copyright (c) 2015-2020 Amazon.com, Inc. or its affiliates.
+  * All rights reserved.
+  */
+ 
+@@ -1282,6 +1282,7 @@ static int ena_rx_queue_setup(struct rte_eth_dev *dev,
+ {
+ 	struct ena_adapter *adapter = dev->data->dev_private;
+ 	struct ena_ring *rxq = NULL;
++	size_t buffer_size;
+ 	int i;
+ 
+ 	rxq = &adapter->rx_ring[queue_idx];
+@@ -1309,6 +1310,15 @@ static int ena_rx_queue_setup(struct rte_eth_dev *dev,
+ 		return -EINVAL;
+ 	}
+ 
++	/* ENA isn't supporting buffers smaller than 1400 bytes */
++	buffer_size = rte_pktmbuf_data_room_size(mp) - RTE_PKTMBUF_HEADROOM;
++	if (buffer_size < ENA_RX_BUF_MIN_SIZE) {
++		PMD_DRV_LOG(ERR,
++			"Unsupported size of RX buffer: %zu (min size: %d)\n",
++			buffer_size, ENA_RX_BUF_MIN_SIZE);
++		return -EINVAL;
++	}
++
+ 	rxq->port_id = dev->data->port_id;
+ 	rxq->next_to_clean = 0;
+ 	rxq->next_to_use = 0;
+diff --git a/drivers/net/ena/ena_ethdev.h b/drivers/net/ena/ena_ethdev.h
+index af5eeea280..e9b55dc029 100644
+--- a/drivers/net/ena/ena_ethdev.h
++++ b/drivers/net/ena/ena_ethdev.h
+@@ -1,5 +1,5 @@
+ /* SPDX-License-Identifier: BSD-3-Clause
+- * Copyright (c) 2015-2019 Amazon.com, Inc. or its affiliates.
++ * Copyright (c) 2015-2020 Amazon.com, Inc. or its affiliates.
+  * All rights reserved.
+  */
+ 
+@@ -20,6 +20,7 @@
+ #define ENA_MIN_FRAME_LEN	64
+ #define ENA_NAME_MAX_LEN	20
+ #define ENA_PKT_MAX_BUFS	17
++#define ENA_RX_BUF_MIN_SIZE	1400
+ 
+ #define ENA_MIN_MTU		128
+ 
+-- 
+2.20.1
+

--- a/userspace/dpdk/20.02/0002-net-ena-base-make-allocation-macros-thread-safe.patch
+++ b/userspace/dpdk/20.02/0002-net-ena-base-make-allocation-macros-thread-safe.patch
@@ -1,0 +1,78 @@
+From bc77595117ca0bd80a9716ec823b7c2f73c9b5e4 Mon Sep 17 00:00:00 2001
+From: Igor Chauskin <igorch@amazon.com>
+Date: Wed, 8 Apr 2020 10:28:53 +0200
+Subject: [PATCH 2/7] net/ena/base: make allocation macros thread-safe
+
+[ upstream commit b14fcac035fd8514851c9140a4e26d765b61c532 ]
+
+Memory allocation region id could possibly be non-unique
+due to non-atomic increment, causing allocation failure.
+
+Fixes: 9ba7981ec992 ("ena: add communication layer for DPDK")
+Cc: stable@dpdk.org
+
+Change-Id: Ib9207aaae4e5e7ecdf1a99a0f23a508a53af631d
+Signed-off-by: Igor Chauskin <igorch@amazon.com>
+Reviewed-by: Michal Krawczyk <mk@semihalf.com>
+Reviewed-by: Guy Tzalik <gtzalik@amazon.com>
+---
+ drivers/net/ena/base/ena_plat_dpdk.h | 10 ++++++----
+ drivers/net/ena/ena_ethdev.c         |  2 +-
+ 2 files changed, 7 insertions(+), 5 deletions(-)
+
+diff --git a/drivers/net/ena/base/ena_plat_dpdk.h b/drivers/net/ena/base/ena_plat_dpdk.h
+index b611fb204b..70261bdbc6 100644
+--- a/drivers/net/ena/base/ena_plat_dpdk.h
++++ b/drivers/net/ena/base/ena_plat_dpdk.h
+@@ -1,5 +1,5 @@
+ /* SPDX-License-Identifier: BSD-3-Clause
+- * Copyright (c) 2015-2019 Amazon.com, Inc. or its affiliates.
++ * Copyright (c) 2015-2020 Amazon.com, Inc. or its affiliates.
+  * All rights reserved.
+  */
+ 
+@@ -180,7 +180,7 @@ do {                                                                   \
+  * Each rte_memzone should have unique name.
+  * To satisfy it, count number of allocations and add it to name.
+  */
+-extern uint32_t ena_alloc_cnt;
++extern rte_atomic32_t ena_alloc_cnt;
+ 
+ #define ENA_MEM_ALLOC_COHERENT(dmadev, size, virt, phys, handle)	\
+ 	do {								\
+@@ -188,7 +188,8 @@ extern uint32_t ena_alloc_cnt;
+ 		char z_name[RTE_MEMZONE_NAMESIZE];			\
+ 		ENA_TOUCH(dmadev); ENA_TOUCH(handle);			\
+ 		snprintf(z_name, sizeof(z_name),			\
+-				"ena_alloc_%d", ena_alloc_cnt++);	\
++			 "ena_alloc_%d",				\
++			 rte_atomic32_add_return(&ena_alloc_cnt, 1));	\
+ 		mz = rte_memzone_reserve(z_name, size, SOCKET_ID_ANY,	\
+ 				RTE_MEMZONE_IOVA_CONTIG);		\
+ 		handle = mz;						\
+@@ -213,7 +214,8 @@ extern uint32_t ena_alloc_cnt;
+ 		char z_name[RTE_MEMZONE_NAMESIZE];			\
+ 		ENA_TOUCH(dmadev); ENA_TOUCH(dev_node);			\
+ 		snprintf(z_name, sizeof(z_name),			\
+-				"ena_alloc_%d", ena_alloc_cnt++);	\
++			 "ena_alloc_%d",				\
++			 rte_atomic32_add_return(&ena_alloc_cnt, 1));	\
+ 		mz = rte_memzone_reserve(z_name, size, node,		\
+ 				RTE_MEMZONE_IOVA_CONTIG);		\
+ 		mem_handle = mz;					\
+diff --git a/drivers/net/ena/ena_ethdev.c b/drivers/net/ena/ena_ethdev.c
+index 64aabbbb19..e0ed28419c 100644
+--- a/drivers/net/ena/ena_ethdev.c
++++ b/drivers/net/ena/ena_ethdev.c
+@@ -89,7 +89,7 @@ struct ena_stats {
+  * Each rte_memzone should have unique name.
+  * To satisfy it, count number of allocation and add it to name.
+  */
+-uint32_t ena_alloc_cnt;
++rte_atomic32_t ena_alloc_cnt;
+ 
+ static const struct ena_stats ena_stats_global_strings[] = {
+ 	ENA_STAT_GLOBAL_ENTRY(wd_expired),
+-- 
+2.20.1
+

--- a/userspace/dpdk/20.02/0003-net-ena-base-prevent-allocation-of-zero-sized-memory.patch
+++ b/userspace/dpdk/20.02/0003-net-ena-base-prevent-allocation-of-zero-sized-memory.patch
@@ -1,0 +1,77 @@
+From 70f5b3143b5324d2171a7815e62eb9fca81b3d9b Mon Sep 17 00:00:00 2001
+From: Igor Chauskin <igorch@amazon.com>
+Date: Wed, 8 Apr 2020 10:28:54 +0200
+Subject: [PATCH 3/7] net/ena/base: prevent allocation of zero sized memory
+
+[ upstream commit 29dc10d9424ccf26a346387b0a707185e2432400 ]
+
+rte_memzone_reserve() will reserve the biggest contiguous memzone
+available if received 0 as size param.
+
+Fixes: 9ba7981ec992 ("ena: add communication layer for DPDK")
+Cc: stable@dpdk.org
+
+Change-Id: I2f71119e93c5e9addd8c538820093f030066d690
+Signed-off-by: Igor Chauskin <igorch@amazon.com>
+Reviewed-by: Michal Krawczyk <mk@semihalf.com>
+Reviewed-by: Guy Tzalik <gtzalik@amazon.com>
+---
+ drivers/net/ena/base/ena_plat_dpdk.h | 29 ++++++++++++++++------------
+ 1 file changed, 17 insertions(+), 12 deletions(-)
+
+diff --git a/drivers/net/ena/base/ena_plat_dpdk.h b/drivers/net/ena/base/ena_plat_dpdk.h
+index 70261bdbc6..4b8fe017dd 100644
+--- a/drivers/net/ena/base/ena_plat_dpdk.h
++++ b/drivers/net/ena/base/ena_plat_dpdk.h
+@@ -184,15 +184,18 @@ extern rte_atomic32_t ena_alloc_cnt;
+ 
+ #define ENA_MEM_ALLOC_COHERENT(dmadev, size, virt, phys, handle)	\
+ 	do {								\
+-		const struct rte_memzone *mz;				\
+-		char z_name[RTE_MEMZONE_NAMESIZE];			\
++		const struct rte_memzone *mz = NULL;			\
+ 		ENA_TOUCH(dmadev); ENA_TOUCH(handle);			\
+-		snprintf(z_name, sizeof(z_name),			\
++		if (size > 0) {						\
++			char z_name[RTE_MEMZONE_NAMESIZE];		\
++			snprintf(z_name, sizeof(z_name),		\
+ 			 "ena_alloc_%d",				\
+ 			 rte_atomic32_add_return(&ena_alloc_cnt, 1));	\
+-		mz = rte_memzone_reserve(z_name, size, SOCKET_ID_ANY,	\
+-				RTE_MEMZONE_IOVA_CONTIG);		\
+-		handle = mz;						\
++			mz = rte_memzone_reserve(z_name, size,		\
++					SOCKET_ID_ANY,			\
++					RTE_MEMZONE_IOVA_CONTIG);	\
++			handle = mz;					\
++		}							\
+ 		if (mz == NULL) {					\
+ 			virt = NULL;					\
+ 			phys = 0;					\
+@@ -210,15 +213,17 @@ extern rte_atomic32_t ena_alloc_cnt;
+ #define ENA_MEM_ALLOC_COHERENT_NODE(					\
+ 	dmadev, size, virt, phys, mem_handle, node, dev_node)		\
+ 	do {								\
+-		const struct rte_memzone *mz;				\
+-		char z_name[RTE_MEMZONE_NAMESIZE];			\
++		const struct rte_memzone *mz = NULL;			\
+ 		ENA_TOUCH(dmadev); ENA_TOUCH(dev_node);			\
+-		snprintf(z_name, sizeof(z_name),			\
++		if (size > 0) {						\
++			char z_name[RTE_MEMZONE_NAMESIZE];		\
++			snprintf(z_name, sizeof(z_name),		\
+ 			 "ena_alloc_%d",				\
+-			 rte_atomic32_add_return(&ena_alloc_cnt, 1));	\
+-		mz = rte_memzone_reserve(z_name, size, node,		\
++			 rte_atomic32_add_return(&ena_alloc_cnt, 1));   \
++			mz = rte_memzone_reserve(z_name, size, node,	\
+ 				RTE_MEMZONE_IOVA_CONTIG);		\
+-		mem_handle = mz;					\
++			mem_handle = mz;				\
++		}							\
+ 		if (mz == NULL) {					\
+ 			virt = NULL;					\
+ 			phys = 0;					\
+-- 
+2.20.1
+

--- a/userspace/dpdk/20.02/0004-net-ena-set-IO-ring-size-to-valid-value.patch
+++ b/userspace/dpdk/20.02/0004-net-ena-set-IO-ring-size-to-valid-value.patch
@@ -1,0 +1,49 @@
+From 1493247303bf3b542f6e39f89cee551de4e8eec3 Mon Sep 17 00:00:00 2001
+From: Michal Krawczyk <mk@semihalf.com>
+Date: Wed, 8 Apr 2020 10:29:08 +0200
+Subject: [PATCH 4/7] net/ena: set IO ring size to valid value
+
+[ upstream commit badc3a6aa133a886a61b9e3ad666e5675f7ec3d3 ]
+
+IO rings were configured with the maximum allowed size for the Tx/Rx
+rings. However, the application could decide to create smaller rings.
+
+This patch is using value stored in the ring instead of the value from
+the adapter which is indicating the maximum allowed value.
+
+Fixes: df238f84c0a2 ("net/ena: recreate HW IO rings on start and stop")
+Cc: stable@dpdk.org
+
+Change-Id: Icf9102e2aa4e7413b6620b36dd232673239b7291
+Signed-off-by: Michal Krawczyk <mk@semihalf.com>
+Reviewed-by: Igor Chauskin <igorch@amazon.com>
+Reviewed-by: Guy Tzalik <gtzalik@amazon.com>
+---
+ drivers/net/ena/ena_ethdev.c | 3 +--
+ 1 file changed, 1 insertion(+), 2 deletions(-)
+
+diff --git a/drivers/net/ena/ena_ethdev.c b/drivers/net/ena/ena_ethdev.c
+index e0ed28419c..d853dbe9a4 100644
+--- a/drivers/net/ena/ena_ethdev.c
++++ b/drivers/net/ena/ena_ethdev.c
+@@ -1082,16 +1082,15 @@ static int ena_create_io_queue(struct ena_ring *ring)
+ 		ena_qid = ENA_IO_TXQ_IDX(ring->id);
+ 		ctx.direction = ENA_COM_IO_QUEUE_DIRECTION_TX;
+ 		ctx.mem_queue_type = ena_dev->tx_mem_queue_type;
+-		ctx.queue_size = adapter->tx_ring_size;
+ 		for (i = 0; i < ring->ring_size; i++)
+ 			ring->empty_tx_reqs[i] = i;
+ 	} else {
+ 		ena_qid = ENA_IO_RXQ_IDX(ring->id);
+ 		ctx.direction = ENA_COM_IO_QUEUE_DIRECTION_RX;
+-		ctx.queue_size = adapter->rx_ring_size;
+ 		for (i = 0; i < ring->ring_size; i++)
+ 			ring->empty_rx_reqs[i] = i;
+ 	}
++	ctx.queue_size = ring->ring_size;
+ 	ctx.qid = ena_qid;
+ 	ctx.msix_vector = -1; /* interrupts not used */
+ 	ctx.numa_node = ring->numa_socket_id;
+-- 
+2.20.1
+

--- a/userspace/dpdk/20.02/0005-net-ena-remove-memory-barriers-before-doorbells.patch
+++ b/userspace/dpdk/20.02/0005-net-ena-remove-memory-barriers-before-doorbells.patch
@@ -1,0 +1,56 @@
+From 1fa52eb7fb45b4ae45710b1321380fa7717797dd Mon Sep 17 00:00:00 2001
+From: Michal Krawczyk <mk@semihalf.com>
+Date: Wed, 8 Apr 2020 10:29:11 +0200
+Subject: [PATCH 5/7] net/ena: remove memory barriers before doorbells
+
+[ upstream commit 38faa87eb8873e04ccef8fcaea4aaf3ad125fc83 ]
+
+The doorbell code is already issuing the doorbell by using rte_write.
+Because of that, there is no need to do that before calling the
+function.
+
+Change-Id: Ia9c348e485987bc618bc7e89bf7fa057cc240617
+Signed-off-by: Michal Krawczyk <mk@semihalf.com>
+Reviewed-by: Igor Chauskin <igorch@amazon.com>
+Reviewed-by: Guy Tzalik <gtzalik@amazon.com>
+---
+ drivers/net/ena/ena_ethdev.c | 9 +--------
+ 1 file changed, 1 insertion(+), 8 deletions(-)
+
+diff --git a/drivers/net/ena/ena_ethdev.c b/drivers/net/ena/ena_ethdev.c
+index d853dbe9a4..d05f09ae61 100644
+--- a/drivers/net/ena/ena_ethdev.c
++++ b/drivers/net/ena/ena_ethdev.c
+@@ -1429,12 +1429,7 @@ static int ena_populate_rx_queue(struct ena_ring *rxq, unsigned int count)
+ 
+ 	/* When we submitted free recources to device... */
+ 	if (likely(i > 0)) {
+-		/* ...let HW know that it can fill buffers with data
+-		 *
+-		 * Add memory barrier to make sure the desc were written before
+-		 * issue a doorbell
+-		 */
+-		rte_wmb();
++		/* ...let HW know that it can fill buffers with data. */
+ 		ena_com_write_sq_doorbell(rxq->ena_com_io_sq);
+ 
+ 		rxq->next_to_use = next_to_use;
+@@ -2353,7 +2348,6 @@ static uint16_t eth_ena_xmit_pkts(void *tx_queue, struct rte_mbuf **tx_pkts,
+ 			PMD_DRV_LOG(DEBUG, "llq tx max burst size of queue %d"
+ 				" achieved, writing doorbell to send burst\n",
+ 				tx_ring->id);
+-			rte_wmb();
+ 			ena_com_write_sq_doorbell(tx_ring->ena_com_io_sq);
+ 		}
+ 
+@@ -2376,7 +2370,6 @@ static uint16_t eth_ena_xmit_pkts(void *tx_queue, struct rte_mbuf **tx_pkts,
+ 	/* If there are ready packets to be xmitted... */
+ 	if (sent_idx > 0) {
+ 		/* ...let HW do its best :-) */
+-		rte_wmb();
+ 		ena_com_write_sq_doorbell(tx_ring->ena_com_io_sq);
+ 		tx_ring->tx_stats.doorbells++;
+ 		tx_ring->next_to_use = next_to_use;
+-- 
+2.20.1
+

--- a/userspace/dpdk/20.02/0006-net-ena-limit-refill-threshold-by-fixed-value.patch
+++ b/userspace/dpdk/20.02/0006-net-ena-limit-refill-threshold-by-fixed-value.patch
@@ -1,0 +1,118 @@
+From 4600e111c89d7e2ab75bb3b530634a4038c6ff4f Mon Sep 17 00:00:00 2001
+From: Michal Krawczyk <mk@semihalf.com>
+Date: Wed, 8 Apr 2020 10:29:16 +0200
+Subject: [PATCH 6/7] net/ena: limit refill threshold by fixed value
+
+[ upstream commit 7755060798de9c0146df8809926030ed47fc9086 ]
+
+Divider used for both Tx and Rx cleanup/refill threshold can cause too
+big delay in case of the really big rings - for example if the 8k Rx
+ring will be used, the refill won't trigger unless 1024 threshold will
+be reached. It will also cause driver to try to allocate that much
+descriptors.
+
+Limiting it by fixed value - 256 in that case, would limit maximum
+time spent in repopulate function.
+
+Change-Id: Ia8659e6ddf179ff612a780adc6fe55d13eeac6e9
+Signed-off-by: Michal Krawczyk <mk@semihalf.com>
+Reviewed-by: Igor Chauskin <igorch@amazon.com>
+Reviewed-by: Guy Tzalik <gtzalik@amazon.com>
+---
+ drivers/net/ena/ena_ethdev.c | 26 ++++++++++++++------------
+ drivers/net/ena/ena_ethdev.h | 10 ++++++++++
+ 2 files changed, 24 insertions(+), 12 deletions(-)
+
+diff --git a/drivers/net/ena/ena_ethdev.c b/drivers/net/ena/ena_ethdev.c
+index d05f09ae61..06eda43d7a 100644
+--- a/drivers/net/ena/ena_ethdev.c
++++ b/drivers/net/ena/ena_ethdev.c
+@@ -34,14 +34,6 @@
+ /*reverse version of ENA_IO_RXQ_IDX*/
+ #define ENA_IO_RXQ_IDX_REV(q)	((q - 1) / 2)
+ 
+-/* While processing submitted and completed descriptors (rx and tx path
+- * respectively) in a loop it is desired to:
+- *  - perform batch submissions while populating sumbissmion queue
+- *  - avoid blocking transmission of other packets during cleanup phase
+- * Hence the utilization ratio of 1/8 of a queue size.
+- */
+-#define ENA_RING_DESCS_RATIO(ring_size)	(ring_size / 8)
+-
+ #define __MERGE_64B_H_L(h, l) (((uint64_t)h << 32) | l)
+ #define TEST_BIT(val, bit_shift) (val & (1UL << bit_shift))
+ 
+@@ -1990,6 +1982,8 @@ static uint16_t eth_ena_recv_pkts(void *rx_queue, struct rte_mbuf **rx_pkts,
+ 	struct ena_ring *rx_ring = (struct ena_ring *)(rx_queue);
+ 	unsigned int ring_size = rx_ring->ring_size;
+ 	unsigned int ring_mask = ring_size - 1;
++	unsigned int free_queue_entries;
++	unsigned int refill_threshold;
+ 	uint16_t next_to_clean = rx_ring->next_to_clean;
+ 	uint16_t desc_in_use = 0;
+ 	uint16_t req_id;
+@@ -2093,11 +2087,15 @@ static uint16_t eth_ena_recv_pkts(void *rx_queue, struct rte_mbuf **rx_pkts,
+ 	rx_ring->rx_stats.cnt += recv_idx;
+ 	rx_ring->next_to_clean = next_to_clean;
+ 
+-	desc_in_use = desc_in_use - completed + 1;
++	free_queue_entries = ena_com_free_q_entries(rx_ring->ena_com_io_sq);
++	refill_threshold =
++		RTE_MIN(ring_size / ENA_REFILL_THRESH_DIVIDER,
++		(unsigned int)ENA_REFILL_THRESH_PACKET);
++
+ 	/* Burst refill to save doorbells, memory barriers, const interval */
+-	if (ring_size - desc_in_use > ENA_RING_DESCS_RATIO(ring_size)) {
++	if (free_queue_entries > refill_threshold) {
+ 		ena_com_update_dev_comp_head(rx_ring->ena_com_io_cq);
+-		ena_populate_rx_queue(rx_ring, ring_size - desc_in_use);
++		ena_populate_rx_queue(rx_ring, free_queue_entries);
+ 	}
+ 
+ 	return recv_idx;
+@@ -2236,6 +2234,7 @@ static uint16_t eth_ena_xmit_pkts(void *tx_queue, struct rte_mbuf **tx_pkts,
+ 	uint16_t seg_len;
+ 	unsigned int ring_size = tx_ring->ring_size;
+ 	unsigned int ring_mask = ring_size - 1;
++	unsigned int cleanup_budget;
+ 	struct ena_com_tx_ctx ena_tx_ctx;
+ 	struct ena_tx_buffer *tx_info;
+ 	struct ena_com_buf *ebuf;
+@@ -2393,9 +2392,12 @@ static uint16_t eth_ena_xmit_pkts(void *tx_queue, struct rte_mbuf **tx_pkts,
+ 		/* Put back descriptor to the ring for reuse */
+ 		tx_ring->empty_tx_reqs[next_to_clean & ring_mask] = req_id;
+ 		next_to_clean++;
++		cleanup_budget =
++			RTE_MIN(ring_size / ENA_REFILL_THRESH_DIVIDER,
++			(unsigned int)ENA_REFILL_THRESH_PACKET);
+ 
+ 		/* If too many descs to clean, leave it for another run */
+-		if (unlikely(total_tx_descs > ENA_RING_DESCS_RATIO(ring_size)))
++		if (unlikely(total_tx_descs > cleanup_budget))
+ 			break;
+ 	}
+ 	tx_ring->tx_stats.available_desc =
+diff --git a/drivers/net/ena/ena_ethdev.h b/drivers/net/ena/ena_ethdev.h
+index e9b55dc029..4b7e1ce3c0 100644
+--- a/drivers/net/ena/ena_ethdev.h
++++ b/drivers/net/ena/ena_ethdev.h
+@@ -29,6 +29,16 @@
+ #define ENA_WD_TIMEOUT_SEC	3
+ #define ENA_DEVICE_KALIVE_TIMEOUT (ENA_WD_TIMEOUT_SEC * rte_get_timer_hz())
+ 
++/* While processing submitted and completed descriptors (rx and tx path
++ * respectively) in a loop it is desired to:
++ *  - perform batch submissions while populating sumbissmion queue
++ *  - avoid blocking transmission of other packets during cleanup phase
++ * Hence the utilization ratio of 1/8 of a queue size or max value if the size
++ * of the ring is very big - like 8k Rx rings.
++ */
++#define ENA_REFILL_THRESH_DIVIDER      8
++#define ENA_REFILL_THRESH_PACKET       256
++
+ struct ena_adapter;
+ 
+ enum ena_ring_type {
+-- 
+2.20.1
+

--- a/userspace/dpdk/20.02/0007-net-ena-fix-build-for-O1-optimization.patch
+++ b/userspace/dpdk/20.02/0007-net-ena-fix-build-for-O1-optimization.patch
@@ -1,0 +1,47 @@
+From 388d5c19b255a8ee8eb56663234d15a92cebbfc1 Mon Sep 17 00:00:00 2001
+From: Ferruh Yigit <ferruh.yigit@intel.com>
+Date: Mon, 11 May 2020 17:07:24 +0100
+Subject: [PATCH 7/7] net/ena: fix build for O1 optimization
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+[ upstream commit 5f267cb01b41def2af37b8fa56828e75ae91add0 ]
+
+Can be reproduced with "make EXTRA_CFLAGS='-O1'" command using
+gcc (GCC) 9.3.1 20200408 (Red Hat 9.3.1-2)
+
+Build error:
+.../drivers/net/ena/ena_ethdev.c: In function ‘eth_ena_dev_init’:
+.../drivers/net/ena/ena_ethdev.c:1815:20:
+    error: ‘wd_state’ may be used uninitialized in this function
+           [-Werror=maybe-uninitialized]
+ 1815 |  adapter->wd_state = wd_state;
+      |  ~~~~~~~~~~~~~~~~~~^~~~~~~~~~
+
+This looks like false positive, fixing by assigning initial value to
+'wd_state' variable.
+
+Change-Id: I68bd21d4e2a4b41466e670e282856d4f072dadc0
+Signed-off-by: Ferruh Yigit <ferruh.yigit@intel.com>
+Acked-by: Michal Krawczyk <mk@semihalf.com>
+---
+ drivers/net/ena/ena_ethdev.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/drivers/net/ena/ena_ethdev.c b/drivers/net/ena/ena_ethdev.c
+index 06eda43d7a..eaa081fbd3 100644
+--- a/drivers/net/ena/ena_ethdev.c
++++ b/drivers/net/ena/ena_ethdev.c
+@@ -1674,7 +1674,7 @@ static int eth_ena_dev_init(struct rte_eth_dev *eth_dev)
+ 	int rc;
+ 
+ 	static int adapters_found;
+-	bool wd_state;
++	bool wd_state = false;
+ 
+ 	eth_dev->dev_ops = &ena_dev_ops;
+ 	eth_dev->rx_pkt_burst = &eth_ena_recv_pkts;
+-- 
+2.20.1
+

--- a/userspace/dpdk/README.md
+++ b/userspace/dpdk/README.md
@@ -19,15 +19,75 @@ mention about `vfio-pci` support, it can be used with the ENA DPDK PMD. It was
 tested for DPDK releases starting from v17.02, so there are no contraindications
 to use `vfio-pci` instead of `igb_uio` since v17.02 release.
 
-### Instruction for using `vfio-pci`
-To use `vfio-pci`, please do the following:
-1. Insert module
-```
-modprobe vfio-pci
-```
-2. If the machine is not having IOMMU enabled (or is simply not supporting it),
-   please use `vfio-pci` driver in `noiommu` mode
-```
-echo 1 > /sys/module/vfio/parameters/enable_unsafe_noiommu_mode
-```
-3. Bind the intended ENA device to the `vfio-pci` module
+## Instruction for using `igb_uio` or vfio-pci`
+
+1. Insert `vfio-pci` or `igb_uio` kernel module using the command
+   `modprobe vfio-pci` or `modprobe uio; insmod igb_uio.ko wc_activate=1`
+   respectively.
+
+1. For `vfio-pci` users only:
+   Please make sure that `IOMMU` is enabled in your system,
+   or use `vfio` driver in `noiommu` mode:
+
+   ```
+   echo 1 > /sys/module/vfio/parameters/enable_unsafe_noiommu_mode
+   ```
+
+1. To use `noiommu` mode, the `vfio-pci` must be built with flag
+   `CONFIG_VFIO_NOIOMMU`.
+
+1. Bind the intended ENA device to `vfio-pci` or `igb_uio` module.
+
+At this point the system should be ready to run DPDK applications. Once the
+application runs to completion, the ENA can be detached from attached module if
+necessary.
+
+### Note about usage on *.metal instances
+
+On AWS, the metal instances are supporting IOMMU for both arm64 and x86_64
+hosts.
+
+* x86_64 (e.g. c5.metal, i3.metal):
+
+  IOMMU should be disabled by default. In that situation, the `igb_uio` can
+  be used as it is but `vfio-pci` should be working in no-IOMMU mode (please
+  see above).
+
+  When IOMMU is enabled, `igb_uio` cannot be used as it's not supporting this
+  feature, while `vfio-pci` should work without any changes.
+  To enable IOMMU on those hosts, please update `GRUB_CMDLINE_LINUX` in file
+  `/etc/default/grub` with the below extra boot arguments:
+
+  ```
+  iommu=1 intel_iommu=on
+  ```
+
+  Then, make the changes live by executing as a root:
+
+  ```
+  # grub2-mkconfig > /boot/grub2/grub.cfg
+  ```
+
+  Finally, reboot should result in IOMMU being enabled.
+
+* arm64 (a1.metal):
+  IOMMU should be enabled by default. Unfortunately, `vfio-pci` isn't
+  supporting SMMU, which is implementation of IOMMU for arm64 architecture and
+  `igb_uio` isn't supporting IOMMU at all, so to use DPDK with ENA on those
+  hosts, one must disable IOMMU. This can be done by updating
+  `GRUB_CMDLINE_LINUX` in file `/etc/default/grub` with the extra boot
+  argument:
+
+  ```
+  iommu.passthrough=1
+  ```
+
+  Then, make the changes live by executing as a root:
+
+  ```
+  # grub2-mkconfig > /boot/grub2/grub.cfg
+  ```
+
+  Finally, reboot should result in IOMMU being disabled.
+  Without IOMMU, `igb_uio` can be used as it is but `vfio-pci` should be
+  working in no-IOMMU mode (please see above).

--- a/userspace/dpdk/RELEASENOTES.md
+++ b/userspace/dpdk/RELEASENOTES.md
@@ -4,6 +4,60 @@ ___
 
 ### Normal releases
 
+#### v20.05
+_Release of the new version of the driver - r2.2.0_
+
+New Features:
+* Support large LLQ headers for use cases like IPv6 with multiple extensions,
+  where standard header size (96B) can be too small for the LLQ. They can be
+  enabled using device parameter 'large_llq_hdr'.
+* Expose 'Tx drops' statistic.
+* Disable meta descriptor caching. New HW may require this feature to be
+  enabled.
+* Reuse zero-length descriptor. Some HW could append descriptor which length
+  is 0. The driver is reusing it back on the Rx so the application doesn't have
+  to handle this case.
+
+Bug Fixes:
+* Create IO rings with the valid value. Previously, the rings were created
+  using maximum allowed IO ring size, making the memory management ineffective.
+* Remove barriers before calling device doorbells. The doorbell function is
+  already calling a barrier.
+* Fix build with optimization flag O1.
+
+Minor Changes:
+* Limit minimum Rx buffer size to 1400B as some HW isn't supporting smaller
+  buffers.
+* Update ena_com to version from 25.09.2019.
+* Refactor getting IO queues capabilities.
+* Refactor Rx path.
+* Refactor Tx path.
+* Limit refill threshold by a fixed value. For big Rx ring, the refill function
+  could be spending too much time or being called to rarely, so the maximum
+  threshold value was set as 256.
+
+#### v20.02
+_Release of the new version of the driver - r2.0.3_
+
+New Features:
+* Add support for 'Rx offsets' - some HW append data to the mbuf in the given
+  offset and now the driver is aware of that.
+
+* Minor Changes:
+* Update ena_com to version from 20.03.2019.
+
+#### v19.11
+_Release of the new version of the driver - r2.0.2._
+
+Bug Fixes:
+* Fix indication of bad L4 Rx checksum. If the packet was fragmented, the L4
+  checksum should be set as PKT_RX_L4_CKSUM_UNKNOWN. Also, the error flag
+  shouldn't be tested, unless the device indicated the L4 checksum was checked.
+
+Minor Changes:
+* Use SPDX license tags.
+* Use dynamic log type for debug logging.
+
 #### v19.08
 _Release of the new version of the driver - r2.0.1._
 
@@ -195,6 +249,17 @@ Bug Fixes:
 ### Stable releases
 
 There comes only backported patches.
+
+#### v19.11.3
+Bug fixes:
+* HAL fixes (v20.05):
+  - Make allocations thread safe.
+  - Prevent allocation of zero sized memory.
+  - Fix testing for supported RSS hash function.
+* Create IO rings with the valid value. Previously, the rings were created
+  using maximum allowed IO ring size, making the memory management
+  ineffective. (v20.05)
+* Fix build with optimization flag O1. (v20.05)
 
 #### v18.11.3
 Bug fixes:


### PR DESCRIPTION
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
