### PR TITLE
fbsd/ena: update ENA FreeBSD driver to v2.3.0

### DIFF
--- a/kernel/fbsd/ena/Makefile
+++ b/kernel/fbsd/ena/Makefile
@@ -1,5 +1,5 @@
 #
-# BSD LICENSE
+# SPDX-License-Identifier: BSD-2-Clause
 #
 # Copyright (c) 2015-2020 Amazon.com, Inc. or its affiliates.
 # All rights reserved.
@@ -52,6 +52,10 @@ CFLAGS  += -I${.CURDIR}/ena_com
 # Add netmap support in the driver.
 # Uncomment this only if the netmap is enabled in the kernel.
 # CFLAGS += -DDEV_NETMAP
+
+# Add kernel side RSS support in the driver.
+# Uncomment this only if RSS is enabled in the kernel.
+# CFLAGS += -DRSS
 
 clean:
 	rm -f opt_global.h opt_bdg.h device_if.h bus_if.h pci_if.h setdef* *_StripErr

--- a/kernel/fbsd/ena/README
+++ b/kernel/fbsd/ena/README
@@ -3,16 +3,16 @@ FreeBSD kernel driver for Elastic Network Adapter (ENA) family:
 
 Version:
 ========
-v2.2.0
+v2.3.0
 
 Supported FreeBSD Versions:
 ===========================
 amd64:
 - FreeBSD release/11.0 and so on
 - FreeBSD 12, starting from rS3091111
+- FreeBSD 13
 
 aarch64 (A1 instances):
-- FreeBSD stable/11, starting from r345871
 - FreeBSD stable/12, starting from r345872
 - FreeBSD 13, starting from r345371
 
@@ -115,12 +115,164 @@ sync; sleep 30;
 
 Then restart the OS (reboot and reconnect).
 
+Driver tunables:
+=================
+The driver's behavior can be changed using run-time or boot-time sysctl
+arguments.
+
+Boot-time arguments
+-------------------
+The boot-time arguments can be changed in the /boot/loader.conf file (must
+be edited as a root). To make them go live, the system must be rebooted.
+
+- Use 9k mbufs for the Rx descriptors
+  ---
+  Node:          hw.ena.enable_9k_mbufs
+  Scope:         Global for all drivers
+  Input values:  (0|1)
+  Default value: 0
+  Description: If the node value is set to 1, the 9k mbufs will be used for the
+               Rx buffers. If set to 0, the page size mbufs will be used
+               instead.
+               Using 9k buffers for Rx can improve Rx throughput, but in low
+               memory conditions it might increase allocation time, as the
+               system has to look for 3 contiguous pages. This can further lead
+               to OS instability, together with ENA driver reset and NVMe
+               timeouts.
+               If network performance is critical and memory capacity are
+               sufficient, the 9k mbufs can be used.
+
+Run-time arguments
+------------------
+The run-time arguments can be changed anytime, using the sysctl(8) command.
+They can only be modified by a user with the root privileges.
+
+- Controls extra logging verbosity of the driver
+  Scope:         Global for all drivers
+  Node:          hw.ena.log_level
+  Input values:  int
+  Default value: 3
+  Description: The higher the logging level, the more logs will be printed out.
+               Default value (3) is the bitmap combination of two log levels:
+               ALERT and WARNING. The input value for the sysctl an int number,
+               but it should be converted from the appropriate bitmap (please
+               see below).
+               0 means all extra logs are disabled and only error logs will be
+               printed out.
+               The possible flags are:
+               * 0x001 - ENA_ALERT   - Enable ena_com error logs and extra error
+                                       messages.
+               * 0x002 - ENA_WARNING - Enable logs for non critical errors.
+               * 0x004 - ENA_INFO    - Makes the driver more verbose about its
+                                       action.
+               * 0x008 - ENA_DBG     - Enable general debug logs.
+               * 0x010 - ENA_TXPTH   - Enables Tx path tracing - requires
+                                       ENA_DBG flag.
+               * 0x020 - ENA_RXPTH   - Enables Rx path tracing - requires
+                                       ENA_DBG flag.
+               * 0x040 - ENA_RSC     - Enables Tx/Rx resources tracing -
+                                       requires ENA_RXPTH or ENA_TXPTH
+                                       flags and ENA_DBG flag.
+               * 0x080 - ENA_IOQ     - Enables detailed information regarding
+                                       the IO queues - requires ENA_INFO flag.
+               * 0x100 - ENA_ADMQ    - Enables detailed information about admin
+                                       queue actions - requires ENA_INFO flag.
+               * 0x200 - ENA_NETMAP  - Enables extra logs for driver working in
+                                       the netmap mode.
+  Example: To enable extra alerts, warnings, and to trace ENA Tx path, the
+           combination of ENA_ALERT | ENA_WARNING | ENA_DBG | ENA_TXPTH is
+           needed. It gives hex mask: 0x01b, which when converted to decimal
+           value, will give 27. To update the logging level, the below command
+           should be used:
+             sysctl hw.ena.log_level=27
+
+- Number of the currently allocated and used IO queues
+  Scope:         Local for the interface X (X is the interface number)
+  Node:          dev.ena.X.io_queues_nb
+  Input values:  [1, max_num_io_queues]
+  Default value: max_num_io_queues
+  Description: Controls the number of IO queues pairs (Tx/Rx). Currently it's
+               impossible to have different number of Tx and Rx queues.
+               As this call has to reallocate the queues, it will reset the
+               interface and restart all the queues - it means that everything
+               that was currently held in the queue will be lost, leading to
+               potential packet drops.
+               This call can fail if the system isn't able to provide
+               the driver with enough resources. In that situation, the driver
+               will try to revert the previous number of the IO queues. If this
+               also fails, the device reset will be triggered.
+  Example: To use only 2 Tx and Rx queues for the device ena1, the below command
+           should be used:
+             sysctl dev.ena.1.io_queues_nb=2
+
+- Size of the Rx queue
+  Scope:         Local for the interface X (X is the interface number)
+  Node:          dev.ena.X.rx_queue_size
+  Input values:  [256, max_rx_ring_size] - must be a power of 2
+  Default value: 1024
+  Description: Controls the number of IO descriptors for each Rx queue.
+               The user may want to increase the Rx queue size if he can observe
+               high number of the Rx drops in the driver's statistics.
+               For performance reasons, the Rx queue size must be a
+               power of 2.
+               This call can fail if the system isn't able to provide
+               the driver with enough resources. In that situation, the driver
+               will try to revert the previous number of the descriptors. If
+               this also fails, the device reset will be triggered.
+  Example: To increase Rx ring size to 8K descriptors for the device ena0, the
+           below command should be used:
+             sysctl dev.ena.0.rx_queue_size=8192
+
+- Size of the Tx buffer ring (drbr)
+  Scope:         Local for the interface X (X is the interface number)
+  Node:          dev.ena.X.buf_ring_size
+  Input values:  uint32_t - must be a power of 2
+  Default value: 4096
+  Description: Controls the number of mbufs that can be held in the Tx buffer
+               ring. The drbr is being used as a multiple-producer,
+               single-consumer lockless ring for buffering extra mbufs coming
+               from the stack in case the Tx procedure is busy sending the
+               packets or the Tx ring is full.
+               Increasing size of the buffer ring may reduce the number of Tx
+               packets being dropped in case of big Tx burst which can't be
+               handled by the IO queue immediately.
+               Each Tx queue has it's own drbr.
+               It is recommended to keep the drbr with at least the default
+               value, but if the system lacks the resource, it can be reduced.
+               This call can fail if the system isn't able to provide the driver
+               with enough resources. In that situation, the driver will try to
+               revert the previous number of the drbr and trigger the device
+               reset.
+  Example: To make the drbr half of a size for the interface ena0, the below
+           command should be used:
+             sysctl dev.ena.0.buf_ring_size=2048
+
+- Interval in seconds for updating ENI metrics.
+  Scope:         Local for the interface X (X is the interface number)
+  Node:          dev.ena.X.eni_metrics.sample_interval
+  Input values:  [0; 3600]
+  Default value: 0
+  Description: Determines how often (if ever) the ENI metrics should be updated.
+               The ENI metrics are being updated asynchronously in a timer
+               service in order to avoid admin queue overload by sysctl node
+               reading. The value in this node controls the interval between
+               issuing admin command to the device which will update the ENI
+               metrics value.
+               If some application is periodically monitoring the eni_metrics,
+               then the ENI metrics interval can be adjusted accordingly.
+               0 is turning off the update totally. 1 is the minimum interval
+               and is equal to 1 second. The maximum allowed update interval is
+               1 hour.
+  Example: To update of the ENI metrics for the device ena1 every 10 seconds,
+           the below command should be used:
+             sysctl dev.ena.1.eni_metrics.sample_interval=10
+
 Supported PCI vendor ID/device IDs:
 ===================================
 1d0f:0ec2 - ENA PF
-1d0f:1ec2 - ENA PF with LLQ support
+1d0f:1ec2 - ENA PF RSERV0
 1d0f:ec20 - ENA VF
-1d0f:ec21 - ENA VF with LLQ support
+1d0f:ec21 - ENA VF RSERV0
 
 ENA Source Code Directory Structure:
 ====================================

--- a/kernel/fbsd/ena/RELEASENOTES.md
+++ b/kernel/fbsd/ena/RELEASENOTES.md
@@ -7,14 +7,33 @@ ENA driver is supported on all FreeBSD releases starting from 11.2
 The driver was verified on the following distributions:
 
 **Releases:**
-* FreeBSD 11.3
-* FreeBSD 11.4-RC1
-* FreeBSD 12.1
+* FreeBSD 11.4
+* FreeBSD 12.2
 
 **Development:**
-* stable/11 - r361551
-* stable/12 - r361551
-* HEAD - r361551
+* stable/11 - r367416
+* stable/12 - r367418
+* HEAD - 367420
+
+## r2.3.0 release notes
+**New Features**
+* Add ENI (Elastic Network Interface) metrics support. They can be
+  enabled and accessed using the sysctl.
+* Add support for the Rx offsets (HW feature)
+
+**Bug Fixes**
+* Fix driver when running on kernel with RSS option being enabled
+  (please note, that the standalone driver should also be built with
+  'CFLAGS += -DRSS' option in the Makefile).
+* Fix alignment of the ena_com_io_cq descriptors.
+* Fix validation of the Rx requested ID.
+
+**Minor Changes**
+* Add SPDX license identifiers.
+* Add description of all driver tunables to the README file.
+* Fix names/description of the device IDs supported by the driver.
+* Update HAL to the newer version.
+* Remove deprecated ENA_WARN macro.
 
 ## r2.2.0 release notes
 **New Features**

--- a/kernel/fbsd/ena/ena.c
+++ b/kernel/fbsd/ena/ena.c
@@ -1,5 +1,5 @@
 /*-
- * BSD LICENSE
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Copyright (c) 2015-2020 Amazon.com, Inc. or its affiliates.
  * All rights reserved.
@@ -61,6 +61,9 @@ __FBSDID("$FreeBSD$");
 #include <net/if_media.h>
 #include <net/if_types.h>
 #include <net/if_vlan_var.h>
+#ifdef RSS
+#include <net/rss_config.h>
+#endif
 
 #include <netinet/in_systm.h>
 #include <netinet/in.h>
@@ -167,15 +170,16 @@ static int	ena_enable_msix_and_set_admin_interrupts(struct ena_adapter *);
 static void ena_update_on_link_change(void *, struct ena_admin_aenq_entry *);
 static void	unimplemented_aenq_handler(void *,
     struct ena_admin_aenq_entry *);
+static int	ena_copy_eni_metrics(struct ena_adapter *);
 static void	ena_timer_service(void *);
 
 static char ena_version[] = DEVICE_NAME DRV_MODULE_NAME " v" DRV_MODULE_VERSION;
 
 static ena_vendor_info_t ena_vendor_info_array[] = {
     { PCI_VENDOR_ID_AMAZON, PCI_DEV_ID_ENA_PF, 0},
-    { PCI_VENDOR_ID_AMAZON, PCI_DEV_ID_ENA_LLQ_PF, 0},
+    { PCI_VENDOR_ID_AMAZON, PCI_DEV_ID_ENA_PF_RSERV0, 0},
     { PCI_VENDOR_ID_AMAZON, PCI_DEV_ID_ENA_VF, 0},
-    { PCI_VENDOR_ID_AMAZON, PCI_DEV_ID_ENA_LLQ_VF, 0},
+    { PCI_VENDOR_ID_AMAZON, PCI_DEV_ID_ENA_VF_RSERV0, 0},
     /* Last entry */
     { 0, 0, 0 }
 };
@@ -195,7 +199,7 @@ ena_dmamap_callback(void *arg, bus_dma_segment_t *segs, int nseg, int error)
 
 int
 ena_dma_alloc(device_t dmadev, bus_size_t size,
-    ena_mem_handle_t *dma , int mapflags)
+    ena_mem_handle_t *dma, int mapflags, bus_size_t alignment)
 {
 	struct ena_adapter* adapter = device_get_softc(dmadev);
 	uint32_t maxsize;
@@ -209,7 +213,7 @@ ena_dma_alloc(device_t dmadev, bus_size_t size,
 		dma_space_addr = BUS_SPACE_MAXADDR;
 
 	error = bus_dma_tag_create(bus_get_dma_tag(dmadev), /* parent */
-	    8, 0,	      /* alignment, bounds 		*/
+	    alignment, 0,     /* alignment, bounds 		*/
 	    dma_space_addr,   /* lowaddr of exclusion window	*/
 	    BUS_SPACE_MAXADDR,/* highaddr of exclusion window	*/
 	    NULL, NULL,	      /* filter, filterarg 		*/
@@ -221,14 +225,14 @@ ena_dma_alloc(device_t dmadev, bus_size_t size,
 	    NULL,	      /* lockarg 			*/
 	    &dma->tag);
 	if (unlikely(error != 0)) {
-		ena_trace(ENA_ALERT, "bus_dma_tag_create failed: %d\n", error);
+		ena_trace(NULL, ENA_ALERT, "bus_dma_tag_create failed: %d\n", error);
 		goto fail_tag;
 	}
 
 	error = bus_dmamem_alloc(dma->tag, (void**) &dma->vaddr,
 	    BUS_DMA_COHERENT | BUS_DMA_ZERO, &dma->map);
 	if (unlikely(error != 0)) {
-		ena_trace(ENA_ALERT, "bus_dmamem_alloc(%ju) failed: %d\n",
+		ena_trace(NULL, ENA_ALERT, "bus_dmamem_alloc(%ju) failed: %d\n",
 		    (uintmax_t)size, error);
 		goto fail_map_create;
 	}
@@ -237,7 +241,7 @@ ena_dma_alloc(device_t dmadev, bus_size_t size,
 	error = bus_dmamap_load(dma->tag, dma->map, dma->vaddr,
 	    size, ena_dmamap_callback, &dma->paddr, mapflags);
 	if (unlikely((error != 0) || (dma->paddr == 0))) {
-		ena_trace(ENA_ALERT, ": bus_dmamap_load failed: %d\n", error);
+		ena_trace(NULL, ENA_ALERT, ": bus_dmamap_load failed: %d\n", error);
 		goto fail_map_load;
 	}
 
@@ -314,7 +318,7 @@ ena_probe(device_t dev)
 	while (ent->vendor_id != 0) {
 		if ((pci_vendor_id == ent->vendor_id) &&
 		    (pci_device_id == ent->device_id)) {
-			ena_trace(ENA_DBG, "vendor=%x device=%x\n",
+			ena_trace(NULL, ENA_DBG, "vendor=%x device=%x\n",
 			    pci_vendor_id, pci_device_id);
 
 			sprintf(adapter_name, DEVICE_DESC);
@@ -344,7 +348,7 @@ ena_change_mtu(if_t ifp, int new_mtu)
 
 	rc = ena_com_set_dev_mtu(adapter->ena_dev, new_mtu);
 	if (likely(rc == 0)) {
-		ena_trace(ENA_DBG, "set MTU to %d\n", new_mtu);
+		ena_trace(NULL, ENA_DBG, "set MTU to %d\n", new_mtu);
 		if_setmtu(ifp, new_mtu);
 	} else {
 		device_printf(adapter->pdev, "Failed to set MTU to %d\n",
@@ -665,7 +669,7 @@ ena_setup_tx_resources(struct ena_adapter *adapter, int qid)
 		err = bus_dmamap_create(adapter->tx_buf_tag, 0,
 		    &tx_ring->tx_buffer_info[i].dmamap);
 		if (unlikely(err != 0)) {
-			ena_trace(ENA_ALERT,
+			ena_trace(NULL, ENA_ALERT,
 			    "Unable to create Tx DMA map for buffer %d\n",
 			    i);
 			goto err_map_release;
@@ -678,7 +682,7 @@ ena_setup_tx_resources(struct ena_adapter *adapter, int qid)
 				err = bus_dmamap_create(adapter->tx_buf_tag, 0,
 				    &map[j]);
 				if (unlikely(err != 0)) {
-					ena_trace(ENA_ALERT, "Unable to create "
+					ena_trace(NULL, ENA_ALERT, "Unable to create "
 					    "Tx DMA for buffer %d %d\n", i, j);
 					goto err_map_release;
 				}
@@ -692,7 +696,7 @@ ena_setup_tx_resources(struct ena_adapter *adapter, int qid)
 	tx_ring->enqueue_tq = taskqueue_create_fast("ena_tx_enque", M_NOWAIT,
 	    taskqueue_thread_enqueue, &tx_ring->enqueue_tq);
 	if (unlikely(tx_ring->enqueue_tq == NULL)) {
-		ena_trace(ENA_ALERT,
+		ena_trace(NULL, ENA_ALERT,
 		    "Unable to create taskqueue for enqueue task\n");
 		i = tx_ring->ring_size;
 		goto err_map_release;
@@ -877,7 +881,7 @@ ena_setup_rx_resources(struct ena_adapter *adapter, unsigned int qid)
 		err = bus_dmamap_create(adapter->rx_buf_tag, 0,
 		    &(rx_ring->rx_buffer_info[i].map));
 		if (err != 0) {
-			ena_trace(ENA_ALERT,
+			ena_trace(NULL, ENA_ALERT,
 			    "Unable to create Rx DMA map for buffer %d\n", i);
 			goto err_buf_info_unmap;
 		}
@@ -890,7 +894,7 @@ ena_setup_rx_resources(struct ena_adapter *adapter, unsigned int qid)
 			device_printf(adapter->pdev,
 			    "LRO[%d] Initialization failed!\n", qid);
 		} else {
-			ena_trace(ENA_INFO,
+			ena_trace(NULL, ENA_INFO,
 			    "RX Soft LRO[%d] Initialized\n", qid);
 			rx_ring->lro.ifp = adapter->ifp;
 		}
@@ -1021,13 +1025,13 @@ ena_alloc_rx_mbuf(struct ena_adapter *adapter,
 	rx_info->mbuf->m_pkthdr.len = rx_info->mbuf->m_len = mlen;
 
 	/* Map packets for DMA */
-	ena_trace(ENA_DBG | ENA_RSC | ENA_RXPTH,
+	ena_trace(NULL, ENA_DBG | ENA_RSC | ENA_RXPTH,
 	    "Using tag %p for buffers' DMA mapping, mbuf %p len: %d\n",
 	    adapter->rx_buf_tag,rx_info->mbuf, rx_info->mbuf->m_len);
 	error = bus_dmamap_load_mbuf_sg(adapter->rx_buf_tag, rx_info->map,
 	    rx_info->mbuf, segs, &nsegs, BUS_DMA_NOWAIT);
 	if (unlikely((error != 0) || (nsegs != 1))) {
-		ena_trace(ENA_WARNING, "failed to map mbuf, error: %d, "
+		ena_trace(NULL, ENA_WARNING, "failed to map mbuf, error: %d, "
 		    "nsegs: %d\n", error, nsegs);
 		counter_u64_add(rx_ring->rx_stats.dma_mapping_err, 1);
 		goto exit;
@@ -1040,7 +1044,7 @@ ena_alloc_rx_mbuf(struct ena_adapter *adapter,
 	ena_buf->paddr = segs[0].ds_addr;
 	ena_buf->len = mlen;
 
-	ena_trace(ENA_DBG | ENA_RSC | ENA_RXPTH,
+	ena_trace(NULL, ENA_DBG | ENA_RSC | ENA_RXPTH,
 	    "ALLOC RX BUF: mbuf %p, rx_info %p, len %d, paddr %#jx\n",
 	    rx_info->mbuf, rx_info,ena_buf->len, (uintmax_t)ena_buf->paddr);
 
@@ -1058,7 +1062,7 @@ ena_free_rx_mbuf(struct ena_adapter *adapter, struct ena_ring *rx_ring,
 {
 
 	if (rx_info->mbuf == NULL) {
-		ena_trace(ENA_WARNING, "Trying to free unallocated buffer\n");
+		ena_trace(NULL, ENA_WARNING, "Trying to free unallocated buffer\n");
 		return;
 	}
 
@@ -1083,7 +1087,7 @@ ena_refill_rx_bufs(struct ena_ring *rx_ring, uint32_t num)
 	uint32_t i;
 	int rc;
 
-	ena_trace(ENA_DBG | ENA_RXPTH | ENA_RSC, "refill qid: %d\n",
+	ena_trace(NULL, ENA_DBG | ENA_RXPTH | ENA_RSC, "refill qid: %d\n",
 	    rx_ring->qid);
 
 	next_to_use = rx_ring->next_to_use;
@@ -1091,7 +1095,7 @@ ena_refill_rx_bufs(struct ena_ring *rx_ring, uint32_t num)
 	for (i = 0; i < num; i++) {
 		struct ena_rx_buffer *rx_info;
 
-		ena_trace(ENA_DBG | ENA_RXPTH | ENA_RSC,
+		ena_trace(NULL, ENA_DBG | ENA_RXPTH | ENA_RSC,
 		    "RX buffer - next to use: %d\n", next_to_use);
 
 		req_id = rx_ring->free_rx_ids[next_to_use];
@@ -1103,7 +1107,7 @@ ena_refill_rx_bufs(struct ena_ring *rx_ring, uint32_t num)
 #endif /* DEV_NETMAP */
 			rc = ena_alloc_rx_mbuf(adapter, rx_ring, rx_info);
 		if (unlikely(rc != 0)) {
-			ena_trace(ENA_WARNING,
+			ena_trace(NULL, ENA_WARNING,
 			    "failed to alloc buffer for rx queue %d\n",
 			    rx_ring->qid);
 			break;
@@ -1111,7 +1115,7 @@ ena_refill_rx_bufs(struct ena_ring *rx_ring, uint32_t num)
 		rc = ena_com_add_single_rx_desc(rx_ring->ena_com_io_sq,
 		    &rx_info->ena_buf, req_id);
 		if (unlikely(rc != 0)) {
-			ena_trace(ENA_WARNING,
+			ena_trace(NULL, ENA_WARNING,
 			    "failed to add buffer for rx queue %d\n",
 			    rx_ring->qid);
 			break;
@@ -1122,7 +1126,7 @@ ena_refill_rx_bufs(struct ena_ring *rx_ring, uint32_t num)
 
 	if (unlikely(i < num)) {
 		counter_u64_add(rx_ring->rx_stats.refil_partial, 1);
-		ena_trace(ENA_WARNING,
+		ena_trace(NULL, ENA_WARNING,
 		     "refilled rx qid %d with only %d mbufs (from %d)\n",
 		     rx_ring->qid, i, num);
 	}
@@ -1331,7 +1335,7 @@ ena_refill_all_rx_bufs(struct ena_adapter *adapter)
 		bufs_num = rx_ring->ring_size - 1;
 		rc = ena_refill_rx_bufs(rx_ring, bufs_num);
 		if (unlikely(rc != bufs_num))
-			ena_trace(ENA_WARNING, "refilling Queue %d failed. "
+			ena_trace(NULL, ENA_WARNING, "refilling Queue %d failed. "
 			    "Allocated %d buffers from: %d\n", i, rc, bufs_num);
 #ifdef DEV_NETMAP
 		rx_ring->initialized = true;
@@ -1372,7 +1376,7 @@ ena_free_tx_bufs(struct ena_adapter *adapter, unsigned int qid)
 			    qid, i);
 			print_once = false;
 		} else {
-			ena_trace(ENA_DBG,
+			ena_trace(NULL, ENA_DBG,
 			    "free uncompleted tx mbuf qid %d idx 0x%x\n",
 			     qid, i);
 		}
@@ -1592,7 +1596,7 @@ ena_enable_msix(struct ena_adapter *adapter)
 	adapter->msix_entries = malloc(msix_vecs * sizeof(struct msix_entry),
 	    M_DEVBUF, M_WAITOK | M_ZERO);
 
-	ena_trace(ENA_DBG, "trying to enable MSI-X, vectors: %d\n", msix_vecs);
+	ena_trace(NULL, ENA_DBG, "trying to enable MSI-X, vectors: %d\n", msix_vecs);
 
 	for (i = 0; i < msix_vecs; i++) {
 		adapter->msix_entries[i].entry = i;
@@ -1670,7 +1674,7 @@ ena_setup_io_intr(struct ena_adapter *adapter)
 		adapter->irq_tbl[irq_idx].data = &adapter->que[i];
 		adapter->irq_tbl[irq_idx].vector =
 		    adapter->msix_entries[irq_idx].vector;
-		ena_trace(ENA_INFO | ENA_IOQ, "ena_setup_io_intr vector: %d\n",
+		ena_trace(NULL, ENA_INFO | ENA_IOQ, "ena_setup_io_intr vector: %d\n",
 		    adapter->msix_entries[irq_idx].vector);
 
 		/*
@@ -1720,7 +1724,7 @@ ena_request_mgmnt_irq(struct ena_adapter *adapter)
 	return (rc);
 
 err_res_free:
-	ena_trace(ENA_INFO | ENA_ADMQ, "releasing resource for irq %d\n",
+	ena_trace(NULL, ENA_INFO | ENA_ADMQ, "releasing resource for irq %d\n",
 	    irq->vector);
 	rcc = bus_release_resource(adapter->pdev, SYS_RES_IRQ,
 	    irq->vector, irq->res);
@@ -1773,7 +1777,7 @@ ena_request_io_irq(struct ena_adapter *adapter)
 		}
 		irq->requested = true;
 
-		ena_trace(ENA_INFO, "queue %d - cpu %d\n",
+		ena_trace(NULL, ENA_INFO, "queue %d - cpu %d\n",
 		    i - ENA_IO_IRQ_FIRST_IDX, irq->cpu);
 	}
 
@@ -1820,7 +1824,7 @@ ena_free_mgmnt_irq(struct ena_adapter *adapter)
 
 	irq = &adapter->irq_tbl[ENA_MGMNT_IRQ_IDX];
 	if (irq->requested) {
-		ena_trace(ENA_INFO | ENA_ADMQ, "tear down irq: %d\n",
+		ena_trace(NULL, ENA_INFO | ENA_ADMQ, "tear down irq: %d\n",
 		    irq->vector);
 		rc = bus_teardown_intr(adapter->pdev, irq->res, irq->cookie);
 		if (unlikely(rc != 0))
@@ -1830,7 +1834,7 @@ ena_free_mgmnt_irq(struct ena_adapter *adapter)
 	}
 
 	if (irq->res != NULL) {
-		ena_trace(ENA_INFO | ENA_ADMQ, "release resource irq: %d\n",
+		ena_trace(NULL, ENA_INFO | ENA_ADMQ, "release resource irq: %d\n",
 		    irq->vector);
 		rc = bus_release_resource(adapter->pdev, SYS_RES_IRQ,
 		    irq->vector, irq->res);
@@ -1850,7 +1854,7 @@ ena_free_io_irq(struct ena_adapter *adapter)
 	for (int i = ENA_IO_IRQ_FIRST_IDX; i < adapter->msix_vecs; i++) {
 		irq = &adapter->irq_tbl[i];
 		if (irq->requested) {
-			ena_trace(ENA_INFO | ENA_IOQ, "tear down irq: %d\n",
+			ena_trace(NULL, ENA_INFO | ENA_IOQ, "tear down irq: %d\n",
 			    irq->vector);
 			rc = bus_teardown_intr(adapter->pdev, irq->res,
 			    irq->cookie);
@@ -1862,7 +1866,7 @@ ena_free_io_irq(struct ena_adapter *adapter)
 		}
 
 		if (irq->res != NULL) {
-			ena_trace(ENA_INFO | ENA_IOQ, "release resource irq: %d\n",
+			ena_trace(NULL, ENA_INFO | ENA_IOQ, "release resource irq: %d\n",
 			    irq->vector);
 			rc = bus_release_resource(adapter->pdev, SYS_RES_IRQ,
 			    irq->vector, irq->res);
@@ -2009,21 +2013,21 @@ create_queues_with_size_backoff(struct ena_adapter *adapter)
 		/* Allocate transmit descriptors */
 		rc = ena_setup_all_tx_resources(adapter);
 		if (unlikely(rc != 0)) {
-			ena_trace(ENA_ALERT, "err_setup_tx\n");
+			ena_trace(NULL, ENA_ALERT, "err_setup_tx\n");
 			goto err_setup_tx;
 		}
 
 		/* Allocate receive descriptors */
 		rc = ena_setup_all_rx_resources(adapter);
 		if (unlikely(rc != 0)) {
-			ena_trace(ENA_ALERT, "err_setup_rx\n");
+			ena_trace(NULL, ENA_ALERT, "err_setup_rx\n");
 			goto err_setup_rx;
 		}
 
 		/* Create IO queues for Rx & Tx */
 		rc = ena_create_io_queues(adapter);
 		if (unlikely(rc != 0)) {
-			ena_trace(ENA_ALERT,
+			ena_trace(NULL, ENA_ALERT,
 			    "create IO queues failed\n");
 			goto err_io_que;
 		}
@@ -2040,7 +2044,7 @@ err_setup_tx:
 		 * error straightaway.
 		 */
 		if (unlikely(rc != ENOMEM)) {
-			ena_trace(ENA_ALERT,
+			ena_trace(NULL, ENA_ALERT,
 			    "Queue creation failed with error code: %d\n", rc);
 			return (rc);
 		}
@@ -2095,12 +2099,12 @@ ena_up(struct ena_adapter *adapter)
 	/* setup interrupts for IO queues */
 	rc = ena_setup_io_intr(adapter);
 	if (unlikely(rc != 0)) {
-		ena_trace(ENA_ALERT, "error setting up IO interrupt\n");
+		ena_trace(NULL, ENA_ALERT, "error setting up IO interrupt\n");
 		goto error;
 	}
 	rc = ena_request_io_irq(adapter);
 	if (unlikely(rc != 0)) {
-		ena_trace(ENA_ALERT, "err_req_irq\n");
+		ena_trace(NULL, ENA_ALERT, "err_req_irq\n");
 		goto error;
 	}
 
@@ -2115,7 +2119,7 @@ ena_up(struct ena_adapter *adapter)
 
 	rc = create_queues_with_size_backoff(adapter);
 	if (unlikely(rc != 0)) {
-		ena_trace(ENA_ALERT,
+		ena_trace(NULL, ENA_ALERT,
 		    "error creating queues with size backoff\n");
 		goto err_create_queues_with_backoff;
 	}
@@ -2197,7 +2201,7 @@ static void
 ena_media_status(if_t ifp, struct ifmediareq *ifmr)
 {
 	struct ena_adapter *adapter = if_getsoftc(ifp);
-	ena_trace(ENA_DBG, "enter\n");
+	ena_trace(NULL, ENA_DBG, "enter\n");
 
 	ENA_LOCK_LOCK(adapter);
 
@@ -2206,7 +2210,7 @@ ena_media_status(if_t ifp, struct ifmediareq *ifmr)
 
 	if (!ENA_FLAG_ISSET(ENA_FLAG_LINK_UP, adapter)) {
 		ENA_LOCK_UNLOCK(adapter);
-		ena_trace(ENA_INFO, "Link is down\n");
+		ena_trace(NULL, ENA_INFO, "Link is down\n");
 		return;
 	}
 
@@ -2400,7 +2404,7 @@ ena_setup_ifnet(device_t pdev, struct ena_adapter *adapter,
 
 	ifp = adapter->ifp = if_gethandle(IFT_ETHER);
 	if (unlikely(ifp == NULL)) {
-		ena_trace(ENA_ALERT, "can not allocate ifnet structure\n");
+		ena_trace(NULL, ENA_ALERT, "can not allocate ifnet structure\n");
 		return (ENXIO);
 	}
 	if_initname(ifp, device_get_name(pdev), device_get_unit(pdev));
@@ -2542,7 +2546,7 @@ ena_enable_wc(struct resource *res)
 	/* Enable write combining */
 	rc = pmap_change_attr(va, len, VM_MEMATTR_WRITE_COMBINING);
 	if (unlikely(rc != 0)) {
-		ena_trace(ENA_ALERT, "pmap_change_attr failed, %d\n", rc);
+		ena_trace(NULL, ENA_ALERT, "pmap_change_attr failed, %d\n", rc);
 		return (rc);
 	}
 
@@ -2557,7 +2561,7 @@ ena_enable_wc(struct resource *res)
 	int rc;
 	rc = pmap_change_attr(va, len, VM_MEMATTR_WRITE_COMBINING);
 	if (unlikely(rc != 0))
-		ena_trace(ENA_ALERT, "pmap_change_attr failed, %d\n", rc);
+		ena_trace(NULL, ENA_ALERT, "pmap_change_attr failed, %d\n", rc);
 
 	return (rc);
 #else /* defined(__aarch64__) */
@@ -2734,6 +2738,16 @@ ena_rss_init_default(struct ena_adapter *adapter)
 		}
 	}
 
+#ifdef RSS
+	uint8_t rss_algo = rss_gethashalgo();
+	if (rss_algo == RSS_HASH_TOEPLITZ) {
+		uint8_t hash_key[RSS_KEYSIZE];
+
+		rss_getkey(hash_key);
+		rc = ena_com_fill_hash_function(ena_dev, ENA_ADMIN_TOEPLITZ,
+		    hash_key, RSS_KEYSIZE, 0xFFFFFFFF);
+	} else
+#endif
 	rc = ena_com_fill_hash_function(ena_dev, ENA_ADMIN_CRC32, NULL,
 	    ENA_HASH_KEY_SIZE, 0xFFFFFFFF);
 	if (unlikely((rc != 0) && (rc != EOPNOTSUPP))) {
@@ -2764,7 +2778,7 @@ ena_rss_init_default_deferred(void *arg)
 
 	dc = devclass_find("ena");
 	if (unlikely(dc == NULL)) {
-		ena_trace(ENA_ALERT, "No devclass ena\n");
+		ena_trace(NULL, ENA_ALERT, "No devclass ena\n");
 		return;
 	}
 
@@ -2795,7 +2809,7 @@ ena_config_host_info(struct ena_com_dev *ena_dev, device_t dev)
 	/* Allocate only the host info */
 	rc = ena_com_allocate_host_info(ena_dev);
 	if (unlikely(rc != 0)) {
-		ena_trace(ENA_ALERT, "Cannot allocate host info\n");
+		ena_trace(NULL, ENA_ALERT, "Cannot allocate host info\n");
 		return;
 	}
 
@@ -2816,13 +2830,15 @@ ena_config_host_info(struct ena_com_dev *ena_dev, device_t dev)
 		(DRV_MODULE_VER_MINOR << ENA_ADMIN_HOST_INFO_MINOR_SHIFT) |
 		(DRV_MODULE_VER_SUBMINOR << ENA_ADMIN_HOST_INFO_SUB_MINOR_SHIFT);
 	host_info->num_cpus = mp_ncpus;
+	host_info->driver_supported_features =
+	    ENA_ADMIN_HOST_INFO_RX_OFFSET_MASK;
 
 	rc = ena_com_set_host_attributes(ena_dev);
 	if (unlikely(rc != 0)) {
 		if (rc == EOPNOTSUPP)
-			ena_trace(ENA_WARNING, "Cannot set host attributes\n");
+			ena_trace(NULL, ENA_WARNING, "Cannot set host attributes\n");
 		else
-			ena_trace(ENA_ALERT, "Cannot set host attributes\n");
+			ena_trace(NULL, ENA_ALERT, "Cannot set host attributes\n");
 
 		goto err;
 	}
@@ -3076,7 +3092,7 @@ check_missing_comp_in_tx_queue(struct ena_adapter *adapter,
 		if (unlikely(time_offset > adapter->missing_tx_timeout)) {
 
 			if (!tx_buf->print_once)
-				ena_trace(ENA_WARNING, "Found a Tx that wasn't "
+				ena_trace(NULL, ENA_WARNING, "Found a Tx that wasn't "
 				    "completed on time, qid %d, index %d.\n",
 				    tx_ring->qid, i);
 
@@ -3232,6 +3248,44 @@ static void ena_update_hints(struct ena_adapter *adapter,
 	}
 }
 
+/**
+ * ena_copy_eni_metrics - Get and copy ENI metrics from the HW.
+ * @adapter: ENA device adapter
+ *
+ * Returns 0 on success, EOPNOTSUPP if current HW doesn't support those metrics
+ * and other error codes on failure.
+ *
+ * This function can possibly cause a race with other calls to the admin queue.
+ * Because of that, the caller should either lock this function or make sure
+ * that there is no race in the current context.
+ */
+static int
+ena_copy_eni_metrics(struct ena_adapter *adapter)
+{
+	static bool print_once = true;
+	int rc;
+
+	rc = ena_com_get_eni_stats(adapter->ena_dev, &adapter->eni_metrics);
+
+	if (rc != 0) {
+		if (rc == ENA_COM_UNSUPPORTED) {
+			if (print_once) {
+				device_printf(adapter->pdev,
+				    "Retrieving ENI metrics is not supported.\n");
+				print_once = false;
+			} else {
+				ena_trace(NULL, ENA_DBG,
+				    "Retrieving ENI metrics is not supported.\n");
+			}
+		} else {
+			device_printf(adapter->pdev,
+			    "Failed to get ENI metrics: %d\n", rc);
+		}
+	}
+
+	return (rc);
+}
+
 static void
 ena_timer_service(void *data)
 {
@@ -3246,6 +3300,38 @@ ena_timer_service(void *data)
 	check_for_missing_completions(adapter);
 
 	check_for_empty_rx_ring(adapter);
+
+	/*
+	 * User controller update of the ENI metrics.
+	 * If the delay was set to 0, then the stats shouldn't be updated at
+	 * all.
+	 * Otherwise, wait 'eni_metrics_sample_interval' seconds, before
+	 * updating stats.
+	 * As timer service is executed every second, it's enough to increment
+	 * appropriate counter each time the timer service is executed.
+	 */
+	if ((adapter->eni_metrics_sample_interval != 0) &&
+	    (++adapter->eni_metrics_sample_interval_cnt >=
+	     adapter->eni_metrics_sample_interval)) {
+		/*
+		 * There is no race with other admin queue calls, as:
+		 *   - Timer service runs after interface is up, so all
+		 *     configuration calls to the admin queue are finished.
+		 *   - After interface is up, the driver doesn't use (at least
+		 *     for now) other functions writing to the admin queue.
+		 *
+		 * It may change in the future, so in that situation, the lock
+		 * will be needed. ENA_LOCK_*() cannot be used for that purpose,
+		 * as callout ena_timer_service is protected by them. It could
+		 * lead to the deadlock if callout_drain() would hold the lock
+		 * before ena_copy_eni_metrics() was executed. It's advised to
+		 * use separate lock in that situation which will be used only
+		 * for the admin queue.
+		 */
+		(void)ena_copy_eni_metrics(adapter);
+		adapter->eni_metrics_sample_interval_cnt = 0;
+	}
+
 
 	if (host_info != NULL)
 		ena_update_host_info(host_info, adapter->ifp);
@@ -3805,11 +3891,11 @@ static void ena_notification(void *adapter_data,
 	struct ena_adapter *adapter = (struct ena_adapter *)adapter_data;
 	struct ena_admin_ena_hw_hints *hints;
 
-	ENA_WARN(aenq_e->aenq_common_desc.group != ENA_ADMIN_NOTIFICATION,
+	ENA_WARN(NULL, aenq_e->aenq_common_desc.group != ENA_ADMIN_NOTIFICATION,
 	    "Invalid group(%x) expected %x\n",	aenq_e->aenq_common_desc.group,
 	    ENA_ADMIN_NOTIFICATION);
 
-	switch (aenq_e->aenq_common_desc.syndrom) {
+	switch (aenq_e->aenq_common_desc.syndrome) {
 	case ENA_ADMIN_UPDATE_HINTS:
 		hints =
 		    (struct ena_admin_ena_hw_hints *)(&aenq_e->inline_data_w4);
@@ -3818,7 +3904,7 @@ static void ena_notification(void *adapter_data,
 	default:
 		device_printf(adapter->pdev,
 		    "Invalid aenq notification link state %d\n",
-		    aenq_e->aenq_common_desc.syndrom);
+		    aenq_e->aenq_common_desc.syndrome);
 	}
 }
 

--- a/kernel/fbsd/ena/ena.h
+++ b/kernel/fbsd/ena/ena.h
@@ -1,5 +1,5 @@
 /*-
- * BSD LICENSE
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Copyright (c) 2015-2020 Amazon.com, Inc. or its affiliates.
  * All rights reserved.
@@ -40,7 +40,7 @@
 #include "ena_com/ena_eth_com.h"
 
 #define DRV_MODULE_VER_MAJOR	2
-#define DRV_MODULE_VER_MINOR	2
+#define DRV_MODULE_VER_MINOR	3
 #define DRV_MODULE_VER_SUBMINOR 0
 
 #define DRV_MODULE_NAME		"ena"
@@ -150,10 +150,10 @@
  */
 #define	PCI_VENDOR_ID_AMAZON	0x1d0f
 
-#define	PCI_DEV_ID_ENA_PF	0x0ec2
-#define	PCI_DEV_ID_ENA_LLQ_PF	0x1ec2
-#define	PCI_DEV_ID_ENA_VF	0xec20
-#define	PCI_DEV_ID_ENA_LLQ_VF	0xec21
+#define	PCI_DEV_ID_ENA_PF		0x0ec2
+#define	PCI_DEV_ID_ENA_PF_RSERV0	0x1ec2
+#define	PCI_DEV_ID_ENA_VF		0xec20
+#define	PCI_DEV_ID_ENA_VF_RSERV0	0xec21
 
 /*
  * Flags indicating current ENA driver state
@@ -463,9 +463,13 @@ struct ena_adapter {
 	uint32_t missing_tx_threshold;
 	bool disable_meta_caching;
 
+	uint16_t eni_metrics_sample_interval;
+	uint16_t eni_metrics_sample_interval_cnt;
+
 	/* Statistics */
 	struct ena_stats_dev dev_stats;
 	struct ena_hw_stats hw_stats;
+	struct ena_admin_eni_stats eni_metrics;
 
 	enum ena_regs_reset_reason_types reset_reason;
 };
@@ -512,22 +516,6 @@ ena_trigger_reset(struct ena_adapter *adapter,
 		adapter->reset_reason = reset_reason;
 		ENA_FLAG_SET_ATOMIC(ENA_FLAG_TRIGGER_RESET, adapter);
 	}
-}
-
-static inline int
-validate_rx_req_id(struct ena_ring *rx_ring, uint16_t req_id)
-{
-	if (likely(req_id < rx_ring->ring_size))
-		return (0);
-
-	device_printf(rx_ring->adapter->pdev, "Invalid rx req_id: %hu\n",
-	    req_id);
-	counter_u64_add(rx_ring->rx_stats.bad_req_id, 1);
-
-	/* Trigger device reset */
-	ena_trigger_reset(rx_ring->adapter, ENA_REGS_RESET_INV_RX_REQ_ID);
-
-	return (EFAULT);
 }
 
 #endif /* !(ENA_H) */

--- a/kernel/fbsd/ena/ena_com/ena_defs/ena_admin_defs.h
+++ b/kernel/fbsd/ena/ena_com/ena_defs/ena_admin_defs.h
@@ -1,5 +1,5 @@
 /*-
- * BSD LICENSE
+ * SPDX-License-Identifier: BSD-3-Clause
  *
  * Copyright (c) 2015-2020 Amazon.com, Inc. or its affiliates.
  * All rights reserved.
@@ -36,6 +36,8 @@
 #define ENA_ADMIN_EXTRA_PROPERTIES_STRING_LEN 32
 #define ENA_ADMIN_EXTRA_PROPERTIES_COUNT     32
 
+#define ENA_ADMIN_RSS_KEY_PARTS              10
+
 enum ena_admin_aq_opcode {
 	ENA_ADMIN_CREATE_SQ                         = 1,
 	ENA_ADMIN_DESTROY_SQ                        = 2,
@@ -58,6 +60,7 @@ enum ena_admin_aq_completion_status {
 	ENA_ADMIN_RESOURCE_BUSY                     = 7,
 };
 
+/* subcommands for the set/get feature admin commands */
 enum ena_admin_aq_feature_id {
 	ENA_ADMIN_DEVICE_ATTRIBUTES                 = 1,
 	ENA_ADMIN_MAX_QUEUES_NUM                    = 2,
@@ -68,7 +71,7 @@ enum ena_admin_aq_feature_id {
 	ENA_ADMIN_MAX_QUEUES_EXT                    = 7,
 	ENA_ADMIN_RSS_HASH_FUNCTION                 = 10,
 	ENA_ADMIN_STATELESS_OFFLOAD_CONFIG          = 11,
-	ENA_ADMIN_RSS_REDIRECTION_TABLE_CONFIG      = 12,
+	ENA_ADMIN_RSS_INDIRECTION_TABLE_CONFIG      = 12,
 	ENA_ADMIN_MTU                               = 14,
 	ENA_ADMIN_RSS_HASH_INPUT                    = 18,
 	ENA_ADMIN_INTERRUPT_MODERATION              = 20,
@@ -122,6 +125,8 @@ enum ena_admin_completion_policy_type {
 enum ena_admin_get_stats_type {
 	ENA_ADMIN_GET_STATS_TYPE_BASIC              = 0,
 	ENA_ADMIN_GET_STATS_TYPE_EXTENDED           = 1,
+	/* extra HW stats for specific network interface */
+	ENA_ADMIN_GET_STATS_TYPE_ENI                = 2,
 };
 
 enum ena_admin_get_stats_scope {
@@ -198,7 +203,7 @@ struct ena_admin_acq_common_desc {
 	uint16_t extended_status;
 
 	/* indicates to the driver which AQ entry has been consumed by the
-	 *    device and could be reused
+	 * device and could be reused
 	 */
 	uint16_t sq_head_indx;
 };
@@ -243,8 +248,8 @@ struct ena_admin_aq_create_sq_cmd {
 	 */
 	uint8_t sq_caps_3;
 
-	/* associated completion queue id. This CQ must be created prior to
-	 *    SQ creation
+	/* associated completion queue id. This CQ must be created prior to SQ
+	 * creation
 	 */
 	uint16_t cq_idx;
 
@@ -383,7 +388,7 @@ struct ena_admin_aq_get_stats_cmd {
 	uint16_t queue_idx;
 
 	/* device id, value 0xFFFF means mine. only privileged device can get
-	 *    stats of other device
+	 * stats of other device
 	 */
 	uint16_t device_id;
 };
@@ -415,10 +420,43 @@ struct ena_admin_basic_stats {
 	uint32_t tx_drops_high;
 };
 
+/* ENI Statistics Command. */
+struct ena_admin_eni_stats {
+	/* The number of packets shaped due to inbound aggregate BW
+	 * allowance being exceeded
+	 */
+	uint64_t bw_in_allowance_exceeded;
+
+	/* The number of packets shaped due to outbound aggregate BW
+	 * allowance being exceeded
+	 */
+	uint64_t bw_out_allowance_exceeded;
+
+	/* The number of packets shaped due to PPS allowance being exceeded */
+	uint64_t pps_allowance_exceeded;
+
+	/* The number of packets shaped due to connection tracking
+	 * allowance being exceeded and leading to failure in establishment
+	 * of new connections
+	 */
+	uint64_t conntrack_allowance_exceeded;
+
+	/* The number of packets shaped due to linklocal packet rate
+	 * allowance being exceeded
+	 */
+	uint64_t linklocal_allowance_exceeded;
+};
+
 struct ena_admin_acq_get_stats_resp {
 	struct ena_admin_acq_common_desc acq_common_desc;
 
-	struct ena_admin_basic_stats basic_stats;
+	union {
+		uint64_t raw[7];
+
+		struct ena_admin_basic_stats basic_stats;
+
+		struct ena_admin_eni_stats eni_stats;
+	} u;
 };
 
 struct ena_admin_get_set_feature_common_desc {
@@ -432,8 +470,8 @@ struct ena_admin_get_set_feature_common_desc {
 	uint8_t feature_id;
 
 	/* The driver specifies the max feature version it supports and the
-	 *    device responds with the currently supported feature version. The
-	 *    field is zero based
+	 * device responds with the currently supported feature version. The
+	 * field is zero based
 	 */
 	uint8_t feature_version;
 
@@ -445,7 +483,9 @@ struct ena_admin_device_attr_feature_desc {
 
 	uint32_t device_version;
 
-	/* bitmap of ena_admin_aq_feature_id */
+	/* bitmap of ena_admin_aq_feature_id, which represents supported
+	 * subcommands for the set/get feature admin commands.
+	 */
 	uint32_t supported_features;
 
 	uint32_t reserved3;
@@ -531,32 +571,30 @@ struct ena_admin_feature_llq_desc {
 
 	uint32_t max_llq_depth;
 
-	/*  specify the header locations the device supports. bitfield of
-	 *    enum ena_admin_llq_header_location.
+	/* specify the header locations the device supports. bitfield of enum
+	 * ena_admin_llq_header_location.
 	 */
 	uint16_t header_location_ctrl_supported;
 
 	/* the header location the driver selected to use. */
 	uint16_t header_location_ctrl_enabled;
 
-	/* if inline header is specified - this is the size of descriptor
-	 *    list entry. If header in a separate ring is specified - this is
-	 *    the size of header ring entry. bitfield of enum
-	 *    ena_admin_llq_ring_entry_size. specify the entry sizes the device
-	 *    supports
+	/* if inline header is specified - this is the size of descriptor list
+	 * entry. If header in a separate ring is specified - this is the size
+	 * of header ring entry. bitfield of enum ena_admin_llq_ring_entry_size.
+	 * specify the entry sizes the device supports
 	 */
 	uint16_t entry_size_ctrl_supported;
 
 	/* the entry size the driver selected to use. */
 	uint16_t entry_size_ctrl_enabled;
 
-	/* valid only if inline header is specified. First entry associated
-	 *    with the packet includes descriptors and header. Rest of the
-	 *    entries occupied by descriptors. This parameter defines the max
-	 *    number of descriptors precedding the header in the first entry.
-	 *    The field is bitfield of enum
-	 *    ena_admin_llq_num_descs_before_header and specify the values the
-	 *    device supports
+	/* valid only if inline header is specified. First entry associated with
+	 * the packet includes descriptors and header. Rest of the entries
+	 * occupied by descriptors. This parameter defines the max number of
+	 * descriptors precedding the header in the first entry. The field is
+	 * bitfield of enum ena_admin_llq_num_descs_before_header and specify
+	 * the values the device supports
 	 */
 	uint16_t desc_num_before_header_supported;
 
@@ -564,7 +602,7 @@ struct ena_admin_feature_llq_desc {
 	uint16_t desc_num_before_header_enabled;
 
 	/* valid only if inline was chosen. bitfield of enum
-	 *    ena_admin_llq_stride_ctrl
+	 * ena_admin_llq_stride_ctrl
 	 */
 	uint16_t descriptors_stride_ctrl_supported;
 
@@ -574,8 +612,8 @@ struct ena_admin_feature_llq_desc {
 	/* reserved */
 	uint32_t reserved1;
 
-	/* accelerated low latency queues requirment. driver needs to
-	 * support those requirments in order to use accelerated llq
+	/* accelerated low latency queues requirement. driver needs to
+	 * support those requirements in order to use accelerated llq
 	 */
 	struct ena_admin_accel_mode_req accel_mode;
 };
@@ -599,8 +637,8 @@ struct ena_admin_queue_ext_feature_fields {
 
 	uint32_t max_tx_header_size;
 
-	/* Maximum Descriptors number, including meta descriptor, allowed for
-	 *    a single Tx packet
+	/* Maximum Descriptors number, including meta descriptor, allowed for a
+	 * single Tx packet
 	 */
 	uint16_t max_per_packet_tx_descs;
 
@@ -623,8 +661,8 @@ struct ena_admin_queue_feature_desc {
 
 	uint32_t max_header_size;
 
-	/* Maximum Descriptors number, including meta descriptor, allowed for
-	 *    a single Tx packet
+	/* Maximum Descriptors number, including meta descriptor, allowed for a
+	 * single Tx packet
 	 */
 	uint16_t max_packet_tx_descs;
 
@@ -720,11 +758,11 @@ enum ena_admin_hash_functions {
 };
 
 struct ena_admin_feature_rss_flow_hash_control {
-	uint32_t keys_num;
+	uint32_t key_parts;
 
 	uint32_t reserved;
 
-	uint32_t key[10];
+	uint32_t key[ENA_ADMIN_RSS_KEY_PARTS];
 };
 
 struct ena_admin_feature_rss_flow_hash_function {
@@ -859,11 +897,12 @@ struct ena_admin_host_info {
 
 	uint16_t reserved;
 
-	/* 0 : mutable_rss_table_size
+	/* 0 : reserved
 	 * 1 : rx_offset
 	 * 2 : interrupt_moderation
-	 * 3 : map_rx_buf_bidirectional
-	 * 31:4 : reserved
+	 * 3 : rx_buf_mirroring
+	 * 4 : rss_configurable_function_key
+	 * 31:5 : reserved
 	 */
 	uint32_t driver_supported_features;
 };
@@ -945,7 +984,7 @@ struct ena_admin_queue_ext_feature_desc {
 		struct ena_admin_queue_ext_feature_fields max_queue_ext;
 
 		uint32_t raw[10];
-	} ;
+	};
 };
 
 struct ena_admin_get_feat_resp {
@@ -1028,7 +1067,7 @@ struct ena_admin_set_feat_resp {
 struct ena_admin_aenq_common_desc {
 	uint16_t group;
 
-	uint16_t syndrom;
+	uint16_t syndrome;
 
 	/* 0 : phase
 	 * 7:1 : reserved - MBZ
@@ -1052,7 +1091,7 @@ enum ena_admin_aenq_group {
 	ENA_ADMIN_AENQ_GROUPS_NUM                   = 5,
 };
 
-enum ena_admin_aenq_notification_syndrom {
+enum ena_admin_aenq_notification_syndrome {
 	ENA_ADMIN_SUSPEND                           = 0,
 	ENA_ADMIN_RESUME                            = 1,
 	ENA_ADMIN_UPDATE_HINTS                      = 2,
@@ -1181,13 +1220,14 @@ struct ena_admin_ena_mmio_req_read_less_resp {
 #define ENA_ADMIN_HOST_INFO_DEVICE_MASK                     GENMASK(7, 3)
 #define ENA_ADMIN_HOST_INFO_BUS_SHIFT                       8
 #define ENA_ADMIN_HOST_INFO_BUS_MASK                        GENMASK(15, 8)
-#define ENA_ADMIN_HOST_INFO_MUTABLE_RSS_TABLE_SIZE_MASK     BIT(0)
 #define ENA_ADMIN_HOST_INFO_RX_OFFSET_SHIFT                 1
 #define ENA_ADMIN_HOST_INFO_RX_OFFSET_MASK                  BIT(1)
 #define ENA_ADMIN_HOST_INFO_INTERRUPT_MODERATION_SHIFT      2
 #define ENA_ADMIN_HOST_INFO_INTERRUPT_MODERATION_MASK       BIT(2)
-#define ENA_ADMIN_HOST_INFO_MAP_RX_BUF_BIDIRECTIONAL_SHIFT  3
-#define ENA_ADMIN_HOST_INFO_MAP_RX_BUF_BIDIRECTIONAL_MASK   BIT(3)
+#define ENA_ADMIN_HOST_INFO_RX_BUF_MIRRORING_SHIFT          3
+#define ENA_ADMIN_HOST_INFO_RX_BUF_MIRRORING_MASK           BIT(3)
+#define ENA_ADMIN_HOST_INFO_RSS_CONFIGURABLE_FUNCTION_KEY_SHIFT 4
+#define ENA_ADMIN_HOST_INFO_RSS_CONFIGURABLE_FUNCTION_KEY_MASK BIT(4)
 
 /* feature_rss_ind_table */
 #define ENA_ADMIN_FEATURE_RSS_IND_TABLE_ONE_ENTRY_UPDATE_MASK BIT(0)
@@ -1609,16 +1649,6 @@ static inline void set_ena_admin_host_info_bus(struct ena_admin_host_info *p, ui
 	p->bdf |= (val << ENA_ADMIN_HOST_INFO_BUS_SHIFT) & ENA_ADMIN_HOST_INFO_BUS_MASK;
 }
 
-static inline uint32_t get_ena_admin_host_info_mutable_rss_table_size(const struct ena_admin_host_info *p)
-{
-	return p->driver_supported_features & ENA_ADMIN_HOST_INFO_MUTABLE_RSS_TABLE_SIZE_MASK;
-}
-
-static inline void set_ena_admin_host_info_mutable_rss_table_size(struct ena_admin_host_info *p, uint32_t val)
-{
-	p->driver_supported_features |= val & ENA_ADMIN_HOST_INFO_MUTABLE_RSS_TABLE_SIZE_MASK;
-}
-
 static inline uint32_t get_ena_admin_host_info_rx_offset(const struct ena_admin_host_info *p)
 {
 	return (p->driver_supported_features & ENA_ADMIN_HOST_INFO_RX_OFFSET_MASK) >> ENA_ADMIN_HOST_INFO_RX_OFFSET_SHIFT;
@@ -1639,14 +1669,24 @@ static inline void set_ena_admin_host_info_interrupt_moderation(struct ena_admin
 	p->driver_supported_features |= (val << ENA_ADMIN_HOST_INFO_INTERRUPT_MODERATION_SHIFT) & ENA_ADMIN_HOST_INFO_INTERRUPT_MODERATION_MASK;
 }
 
-static inline uint32_t get_ena_admin_host_info_map_rx_buf_bidirectional(const struct ena_admin_host_info *p)
+static inline uint32_t get_ena_admin_host_info_rx_buf_mirroring(const struct ena_admin_host_info *p)
 {
-	return (p->driver_supported_features & ENA_ADMIN_HOST_INFO_MAP_RX_BUF_BIDIRECTIONAL_MASK) >> ENA_ADMIN_HOST_INFO_MAP_RX_BUF_BIDIRECTIONAL_SHIFT;
+	return (p->driver_supported_features & ENA_ADMIN_HOST_INFO_RX_BUF_MIRRORING_MASK) >> ENA_ADMIN_HOST_INFO_RX_BUF_MIRRORING_SHIFT;
 }
 
-static inline void set_ena_admin_host_info_map_rx_buf_bidirectional(struct ena_admin_host_info *p, uint32_t val)
+static inline void set_ena_admin_host_info_rx_buf_mirroring(struct ena_admin_host_info *p, uint32_t val)
 {
-	p->driver_supported_features |= (val << ENA_ADMIN_HOST_INFO_MAP_RX_BUF_BIDIRECTIONAL_SHIFT) & ENA_ADMIN_HOST_INFO_MAP_RX_BUF_BIDIRECTIONAL_MASK;
+	p->driver_supported_features |= (val << ENA_ADMIN_HOST_INFO_RX_BUF_MIRRORING_SHIFT) & ENA_ADMIN_HOST_INFO_RX_BUF_MIRRORING_MASK;
+}
+
+static inline uint32_t get_ena_admin_host_info_rss_configurable_function_key(const struct ena_admin_host_info *p)
+{
+	return (p->driver_supported_features & ENA_ADMIN_HOST_INFO_RSS_CONFIGURABLE_FUNCTION_KEY_MASK) >> ENA_ADMIN_HOST_INFO_RSS_CONFIGURABLE_FUNCTION_KEY_SHIFT;
+}
+
+static inline void set_ena_admin_host_info_rss_configurable_function_key(struct ena_admin_host_info *p, uint32_t val)
+{
+	p->driver_supported_features |= (val << ENA_ADMIN_HOST_INFO_RSS_CONFIGURABLE_FUNCTION_KEY_SHIFT) & ENA_ADMIN_HOST_INFO_RSS_CONFIGURABLE_FUNCTION_KEY_MASK;
 }
 
 static inline uint8_t get_ena_admin_feature_rss_ind_table_one_entry_update(const struct ena_admin_feature_rss_ind_table *p)

--- a/kernel/fbsd/ena/ena_com/ena_defs/ena_common_defs.h
+++ b/kernel/fbsd/ena/ena_com/ena_defs/ena_common_defs.h
@@ -1,5 +1,5 @@
 /*-
- * BSD LICENSE
+ * SPDX-License-Identifier: BSD-3-Clause
  *
  * Copyright (c) 2015-2020 Amazon.com, Inc. or its affiliates.
  * All rights reserved.

--- a/kernel/fbsd/ena/ena_com/ena_defs/ena_eth_io_defs.h
+++ b/kernel/fbsd/ena/ena_com/ena_defs/ena_eth_io_defs.h
@@ -1,5 +1,5 @@
 /*-
- * BSD LICENSE
+ * SPDX-License-Identifier: BSD-3-Clause
  *
  * Copyright (c) 2015-2020 Amazon.com, Inc. or its affiliates.
  * All rights reserved.

--- a/kernel/fbsd/ena/ena_com/ena_defs/ena_gen_info.h
+++ b/kernel/fbsd/ena/ena_com/ena_defs/ena_gen_info.h
@@ -1,5 +1,5 @@
 /*-
- * BSD LICENSE
+ * SPDX-License-Identifier: BSD-3-Clause
  *
  * Copyright (c) 2015-2020 Amazon.com, Inc. or its affiliates.
  * All rights reserved.
@@ -30,5 +30,5 @@
  * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
-#define	ENA_GEN_DATE	"Mon Apr 20 15:41:59 DST 2020"
-#define	ENA_GEN_COMMIT	"daa45ac"
+#define	ENA_GEN_DATE	"Fri Sep 18 17:09:00 IDT 2020"
+#define	ENA_GEN_COMMIT	"0f80d82"

--- a/kernel/fbsd/ena/ena_com/ena_defs/ena_regs_defs.h
+++ b/kernel/fbsd/ena/ena_com/ena_defs/ena_regs_defs.h
@@ -1,5 +1,5 @@
 /*-
- * BSD LICENSE
+ * SPDX-License-Identifier: BSD-3-Clause
  *
  * Copyright (c) 2015-2020 Amazon.com, Inc. or its affiliates.
  * All rights reserved.

--- a/kernel/fbsd/ena/ena_com/ena_eth_com.h
+++ b/kernel/fbsd/ena/ena_com/ena_eth_com.h
@@ -1,5 +1,5 @@
 /*-
- * BSD LICENSE
+ * SPDX-License-Identifier: BSD-3-Clause
  *
  * Copyright (c) 2015-2020 Amazon.com, Inc. or its affiliates.
  * All rights reserved.
@@ -171,7 +171,8 @@ static inline bool ena_com_is_doorbell_needed(struct ena_com_io_sq *io_sq,
 						   llq_info->descs_per_entry);
 	}
 
-	ena_trc_dbg("queue: %d num_descs: %d num_entries_needed: %d\n",
+	ena_trc_dbg(ena_com_io_sq_to_ena_dev(io_sq),
+		    "Queue: %d num_descs: %d num_entries_needed: %d\n",
 		    io_sq->qid, num_descs, num_entries_needed);
 
 	return num_entries_needed > io_sq->entries_in_tx_burst_left;
@@ -182,14 +183,16 @@ static inline int ena_com_write_sq_doorbell(struct ena_com_io_sq *io_sq)
 	u16 max_entries_in_tx_burst = io_sq->llq_info.max_entries_in_tx_burst;
 	u16 tail = io_sq->tail;
 
-	ena_trc_dbg("write submission queue doorbell for queue: %d tail: %d\n",
+	ena_trc_dbg(ena_com_io_sq_to_ena_dev(io_sq),
+		    "Write submission queue doorbell for queue: %d tail: %d\n",
 		    io_sq->qid, tail);
 
 	ENA_REG_WRITE32(io_sq->bus, tail, io_sq->db_addr);
 
 	if (is_llq_max_tx_burst_exists(io_sq)) {
-		ena_trc_dbg("reset available entries in tx burst for queue %d to %d\n",
-			     io_sq->qid, max_entries_in_tx_burst);
+		ena_trc_dbg(ena_com_io_sq_to_ena_dev(io_sq),
+			    "Reset available entries in tx burst for queue %d to %d\n",
+			    io_sq->qid, max_entries_in_tx_burst);
 		io_sq->entries_in_tx_burst_left = max_entries_in_tx_burst;
 	}
 
@@ -207,7 +210,8 @@ static inline int ena_com_update_dev_comp_head(struct ena_com_io_cq *io_cq)
 		need_update = unreported_comp > (io_cq->q_depth / ENA_COMP_HEAD_THRESH);
 
 		if (unlikely(need_update)) {
-			ena_trc_dbg("Write completion queue doorbell for queue %d: head: %d\n",
+			ena_trc_dbg(ena_com_io_cq_to_ena_dev(io_cq),
+				    "Write completion queue doorbell for queue %d: head: %d\n",
 				    io_cq->qid, head);
 			ENA_REG_WRITE32(io_cq->bus, head, io_cq->cq_head_db_reg);
 			io_cq->last_head_update = head;
@@ -271,7 +275,8 @@ static inline int ena_com_tx_comp_req_id_get(struct ena_com_io_cq *io_cq,
 
 	*req_id = READ_ONCE16(cdesc->req_id);
 	if (unlikely(*req_id >= io_cq->q_depth)) {
-		ena_trc_err("Invalid req id %d\n", cdesc->req_id);
+		ena_trc_err(ena_com_io_cq_to_ena_dev(io_cq),
+			    "Invalid req id %d\n", cdesc->req_id);
 		return ENA_COM_INVAL;
 	}
 

--- a/kernel/fbsd/ena/ena_datapath.c
+++ b/kernel/fbsd/ena/ena_datapath.c
@@ -1,5 +1,5 @@
 /*-
- * BSD LICENSE
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Copyright (c) 2015-2020 Amazon.com, Inc. or its affiliates.
  * All rights reserved.
@@ -75,7 +75,7 @@ ena_cleanup(void *arg, int pending)
 	if (unlikely((if_getdrvflags(ifp) & IFF_DRV_RUNNING) == 0))
 		return;
 
-	ena_trace(ENA_DBG, "MSI-X TX/RX routine\n");
+	ena_trace(NULL, ENA_DBG, "MSI-X TX/RX routine\n");
 
 	tx_ring = que->tx_ring;
 	rx_ring = que->rx_ring;
@@ -266,7 +266,7 @@ ena_tx_cleanup(struct ena_ring *tx_ring)
 		bus_dmamap_unload(adapter->tx_buf_tag,
 		    tx_info->dmamap);
 
-		ena_trace(ENA_DBG | ENA_TXPTH, "tx: q %d mbuf %p completed\n",
+		ena_trace(NULL, ENA_DBG | ENA_TXPTH, "tx: q %d mbuf %p completed\n",
 		    tx_ring->qid, mbuf);
 
 		m_freem(mbuf);
@@ -291,7 +291,7 @@ ena_tx_cleanup(struct ena_ring *tx_ring)
 
 	work_done = TX_BUDGET - budget;
 
-	ena_trace(ENA_DBG | ENA_TXPTH, "tx: q %d done. total pkts: %d\n",
+	ena_trace(NULL, ENA_DBG | ENA_TXPTH, "tx: q %d done. total pkts: %d\n",
 	tx_ring->qid, work_done);
 
 	/* If there is still something to commit update ring state */
@@ -335,6 +335,19 @@ ena_rx_hash_mbuf(struct ena_ring *rx_ring, struct ena_com_rx_ctx *ena_rx_ctx,
 
 	if (likely(ENA_FLAG_ISSET(ENA_FLAG_RSS_ACTIVE, adapter))) {
 		mbuf->m_pkthdr.flowid = ena_rx_ctx->hash;
+
+#ifdef RSS
+		/*
+		 * Hardware and software RSS are in agreement only when both are
+		 * configured to Toeplitz algorithm.  This driver configures
+		 * that algorithm only when software RSS is enabled and uses it.
+		 */
+		if (adapter->ena_dev->rss.hash_func != ENA_ADMIN_TOEPLITZ &&
+		    ena_rx_ctx->l3_proto != ENA_ETH_IO_L3_PROTO_UNKNOWN) {
+			M_HASHTYPE_SET(mbuf, M_HASHTYPE_OPAQUE_HASH);
+			return;
+		}
+#endif
 
 		if (ena_rx_ctx->frag &&
 		    (ena_rx_ctx->l3_proto != ENA_ETH_IO_L3_PROTO_UNKNOWN)) {
@@ -395,7 +408,6 @@ ena_rx_mbuf(struct ena_ring *rx_ring, struct ena_com_rx_buf_info *ena_bufs,
 	struct ena_rx_buffer *rx_info;
 	struct ena_adapter *adapter;
 	unsigned int descs = ena_rx_ctx->descs;
-	int rc;
 	uint16_t ntc, len, req_id, buf = 0;
 
 	ntc = *next_to_clean;
@@ -403,17 +415,13 @@ ena_rx_mbuf(struct ena_ring *rx_ring, struct ena_com_rx_buf_info *ena_bufs,
 
 	len = ena_bufs[buf].len;
 	req_id = ena_bufs[buf].req_id;
-	rc = validate_rx_req_id(rx_ring, req_id);
-	if (unlikely(rc != 0))
-		return (NULL);
-
 	rx_info = &rx_ring->rx_buffer_info[req_id];
 	if (unlikely(rx_info->mbuf == NULL)) {
 		device_printf(adapter->pdev, "NULL mbuf in rx_info");
 		return (NULL);
 	}
 
-	ena_trace(ENA_DBG | ENA_RXPTH, "rx_info %p, mbuf %p, paddr %jx\n",
+	ena_trace(NULL, ENA_DBG | ENA_RXPTH, "rx_info %p, mbuf %p, paddr %jx\n",
 	    rx_info, rx_info->mbuf, (uintmax_t)rx_info->ena_buf.paddr);
 
 	bus_dmamap_sync(adapter->rx_buf_tag, rx_info->map,
@@ -422,12 +430,16 @@ ena_rx_mbuf(struct ena_ring *rx_ring, struct ena_com_rx_buf_info *ena_bufs,
 	mbuf->m_flags |= M_PKTHDR;
 	mbuf->m_pkthdr.len = len;
 	mbuf->m_len = len;
+	// Only for the first segment the data starts at specific offset
+	mbuf->m_data = mtodo(mbuf, ena_rx_ctx->pkt_offset);
+	ena_trace(NULL, ENA_DBG | ENA_RXPTH,
+		"Mbuf data offset=%u\n", ena_rx_ctx->pkt_offset);
 	mbuf->m_pkthdr.rcvif = rx_ring->que->adapter->ifp;
 
 	/* Fill mbuf with hash key and it's interpretation for optimization */
 	ena_rx_hash_mbuf(rx_ring, ena_rx_ctx, mbuf);
 
-	ena_trace(ENA_DBG | ENA_RXPTH, "rx mbuf 0x%p, flags=0x%x, len: %d\n",
+	ena_trace(NULL, ENA_DBG | ENA_RXPTH, "rx mbuf 0x%p, flags=0x%x, len: %d\n",
 	    mbuf, mbuf->m_flags, mbuf->m_pkthdr.len);
 
 	/* DMA address is not needed anymore, unmap it */
@@ -445,16 +457,6 @@ ena_rx_mbuf(struct ena_ring *rx_ring, struct ena_com_rx_buf_info *ena_bufs,
 		++buf;
 		len = ena_bufs[buf].len;
 		req_id = ena_bufs[buf].req_id;
-		rc = validate_rx_req_id(rx_ring, req_id);
-		if (unlikely(rc != 0)) {
-			/*
-			 * If the req_id is invalid, then the device will be
-			 * reset. In that case we must free all mbufs that
-			 * were already gathered.
-			 */
-			m_freem(mbuf);
-			return (NULL);
-		}
 		rx_info = &rx_ring->rx_buffer_info[req_id];
 
 		if (unlikely(rx_info->mbuf == NULL)) {
@@ -477,11 +479,11 @@ ena_rx_mbuf(struct ena_ring *rx_ring, struct ena_com_rx_buf_info *ena_bufs,
 		    BUS_DMASYNC_POSTREAD);
 		if (unlikely(m_append(mbuf, len, rx_info->mbuf->m_data) == 0)) {
 			counter_u64_add(rx_ring->rx_stats.mbuf_alloc_fail, 1);
-			ena_trace(ENA_WARNING, "Failed to append Rx mbuf %p\n",
+			ena_trace(NULL, ENA_WARNING, "Failed to append Rx mbuf %p\n",
 			    mbuf);
 		}
 
-		ena_trace(ENA_DBG | ENA_RXPTH,
+		ena_trace(NULL, ENA_DBG | ENA_RXPTH,
 		    "rx mbuf updated. len %d\n", mbuf->m_pkthdr.len);
 
 		/* Free already appended mbuf, it won't be useful anymore */
@@ -512,7 +514,7 @@ ena_rx_checksum(struct ena_ring *rx_ring, struct ena_com_rx_ctx *ena_rx_ctx,
 		/* ipv4 checksum error */
 		mbuf->m_pkthdr.csum_flags = 0;
 		counter_u64_add(rx_ring->rx_stats.bad_csum, 1);
-		ena_trace(ENA_DBG, "RX IPv4 header checksum error\n");
+		ena_trace(NULL, ENA_DBG, "RX IPv4 header checksum error\n");
 		return;
 	}
 
@@ -523,7 +525,7 @@ ena_rx_checksum(struct ena_ring *rx_ring, struct ena_com_rx_ctx *ena_rx_ctx,
 			/* TCP/UDP checksum error */
 			mbuf->m_pkthdr.csum_flags = 0;
 			counter_u64_add(rx_ring->rx_stats.bad_csum, 1);
-			ena_trace(ENA_DBG, "RX L4 checksum error\n");
+			ena_trace(NULL, ENA_DBG, "RX L4 checksum error\n");
 		} else {
 			mbuf->m_pkthdr.csum_flags = CSUM_IP_CHECKED;
 			mbuf->m_pkthdr.csum_flags |= CSUM_IP_VALID;
@@ -543,6 +545,7 @@ ena_rx_cleanup(struct ena_ring *rx_ring)
 	struct ena_com_rx_ctx ena_rx_ctx;
 	struct ena_com_io_cq* io_cq;
 	struct ena_com_io_sq* io_sq;
+	enum ena_regs_reset_reason_types reset_reason;
 	if_t ifp;
 	uint16_t ena_qid;
 	uint16_t next_to_clean;
@@ -569,23 +572,35 @@ ena_rx_cleanup(struct ena_ring *rx_ring)
 		return (0);
 #endif /* DEV_NETMAP */
 
-	ena_trace(ENA_DBG, "rx: qid %d\n", qid);
+	ena_trace(NULL, ENA_DBG, "rx: qid %d\n", qid);
 
 	do {
 		ena_rx_ctx.ena_bufs = rx_ring->ena_bufs;
 		ena_rx_ctx.max_bufs = adapter->max_rx_sgl_size;
 		ena_rx_ctx.descs = 0;
+		ena_rx_ctx.pkt_offset = 0;
+
 		bus_dmamap_sync(io_cq->cdesc_addr.mem_handle.tag,
 		    io_cq->cdesc_addr.mem_handle.map, BUS_DMASYNC_POSTREAD);
 		rc = ena_com_rx_pkt(io_cq, io_sq, &ena_rx_ctx);
-
-		if (unlikely(rc != 0))
-			goto error;
+		if (unlikely(rc != 0)) {
+			if (rc == ENA_COM_NO_SPACE) {
+				counter_u64_add(rx_ring->rx_stats.bad_desc_num,
+				    1);
+				reset_reason = ENA_REGS_RESET_TOO_MANY_RX_DESCS;
+			} else {
+				counter_u64_add(rx_ring->rx_stats.bad_req_id,
+				    1);
+				reset_reason = ENA_REGS_RESET_INV_RX_REQ_ID;
+			}
+			ena_trigger_reset(adapter, reset_reason);
+			return (0);
+		}
 
 		if (unlikely(ena_rx_ctx.descs == 0))
 			break;
 
-		ena_trace(ENA_DBG | ENA_RXPTH, "rx: q %d got packet from ena. "
+		ena_trace(NULL, ENA_DBG | ENA_RXPTH, "rx: q %d got packet from ena. "
 		    "descs #: %d l3 proto %d l4 proto %d hash: %x\n",
 		    rx_ring->qid, ena_rx_ctx.descs, ena_rx_ctx.l3_proto,
 		    ena_rx_ctx.l4_proto, ena_rx_ctx.hash);
@@ -638,7 +653,7 @@ ena_rx_cleanup(struct ena_ring *rx_ring)
 					do_if_input = 0;
 		}
 		if (do_if_input != 0) {
-			ena_trace(ENA_DBG | ENA_RXPTH,
+			ena_trace(NULL, ENA_DBG | ENA_RXPTH,
 			    "calling if_input() with mbuf %p\n", mbuf);
 			(*ifp->if_input)(ifp, mbuf);
 		}
@@ -664,14 +679,6 @@ ena_rx_cleanup(struct ena_ring *rx_ring)
 	tcp_lro_flush_all(&rx_ring->lro);
 
 	return (RX_BUDGET - budget);
-
-error:
-	counter_u64_add(rx_ring->rx_stats.bad_desc_num, 1);
-
-	/* Too many desc from the device. Trigger reset */
-	ena_trigger_reset(adapter, ENA_REGS_RESET_TOO_MANY_RX_DESCS);
-
-	return (0);
 }
 
 static void
@@ -827,7 +834,7 @@ ena_tx_map_mbuf(struct ena_ring *tx_ring, struct ena_tx_buffer *tx_info,
 	rc = bus_dmamap_load_mbuf_sg(adapter->tx_buf_tag, tx_info->dmamap, mbuf,
 	    segs, &nsegs, BUS_DMA_NOWAIT);
 	if (unlikely((rc != 0) || (nsegs == 0))) {
-		ena_trace(ENA_WARNING,
+		ena_trace(NULL, ENA_WARNING,
 		    "dmamap load failed! err: %d nsegs: %d\n", rc, nsegs);
 		goto dma_error;
 	}
@@ -859,7 +866,7 @@ ena_tx_map_mbuf(struct ena_ring *tx_ring, struct ena_tx_buffer *tx_info,
 			counter_u64_add(tx_ring->tx_stats.llq_buffer_copy, 1);
 		}
 
-		ena_trace(ENA_DBG | ENA_TXPTH,
+		ena_trace(NULL, ENA_DBG | ENA_TXPTH,
 		    "mbuf: %p header_buf->vaddr: %p push_len: %d\n",
 		    mbuf, *push_hdr, *header_len);
 
@@ -937,12 +944,12 @@ ena_xmit_mbuf(struct ena_ring *tx_ring, struct mbuf **mbuf)
 
 	rc = ena_check_and_collapse_mbuf(tx_ring, mbuf);
 	if (unlikely(rc != 0)) {
-		ena_trace(ENA_WARNING,
+		ena_trace(NULL, ENA_WARNING,
 		    "Failed to collapse mbuf! err: %d\n", rc);
 		return (rc);
 	}
 
-	ena_trace(ENA_DBG | ENA_TXPTH, "Tx: %d bytes\n", (*mbuf)->m_pkthdr.len);
+	ena_trace(NULL, ENA_DBG | ENA_TXPTH, "Tx: %d bytes\n", (*mbuf)->m_pkthdr.len);
 
 	next_to_use = tx_ring->next_to_use;
 	req_id = tx_ring->free_tx_ids[next_to_use];
@@ -951,7 +958,7 @@ ena_xmit_mbuf(struct ena_ring *tx_ring, struct mbuf **mbuf)
 
 	rc = ena_tx_map_mbuf(tx_ring, tx_info, *mbuf, &push_hdr, &header_len);
 	if (unlikely(rc != 0)) {
-		ena_trace(ENA_WARNING, "Failed to map TX mbuf\n");
+		ena_trace(NULL, ENA_WARNING, "Failed to map TX mbuf\n");
 		return (rc);
 	}
 	memset(&ena_tx_ctx, 0x0, sizeof(struct ena_com_tx_ctx));
@@ -966,7 +973,7 @@ ena_xmit_mbuf(struct ena_ring *tx_ring, struct mbuf **mbuf)
 
 	if (tx_ring->acum_pkts == DB_THRESHOLD ||
 	    ena_com_is_doorbell_needed(tx_ring->ena_com_io_sq, &ena_tx_ctx)) {
-		ena_trace(ENA_DBG | ENA_TXPTH,
+		ena_trace(NULL, ENA_DBG | ENA_TXPTH,
 		    "llq tx max burst size of queue %d achieved, writing doorbell to send burst\n",
 		    tx_ring->que->id);
 		ena_com_write_sq_doorbell(tx_ring->ena_com_io_sq);
@@ -978,7 +985,7 @@ ena_xmit_mbuf(struct ena_ring *tx_ring, struct mbuf **mbuf)
 	rc = ena_com_prepare_tx(io_sq, &ena_tx_ctx, &nb_hw_desc);
 	if (unlikely(rc != 0)) {
 		if (likely(rc == ENA_COM_NO_MEM)) {
-			ena_trace(ENA_DBG | ENA_TXPTH,
+			ena_trace(NULL, ENA_DBG | ENA_TXPTH,
 			    "tx ring[%d] if out of space\n", tx_ring->que->id);
 		} else {
 			device_printf(adapter->pdev,
@@ -1011,7 +1018,7 @@ ena_xmit_mbuf(struct ena_ring *tx_ring, struct mbuf **mbuf)
 	 */
 	if (unlikely(!ena_com_sq_have_enough_space(tx_ring->ena_com_io_sq,
 	    adapter->max_tx_sgl_size + 2))) {
-		ena_trace(ENA_DBG | ENA_TXPTH, "Stop queue %d\n",
+		ena_trace(NULL, ENA_DBG | ENA_TXPTH, "Stop queue %d\n",
 		    tx_ring->que->id);
 
 		tx_ring->running = false;
@@ -1064,7 +1071,7 @@ ena_start_xmit(struct ena_ring *tx_ring)
 	io_sq = &adapter->ena_dev->io_sq_queues[ena_qid];
 
 	while ((mbuf = drbr_peek(adapter->ifp, tx_ring->br)) != NULL) {
-		ena_trace(ENA_DBG | ENA_TXPTH, "\ndequeued mbuf %p with flags %#x and"
+		ena_trace(NULL, ENA_DBG | ENA_TXPTH, "\ndequeued mbuf %p with flags %#x and"
 		    " header csum flags %#jx\n",
 		    mbuf, mbuf->m_flags, (uint64_t)mbuf->m_pkthdr.csum_flags);
 

--- a/kernel/fbsd/ena/ena_datapath.h
+++ b/kernel/fbsd/ena/ena_datapath.h
@@ -1,5 +1,5 @@
 /*-
- * BSD LICENSE
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Copyright (c) 2015-2020 Amazon.com, Inc. or its affiliates.
  * All rights reserved.

--- a/kernel/fbsd/ena/ena_netmap.c
+++ b/kernel/fbsd/ena/ena_netmap.c
@@ -1,5 +1,5 @@
 /*-
- * BSD LICENSE
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Copyright (c) 2015-2020 Amazon.com, Inc. or its affiliates.
  * All rights reserved.
@@ -88,7 +88,7 @@ ena_netmap_attach(struct ena_adapter *adapter)
 {
 	struct netmap_adapter na;
 
-	ena_trace(ENA_NETMAP, "netmap attach\n");
+	ena_trace(NULL, ENA_NETMAP, "netmap attach\n");
 
 	bzero(&na, sizeof(na));
 	na.na_flags = NAF_MOREFRAG;
@@ -126,12 +126,12 @@ ena_netmap_alloc_rx_slot(struct ena_adapter *adapter,
 	nm_i = kring->nr_hwcur;
 	head = kring->rhead;
 
-	ena_trace(ENA_NETMAP | ENA_DBG, "nr_hwcur: %d, nr_hwtail: %d, "
+	ena_trace(NULL, ENA_NETMAP | ENA_DBG, "nr_hwcur: %d, nr_hwtail: %d, "
 	    "rhead: %d, rcur: %d, rtail: %d\n", kring->nr_hwcur,
 	    kring->nr_hwtail, kring->rhead, kring->rcur, kring->rtail);
 
 	if ((nm_i == head) && rx_ring->initialized) {
-		ena_trace(ENA_NETMAP, "No free slots in netmap ring\n");
+		ena_trace(NULL, ENA_NETMAP, "No free slots in netmap ring\n");
 		return (ENOMEM);
 	}
 
@@ -150,7 +150,7 @@ ena_netmap_alloc_rx_slot(struct ena_adapter *adapter,
 
 	rc = netmap_load_map(na, adapter->rx_buf_tag, rx_info->map, addr);
 	if (rc != 0) {
-		ena_trace(ENA_WARNING, "DMA mapping error\n");
+		ena_trace(NULL, ENA_WARNING, "DMA mapping error\n");
 		return (rc);
 	}
 	bus_dmamap_sync(adapter->rx_buf_tag, rx_info->map, BUS_DMASYNC_PREREAD);
@@ -210,7 +210,7 @@ ena_netmap_free_rx_slot(struct ena_adapter *adapter,
 
 	slot = &kring->ring->slot[nm_i];
 
-	ENA_ASSERT(slot->buf_idx == 0, "Overwrite slot buf\n");
+	ENA_WARN(slot->buf_idx != 0, NULL, "Overwrite slot buf\n");
 	slot->buf_idx = rx_info->netmap_buf_idx;
 	slot->flags = NS_BUF_CHANGED;
 
@@ -252,7 +252,7 @@ ena_netmap_reset_ring(struct ena_adapter *adapter, int qid, enum txrx x)
 		return;
 
 	netmap_reset(NA(adapter->ifp), x, qid, 0);
-	ena_trace(ENA_NETMAP, "%s ring %d is in netmap mode\n",
+	ena_trace(NULL, ENA_NETMAP, "%s ring %d is in netmap mode\n",
 	    (x == NR_TX) ? "Tx" : "Rx", qid);
 }
 
@@ -282,7 +282,7 @@ ena_netmap_reg(struct netmap_adapter *na, int onoff)
 	ena_down(adapter);
 
 	if (onoff) {
-		ena_trace(ENA_NETMAP, "netmap on\n");
+		ena_trace(NULL, ENA_NETMAP, "netmap on\n");
 		for_rx_tx(t) {
 			for (i = 0; i <= nma_get_nrings(na, t); i++) {
 				kring = NMR(na, t)[i];
@@ -293,7 +293,7 @@ ena_netmap_reg(struct netmap_adapter *na, int onoff)
 		}
 		nm_set_native_flags(na);
 	} else {
-		ena_trace(ENA_NETMAP, "netmap off\n");
+		ena_trace(NULL, ENA_NETMAP, "netmap off\n");
 		nm_clear_native_flags(na);
 		for_rx_tx(t) {
 			for (i = 0; i <= nma_get_nrings(na, t); i++) {
@@ -307,7 +307,7 @@ ena_netmap_reg(struct netmap_adapter *na, int onoff)
 
 	rc = ena_up(adapter);
 	if (rc != 0) {
-		ena_trace(ENA_WARNING, "ena_up failed with rc=%d\n", rc);
+		ena_trace(NULL, ENA_WARNING, "ena_up failed with rc=%d\n", rc);
 		adapter->reset_reason = ENA_REGS_RESET_DRIVER_INVALID_STATE;
 		nm_clear_native_flags(na);
 		ena_destroy_device(adapter, false);
@@ -401,7 +401,7 @@ ena_netmap_tx_frame(struct ena_netmap_ctx *ctx)
 
 	adapter = ctx->adapter;
 	if (ena_netmap_count_slots(ctx) > adapter->max_tx_sgl_size) {
-		ena_trace(ENA_WARNING, "Too many slots per packet\n");
+		ena_trace(NULL, ENA_WARNING, "Too many slots per packet\n");
 		return (EINVAL);
 	}
 
@@ -438,7 +438,7 @@ ena_netmap_tx_frame(struct ena_netmap_ctx *ctx)
 	rc = ena_com_prepare_tx(ctx->io_sq, &ena_tx_ctx, &nb_hw_desc);
 	if (unlikely(rc != 0)) {
 		if (likely(rc == ENA_COM_NO_MEM)) {
-			ena_trace(ENA_NETMAP | ENA_DBG | ENA_TXPTH,
+			ena_trace(NULL, ENA_NETMAP | ENA_DBG | ENA_TXPTH,
 			    "Tx ring[%d] is out of space\n", tx_ring->que->id);
 		} else {
 			device_printf(adapter->pdev,
@@ -532,13 +532,13 @@ ena_netmap_map_single_slot(struct netmap_adapter *na, struct netmap_slot *slot,
 
 	*vaddr = PNMB(na, slot, paddr);
 	if (unlikely(vaddr == NULL)) {
-		ena_trace(ENA_ALERT, "Slot address is NULL\n");
+		ena_trace(NULL, ENA_ALERT, "Slot address is NULL\n");
 		return (EINVAL);
 	}
 
 	rc = netmap_load_map(na, dmatag, dmamap, *vaddr);
 	if (unlikely(rc != 0)) {
-		ena_trace(ENA_ALERT, "Failed to map slot %d for DMA\n",
+		ena_trace(NULL, ENA_ALERT, "Failed to map slot %d for DMA\n",
 		    slot->buf_idx);
 		return (EINVAL);
 	}
@@ -626,7 +626,7 @@ ena_netmap_tx_map_slots(struct ena_netmap_ctx *ctx,
 			delta = push_len - slot_head_len;
 		}
 
-		ena_trace(ENA_NETMAP | ENA_DBG | ENA_TXPTH,
+		ena_trace(NULL, ENA_NETMAP | ENA_DBG | ENA_TXPTH,
 		    "slot: %d header_buf->vaddr: %p push_len: %d\n",
 		    slot->buf_idx, *push_hdr, push_len);
 
@@ -860,7 +860,7 @@ ena_netmap_tx_clean_one(struct ena_netmap_ctx *ctx, uint16_t req_id)
 	/* Next, retain the sockets back to the userspace */
 	for (n = 0; n < nm_info->sockets_used; n++) {
 		ctx->nm_i = nm_next(ctx->nm_i, ctx->lim);
-		ENA_ASSERT(ctx->slots[ctx->nm_i].buf_idx == 0,
+		ENA_WARN(ctx->slots[ctx->nm_i].buf_idx != 0, NULL,
 		    "Tx idx is not 0.\n");
 		ctx->slots[ctx->nm_i].buf_idx = nm_info->socket_buf_idx[n];
 		ctx->slots[ctx->nm_i].flags = NS_BUF_CHANGED;
@@ -882,7 +882,7 @@ validate_tx_req_id(struct ena_ring *tx_ring, uint16_t req_id)
 	if (likely(req_id < tx_ring->ring_size))
 		return (0);
 
-	ena_trace(ENA_WARNING, "Invalid req_id: %hu\n", req_id);
+	ena_trace(NULL, ENA_WARNING, "Invalid req_id: %hu\n", req_id);
 	counter_u64_add(tx_ring->tx_stats.bad_req_id, 1);
 
 	ena_trigger_reset(adapter, ENA_REGS_RESET_INV_TX_REQ_ID);
@@ -949,6 +949,7 @@ static inline int
 ena_netmap_rx_frame(struct ena_netmap_ctx *ctx)
 {
 	struct ena_com_rx_ctx ena_rx_ctx;
+	enum ena_regs_reset_reason_types reset_reason;
 	int rc, len = 0;
 	uint16_t buf, nm;
 
@@ -959,16 +960,22 @@ ena_netmap_rx_frame(struct ena_netmap_ctx *ctx)
 
 	rc = ena_com_rx_pkt(ctx->io_cq, ctx->io_sq, &ena_rx_ctx);
 	if (unlikely(rc != 0)) {
-		ena_trace(ENA_ALERT, "Too many desc from the device.\n");
-		counter_u64_add(ctx->ring->rx_stats.bad_desc_num, 1);
-		ena_trigger_reset(ctx->adapter,
-		    ENA_REGS_RESET_TOO_MANY_RX_DESCS);
+		ena_trace(NULL, ENA_ALERT,
+		    "Failed to read pkt from the device with error: %d\n", rc);
+		if (rc == ENA_COM_NO_SPACE) {
+			counter_u64_add(ctx->ring->rx_stats.bad_desc_num, 1);
+			reset_reason = ENA_REGS_RESET_TOO_MANY_RX_DESCS;
+		} else {
+			counter_u64_add(ctx->ring->rx_stats.bad_req_id, 1);
+			reset_reason = ENA_REGS_RESET_INV_RX_REQ_ID;
+		}
+		ena_trigger_reset(ctx->adapter, reset_reason);
 		return (rc);
 	}
 	if (unlikely(ena_rx_ctx.descs == 0))
 		return (ENA_NETMAP_NO_MORE_FRAMES);
 
-        ena_trace(ENA_NETMAP | ENA_DBG, "Rx: q %d got packet from ena. descs #:"
+        ena_trace(NULL, ENA_NETMAP | ENA_DBG, "Rx: q %d got packet from ena. descs #:"
 	    " %d l3 proto %d l4 proto %d hash: %x\n", ctx->ring->qid,
 	    ena_rx_ctx.descs, ena_rx_ctx.l3_proto, ena_rx_ctx.l4_proto,
 	    ena_rx_ctx.hash);
@@ -1017,19 +1024,15 @@ ena_netmap_rx_load_desc(struct ena_netmap_ctx *ctx, uint16_t buf, int *len)
 {
 	struct ena_rx_buffer *rx_info;
 	uint16_t req_id;
-	int rc;
 
 	req_id = ctx->ring->ena_bufs[buf].req_id;
-	rc = validate_rx_req_id(ctx->ring, req_id);
-	if (unlikely(rc != 0))
-		return (rc);
-
 	rx_info = &ctx->ring->rx_buffer_info[req_id];
 	bus_dmamap_sync(ctx->adapter->rx_buf_tag, rx_info->map,
 	    BUS_DMASYNC_POSTREAD);
 	netmap_unload_map(ctx->na, ctx->adapter->rx_buf_tag, rx_info->map);
 
-	ENA_ASSERT(ctx->slots[ctx->nm_i].buf_idx == 0, "Rx idx is not 0.\n");
+	ENA_WARN(ctx->slots[ctx->nm_i].buf_idx != 0, NULL,
+	    "Rx idx is not 0.\n");
 
 	ctx->slots[ctx->nm_i].buf_idx = rx_info->netmap_buf_idx;
 	rx_info->netmap_buf_idx = 0;
@@ -1041,7 +1044,7 @@ ena_netmap_rx_load_desc(struct ena_netmap_ctx *ctx, uint16_t buf, int *len)
 	ctx->slots[ctx->nm_i].len = ctx->ring->ena_bufs[buf].len;
 	*len += ctx->slots[ctx->nm_i].len;
 	ctx->ring->free_rx_ids[ctx->nt] = req_id;
-	ena_trace(ENA_DBG, "rx_info %p, buf_idx %d, paddr %jx, nm: %d\n",
+	ena_trace(NULL, ENA_DBG, "rx_info %p, buf_idx %d, paddr %jx, nm: %d\n",
 	    rx_info, ctx->slots[ctx->nm_i].buf_idx,
 	    (uintmax_t)rx_info->ena_buf.paddr, ctx->nm_i);
 

--- a/kernel/fbsd/ena/ena_netmap.h
+++ b/kernel/fbsd/ena/ena_netmap.h
@@ -1,5 +1,5 @@
 /*-
- * BSD LICENSE
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Copyright (c) 2015-2020 Amazon.com, Inc. or its affiliates.
  * All rights reserved.

--- a/kernel/fbsd/ena/ena_sysctl.h
+++ b/kernel/fbsd/ena/ena_sysctl.h
@@ -1,5 +1,5 @@
 /*-
- * BSD LICENSE
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Copyright (c) 2015-2020 Amazon.com, Inc. or its affiliates.
  * All rights reserved.


### PR DESCRIPTION
Changes since last release (v2.2.0)

**New Features**
* Add ENI (Elastic Network Interface) metrics support. They can be
  enabled and accessed using the sysctl.
* Add support for the Rx offsets (HW feature)

**Bug Fixes**
* Fix driver when running on kernel with RSS option being enabled
  (please note, that the standalone driver should also be built with
  'CFLAGS += -DRSS' option in the Makefile).
* Fix alignment of the ena_com_io_cq descriptors.
* Fix validation of the Rx requested ID.

**Minor Changes**
* Add SPDX license identifiers.
* Add description of all driver tunables to the README file.
* Fix names/description of the device IDs supported by the driver.
* Update HAL to the newer version.
* Remove deprecated ENA_WARN macro.

Signed-off-by: Michal Krawczyk <mk@semihalf.com>

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
