### PR TITLE
macOS/ena: Introduce a new ENA driver for macOS

### DIFF
--- a/kernel/macOS/ena/AmazonENAEthernet.xcodeproj/project.pbxproj
+++ b/kernel/macOS/ena/AmazonENAEthernet.xcodeproj/project.pbxproj
@@ -1,0 +1,420 @@
+// !$*UTF8*$!
+{
+	archiveVersion = 1;
+	classes = {
+	};
+	objectVersion = 48;
+	objects = {
+
+/* Begin PBXBuildFile section */
+		4D3742812355C366003380D0 /* ENAProperties.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4D3742802355C366003380D0 /* ENAProperties.cpp */; };
+		4D3E4D03250F7F9C003990EC /* ENALogs.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 4D3E4D02250F7F9B003990EC /* ENALogs.hpp */; };
+		4D3E4D05250F80A5003990EC /* ENATime.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 4D3E4D04250F80A5003990EC /* ENATime.hpp */; };
+		4D3E4D07250F8125003990EC /* ENATask.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 4D3E4D06250F8125003990EC /* ENATask.hpp */; };
+		4D3E4D09250F8153003990EC /* ENATask.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4D3E4D08250F8153003990EC /* ENATask.cpp */; };
+		4D3E4D0B250F9FC1003990EC /* ENAUtils.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 4D3E4D0A250F9FC1003990EC /* ENAUtils.hpp */; };
+		4D3E4D0D250F9FD5003990EC /* ENARings.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 4D3E4D0C250F9FD5003990EC /* ENARings.hpp */; };
+		4D3E4D0F250F9FF7003990EC /* ENAUtils.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4D3E4D0E250F9FF7003990EC /* ENAUtils.cpp */; };
+		4D3E4D13251082BE003990EC /* ENARings.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4D3E4D12251082BE003990EC /* ENARings.cpp */; };
+		4D42D4DC1FD0733600E57C6F /* ENA.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 4D42D4DB1FD0733600E57C6F /* ENA.hpp */; };
+		4D42D4DE1FD0733600E57C6F /* ENA.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4D42D4DD1FD0733600E57C6F /* ENA.cpp */; };
+		4D870A442355C429004AEBBA /* ENAProperties.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 4D37427E2355C35D003380D0 /* ENAProperties.hpp */; };
+		4D44C9E420FCA53700F8EEC5 /* ENAParallelOutputQueue.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4D44C9E320FCA53700F8EEC5 /* ENAParallelOutputQueue.cpp */; };
+		4D5C0414220ABF5600CA464C /* ENAParallelOutputQueue.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 4D5C0413220ABF5600CA464C /* ENAParallelOutputQueue.hpp */; };
+		4D5C0406220ABDD600CA464C /* ENAHash.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4D5C0405220ABDD600CA464C /* ENAHash.cpp */; };
+		4D5C0408220ABDF300CA464C /* ENAHash.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 4D5C0407220ABDF300CA464C /* ENAHash.hpp */; };
+		4D5C040A220ABDFC00CA464C /* ENANaiveHash.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4D5C0409220ABDFC00CA464C /* ENANaiveHash.cpp */; };
+		4D5C040C220ABE0600CA464C /* ENANaiveHash.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 4D5C040B220ABE0600CA464C /* ENANaiveHash.hpp */; };
+		4D5C040E220ABE0F00CA464C /* ENAToeplitzHash.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4D5C040D220ABE0F00CA464C /* ENAToeplitzHash.cpp */; };
+		4D5C0410220ABE1E00CA464C /* ENAToeplitzHash.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 4D5C040F220ABE1E00CA464C /* ENAToeplitzHash.hpp */; };
+		4DFEFBB4202B6AB600FFFD93 /* ena_com.c in Sources */ = {isa = PBXBuildFile; fileRef = 4DFEFBB1202B6AB600FFFD93 /* ena_com.c */; };
+		4DFEFBB5202B6AB600FFFD93 /* ena_eth_com.c in Sources */ = {isa = PBXBuildFile; fileRef = 4DFEFBB2202B6AB600FFFD93 /* ena_eth_com.c */; };
+		4DFEFBBA202B6B1E00FFFD93 /* ena_plat.h in Headers */ = {isa = PBXBuildFile; fileRef = 4DFEFBB6202B6B1E00FFFD93 /* ena_plat.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		4DFEFBBB202B6B1E00FFFD93 /* ena_com.h in Headers */ = {isa = PBXBuildFile; fileRef = 4DFEFBB7202B6B1E00FFFD93 /* ena_com.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		4DFEFBBC202B6B1E00FFFD93 /* ena_eth_com.h in Headers */ = {isa = PBXBuildFile; fileRef = 4DFEFBB8202B6B1E00FFFD93 /* ena_eth_com.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		4DFEFBBD202B6B1E00FFFD93 /* ena_plat_macos.h in Headers */ = {isa = PBXBuildFile; fileRef = 4DFEFBB9202B6B1E00FFFD93 /* ena_plat_macos.h */; };
+		4DFEFBC6202B6B4900FFFD93 /* ena_gen_info.h in Headers */ = {isa = PBXBuildFile; fileRef = 4DFEFBBE202B6B4900FFFD93 /* ena_gen_info.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		4DFEFBC7202B6B4900FFFD93 /* ena_common_defs.h in Headers */ = {isa = PBXBuildFile; fileRef = 4DFEFBBF202B6B4900FFFD93 /* ena_common_defs.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		4DFEFBC8202B6B4900FFFD93 /* ena_admin_defs.h in Headers */ = {isa = PBXBuildFile; fileRef = 4DFEFBC0202B6B4900FFFD93 /* ena_admin_defs.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		4DFEFBCB202B6B4A00FFFD93 /* ena_eth_io_defs.h in Headers */ = {isa = PBXBuildFile; fileRef = 4DFEFBC3202B6B4900FFFD93 /* ena_eth_io_defs.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		4DFEFBCC202B6B4A00FFFD93 /* ena_includes.h in Headers */ = {isa = PBXBuildFile; fileRef = 4DFEFBC4202B6B4900FFFD93 /* ena_includes.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		4DFEFBCD202B6B4A00FFFD93 /* ena_regs_defs.h in Headers */ = {isa = PBXBuildFile; fileRef = 4DFEFBC5202B6B4900FFFD93 /* ena_regs_defs.h */; settings = {ATTRIBUTES = (Private, ); }; };
+/* End PBXBuildFile section */
+
+/* Begin PBXFileReference section */
+		4D37427E2355C35D003380D0 /* ENAProperties.hpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.h; path = ENAProperties.hpp; sourceTree = "<group>"; };
+		4D3742802355C366003380D0 /* ENAProperties.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = ENAProperties.cpp; sourceTree = "<group>"; };
+		4D3E4D02250F7F9B003990EC /* ENALogs.hpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.h; path = ENALogs.hpp; sourceTree = "<group>"; };
+		4D3E4D04250F80A5003990EC /* ENATime.hpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.h; path = ENATime.hpp; sourceTree = "<group>"; };
+		4D3E4D06250F8125003990EC /* ENATask.hpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.h; path = ENATask.hpp; sourceTree = "<group>"; };
+		4D3E4D08250F8153003990EC /* ENATask.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = ENATask.cpp; sourceTree = "<group>"; };
+		4D3E4D0A250F9FC1003990EC /* ENAUtils.hpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.h; path = ENAUtils.hpp; sourceTree = "<group>"; };
+		4D3E4D0C250F9FD5003990EC /* ENARings.hpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.h; path = ENARings.hpp; sourceTree = "<group>"; };
+		4D3E4D0E250F9FF7003990EC /* ENAUtils.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = ENAUtils.cpp; sourceTree = "<group>"; };
+		4D3E4D12251082BE003990EC /* ENARings.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = ENARings.cpp; sourceTree = "<group>"; };
+		4D42D4D81FD0733600E57C6F /* AmazonENAEthernet.kext */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = AmazonENAEthernet.kext; sourceTree = BUILT_PRODUCTS_DIR; };
+		4D42D4DB1FD0733600E57C6F /* ENA.hpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.h; path = ENA.hpp; sourceTree = "<group>"; };
+		4D42D4DD1FD0733600E57C6F /* ENA.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = ENA.cpp; sourceTree = "<group>"; };
+		4D42D4DF1FD0733600E57C6F /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		4D44C9E320FCA53700F8EEC5 /* ENAParallelOutputQueue.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = ENAParallelOutputQueue.cpp; sourceTree = "<group>"; };
+		4D5C0413220ABF5600CA464C /* ENAParallelOutputQueue.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = ENAParallelOutputQueue.hpp; sourceTree = "<group>"; };
+		4D4B97491FD6EC9D000217B4 /* ena_com */ = {isa = PBXFileReference; lastKnownFileType = folder; path = ena_com; sourceTree = "<group>"; };
+		4D5C0405220ABDD600CA464C /* ENAHash.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = ENAHash.cpp; sourceTree = "<group>"; };
+		4D5C0407220ABDF300CA464C /* ENAHash.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = ENAHash.hpp; sourceTree = "<group>"; };
+		4D5C0409220ABDFC00CA464C /* ENANaiveHash.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = ENANaiveHash.cpp; sourceTree = "<group>"; };
+		4D5C040B220ABE0600CA464C /* ENANaiveHash.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = ENANaiveHash.hpp; sourceTree = "<group>"; };
+		4D5C040D220ABE0F00CA464C /* ENAToeplitzHash.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = ENAToeplitzHash.cpp; sourceTree = "<group>"; };
+		4D5C040F220ABE1E00CA464C /* ENAToeplitzHash.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = ENAToeplitzHash.hpp; sourceTree = "<group>"; };
+		4DFEFBB1202B6AB600FFFD93 /* ena_com.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; name = ena_com.c; path = ena_com/ena_com.c; sourceTree = "<group>"; };
+		4DFEFBB2202B6AB600FFFD93 /* ena_eth_com.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; name = ena_eth_com.c; path = ena_com/ena_eth_com.c; sourceTree = "<group>"; };
+		4DFEFBB6202B6B1E00FFFD93 /* ena_plat.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = ena_plat.h; path = ena_com/ena_plat.h; sourceTree = "<group>"; };
+		4DFEFBB7202B6B1E00FFFD93 /* ena_com.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = ena_com.h; path = ena_com/ena_com.h; sourceTree = "<group>"; };
+		4DFEFBB8202B6B1E00FFFD93 /* ena_eth_com.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = ena_eth_com.h; path = ena_com/ena_eth_com.h; sourceTree = "<group>"; };
+		4DFEFBB9202B6B1E00FFFD93 /* ena_plat_macos.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = ena_plat_macos.h; path = ena_com/ena_plat_macos.h; sourceTree = "<group>"; };
+		4DFEFBBE202B6B4900FFFD93 /* ena_gen_info.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = ena_gen_info.h; path = ena_com/ena_defs/ena_gen_info.h; sourceTree = "<group>"; };
+		4DFEFBBF202B6B4900FFFD93 /* ena_common_defs.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = ena_common_defs.h; path = ena_com/ena_defs/ena_common_defs.h; sourceTree = "<group>"; };
+		4DFEFBC0202B6B4900FFFD93 /* ena_admin_defs.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = ena_admin_defs.h; path = ena_com/ena_defs/ena_admin_defs.h; sourceTree = "<group>"; };
+		4DFEFBC3202B6B4900FFFD93 /* ena_eth_io_defs.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = ena_eth_io_defs.h; path = ena_com/ena_defs/ena_eth_io_defs.h; sourceTree = "<group>"; };
+		4DFEFBC4202B6B4900FFFD93 /* ena_includes.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = ena_includes.h; path = ena_com/ena_defs/ena_includes.h; sourceTree = "<group>"; };
+		4DFEFBC5202B6B4900FFFD93 /* ena_regs_defs.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = ena_regs_defs.h; path = ena_com/ena_defs/ena_regs_defs.h; sourceTree = "<group>"; };
+/* End PBXFileReference section */
+
+/* Begin PBXFrameworksBuildPhase section */
+		4D42D4D41FD0733600E57C6F /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXFrameworksBuildPhase section */
+
+/* Begin PBXGroup section */
+		4D42D4CE1FD0733600E57C6F = {
+			isa = PBXGroup;
+			children = (
+				4D3E4D12251082BE003990EC /* ENARings.cpp */,
+				4D3E4D0E250F9FF7003990EC /* ENAUtils.cpp */,
+				4D3E4D0C250F9FD5003990EC /* ENARings.hpp */,
+				4D3E4D0A250F9FC1003990EC /* ENAUtils.hpp */,
+				4D3E4D08250F8153003990EC /* ENATask.cpp */,
+				4D3E4D06250F8125003990EC /* ENATask.hpp */,
+				4D3E4D04250F80A5003990EC /* ENATime.hpp */,
+				4D3E4D02250F7F9B003990EC /* ENALogs.hpp */,
+				4D5C0413220ABF5600CA464C /* ENAParallelOutputQueue.hpp */,
+				4D5C040F220ABE1E00CA464C /* ENAToeplitzHash.hpp */,
+				4D5C040D220ABE0F00CA464C /* ENAToeplitzHash.cpp */,
+				4D5C040B220ABE0600CA464C /* ENANaiveHash.hpp */,
+				4D5C0409220ABDFC00CA464C /* ENANaiveHash.cpp */,
+				4D5C0407220ABDF300CA464C /* ENAHash.hpp */,
+				4D5C0405220ABDD600CA464C /* ENAHash.cpp */,
+				4D44C9E320FCA53700F8EEC5 /* ENAParallelOutputQueue.cpp */,
+				4DFEFBC0202B6B4900FFFD93 /* ena_admin_defs.h */,
+				4DFEFBBF202B6B4900FFFD93 /* ena_common_defs.h */,
+				4DFEFBC3202B6B4900FFFD93 /* ena_eth_io_defs.h */,
+				4DFEFBBE202B6B4900FFFD93 /* ena_gen_info.h */,
+				4DFEFBC4202B6B4900FFFD93 /* ena_includes.h */,
+				4DFEFBC5202B6B4900FFFD93 /* ena_regs_defs.h */,
+				4DFEFBB7202B6B1E00FFFD93 /* ena_com.h */,
+				4DFEFBB8202B6B1E00FFFD93 /* ena_eth_com.h */,
+				4DFEFBB9202B6B1E00FFFD93 /* ena_plat_macos.h */,
+				4DFEFBB6202B6B1E00FFFD93 /* ena_plat.h */,
+				4DFEFBB1202B6AB600FFFD93 /* ena_com.c */,
+				4DFEFBB2202B6AB600FFFD93 /* ena_eth_com.c */,
+				4D4B97491FD6EC9D000217B4 /* ena_com */,
+				4D42D4DB1FD0733600E57C6F /* ENA.hpp */,
+				4D42D4DD1FD0733600E57C6F /* ENA.cpp */,
+				4D3742802355C366003380D0 /* ENAProperties.cpp */,
+				4D37427E2355C35D003380D0 /* ENAProperties.hpp */,
+				4D42D4DF1FD0733600E57C6F /* Info.plist */,
+				4D42D4D91FD0733600E57C6F /* Products */,
+			);
+			sourceTree = "<group>";
+			wrapsLines = 0;
+		};
+		4D42D4D91FD0733600E57C6F /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				4D42D4D81FD0733600E57C6F /* AmazonENAEthernet.kext */,
+			);
+			name = Products;
+			sourceTree = "<group>";
+		};
+/* End PBXGroup section */
+
+/* Begin PBXHeadersBuildPhase section */
+		4D42D4D51FD0733600E57C6F /* Headers */ = {
+			isa = PBXHeadersBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				4DFEFBBA202B6B1E00FFFD93 /* ena_plat.h in Headers */,
+				4D5C040C220ABE0600CA464C /* ENANaiveHash.hpp in Headers */,
+				4DFEFBBB202B6B1E00FFFD93 /* ena_com.h in Headers */,
+				4DFEFBBC202B6B1E00FFFD93 /* ena_eth_com.h in Headers */,
+				4DFEFBC6202B6B4900FFFD93 /* ena_gen_info.h in Headers */,
+				4DFEFBC7202B6B4900FFFD93 /* ena_common_defs.h in Headers */,
+				4DFEFBC8202B6B4900FFFD93 /* ena_admin_defs.h in Headers */,
+				4DFEFBCB202B6B4A00FFFD93 /* ena_eth_io_defs.h in Headers */,
+				4DFEFBCC202B6B4A00FFFD93 /* ena_includes.h in Headers */,
+				4D3E4D0D250F9FD5003990EC /* ENARings.hpp in Headers */,
+				4D3E4D0B250F9FC1003990EC /* ENAUtils.hpp in Headers */,
+				4D3E4D07250F8125003990EC /* ENATask.hpp in Headers */,
+				4D3E4D05250F80A5003990EC /* ENATime.hpp in Headers */,
+				4D3E4D03250F7F9C003990EC /* ENALogs.hpp in Headers */,
+				4DFEFBCD202B6B4A00FFFD93 /* ena_regs_defs.h in Headers */,
+				4D870A442355C429004AEBBA /* ENAProperties.hpp in Headers */,
+				4D5C0414220ABF5600CA464C /* ENAParallelOutputQueue.hpp in Headers */,
+				4D5C0408220ABDF300CA464C /* ENAHash.hpp in Headers */,
+				4DFEFBBD202B6B1E00FFFD93 /* ena_plat_macos.h in Headers */,
+				4D5C0410220ABE1E00CA464C /* ENAToeplitzHash.hpp in Headers */,
+				4D42D4DC1FD0733600E57C6F /* ENA.hpp in Headers */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXHeadersBuildPhase section */
+
+/* Begin PBXNativeTarget section */
+		4D42D4D71FD0733600E57C6F /* AmazonENAEthernet */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 4D42D4E21FD0733600E57C6F /* Build configuration list for PBXNativeTarget "AmazonENAEthernet" */;
+			buildPhases = (
+				4D42D4D31FD0733600E57C6F /* Sources */,
+				4D42D4D41FD0733600E57C6F /* Frameworks */,
+				4D42D4D51FD0733600E57C6F /* Headers */,
+				4D42D4D61FD0733600E57C6F /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = AmazonENAEthernet;
+			productName = ENA;
+			productReference = 4D42D4D81FD0733600E57C6F /* AmazonENAEthernet.kext */;
+			productType = "com.apple.product-type.kernel-extension";
+		};
+/* End PBXNativeTarget section */
+
+/* Begin PBXProject section */
+		4D42D4CF1FD0733600E57C6F /* Project object */ = {
+			isa = PBXProject;
+			attributes = {
+				LastUpgradeCheck = 0910;
+				ORGANIZATIONNAME = Amazon;
+				TargetAttributes = {
+					4D42D4D71FD0733600E57C6F = {
+						CreatedOnToolsVersion = 9.1;
+						ProvisioningStyle = Automatic;
+					};
+				};
+			};
+			buildConfigurationList = 4D42D4D21FD0733600E57C6F /* Build configuration list for PBXProject "AmazonENAEthernet" */;
+			compatibilityVersion = "Xcode 8.0";
+			developmentRegion = en;
+			hasScannedForEncodings = 0;
+			knownRegions = (
+				en,
+			);
+			mainGroup = 4D42D4CE1FD0733600E57C6F;
+			productRefGroup = 4D42D4D91FD0733600E57C6F /* Products */;
+			projectDirPath = "";
+			projectRoot = "";
+			targets = (
+				4D42D4D71FD0733600E57C6F /* AmazonENAEthernet */,
+			);
+		};
+/* End PBXProject section */
+
+/* Begin PBXResourcesBuildPhase section */
+		4D42D4D61FD0733600E57C6F /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXResourcesBuildPhase section */
+
+/* Begin PBXSourcesBuildPhase section */
+		4D42D4D31FD0733600E57C6F /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				4D3E4D13251082BE003990EC /* ENARings.cpp in Sources */,
+				4D3E4D0F250F9FF7003990EC /* ENAUtils.cpp in Sources */,
+				4D3E4D09250F8153003990EC /* ENATask.cpp in Sources */,
+				4DFEFBB4202B6AB600FFFD93 /* ena_com.c in Sources */,
+				4D5C0406220ABDD600CA464C /* ENAHash.cpp in Sources */,
+				4D5C040A220ABDFC00CA464C /* ENANaiveHash.cpp in Sources */,
+				4DFEFBB5202B6AB600FFFD93 /* ena_eth_com.c in Sources */,
+				4D44C9E420FCA53700F8EEC5 /* ENAParallelOutputQueue.cpp in Sources */,
+				4D5C040E220ABE0F00CA464C /* ENAToeplitzHash.cpp in Sources */,
+				4D42D4DE1FD0733600E57C6F /* ENA.cpp in Sources */,
+				4D3742812355C366003380D0 /* ENAProperties.cpp in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXSourcesBuildPhase section */
+
+/* Begin XCBuildConfiguration section */
+		4D42D4E01FD0733600E57C6F /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++14";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				CODE_SIGN_IDENTITY = "-";
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = dwarf;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_TESTABILITY = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu11;
+				GCC_DYNAMIC_NO_PIC = NO;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"DEBUG=1",
+					"IOASSERT=1",
+					"$(inherited)",
+				);
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				MACOSX_DEPLOYMENT_TARGET = 10.14;
+				MTL_ENABLE_DEBUG_INFO = YES;
+				ONLY_ACTIVE_ARCH = YES;
+				SDKROOT = macosx;
+			};
+			name = Debug;
+		};
+		4D42D4E11FD0733600E57C6F /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++14";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				CODE_SIGN_IDENTITY = "-";
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				ENABLE_NS_ASSERTIONS = NO;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu11;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				MACOSX_DEPLOYMENT_TARGET = 10.14;
+				MTL_ENABLE_DEBUG_INFO = NO;
+				SDKROOT = macosx;
+			};
+			name = Release;
+		};
+		4D42D4E31FD0733600E57C6F /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_STYLE = Automatic;
+				COMBINE_HIDPI_IMAGES = YES;
+				CURRENT_PROJECT_VERSION = 1.5.0;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				INFOPLIST_FILE = Info.plist;
+				MACOSX_DEPLOYMENT_TARGET = 10.14;
+				MODULE_NAME = AmazonENAEthernet;
+				MODULE_VERSION = 1.5.0;
+				PRODUCT_BUNDLE_IDENTIFIER = com.amazon.driver.AmazonENAEthernet;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				WRAPPER_EXTENSION = kext;
+			};
+			name = Debug;
+		};
+		4D42D4E41FD0733600E57C6F /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_STYLE = Automatic;
+				COMBINE_HIDPI_IMAGES = YES;
+				CURRENT_PROJECT_VERSION = 1.5.0;
+				INFOPLIST_FILE = Info.plist;
+				MACOSX_DEPLOYMENT_TARGET = 10.14;
+				MODULE_NAME = AmazonENAEthernet;
+				MODULE_VERSION = 1.5.0;
+				PRODUCT_BUNDLE_IDENTIFIER = com.amazon.driver.AmazonENAEthernet;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				WRAPPER_EXTENSION = kext;
+			};
+			name = Release;
+		};
+/* End XCBuildConfiguration section */
+
+/* Begin XCConfigurationList section */
+		4D42D4D21FD0733600E57C6F /* Build configuration list for PBXProject "AmazonENAEthernet" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				4D42D4E01FD0733600E57C6F /* Debug */,
+				4D42D4E11FD0733600E57C6F /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		4D42D4E21FD0733600E57C6F /* Build configuration list for PBXNativeTarget "AmazonENAEthernet" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				4D42D4E31FD0733600E57C6F /* Debug */,
+				4D42D4E41FD0733600E57C6F /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+/* End XCConfigurationList section */
+	};
+	rootObject = 4D42D4CF1FD0733600E57C6F /* Project object */;
+}

--- a/kernel/macOS/ena/ENA.cpp
+++ b/kernel/macOS/ena/ENA.cpp
@@ -1,0 +1,1878 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+#include "ENA.hpp"
+
+#include "ENALogs.hpp"
+#include "ENAProperties.hpp"
+
+#include <sys/sysctl.h>
+
+#include <netinet/ip6.h>
+#include <netinet/tcp.h>
+#include <netinet/udp.h>
+
+#include <libkern/OSKextLib.h>
+
+#include <IOKit/IOBufferMemoryDescriptor.h>
+
+static ENAProperties enaProperties;
+
+// This required macro defines the class's constructors, destructors,
+// and several other methods I/O Kit requires.
+OSDefineMetaClassAndStructors(ENA, IOEthernetController)
+
+// Define the driver's superclass.
+#define super IOEthernetController
+
+int ena_log_level = 0x3;
+
+bool ENA::init(OSDictionary *properties)
+{
+	ENA_DEBUG_LOGC("init() ----->\n");
+
+	// Set _devName to 0 length string to use default getName() until PCI
+	// address of the device will be available.
+	_devName[0] = '\0';
+
+	if (!super::init(properties)) {
+		ENA_ERROR_LOGC("Init of the super class failed\n");
+		goto error;
+	}
+
+	_globalLock = IOLockAlloc();
+	if (_globalLock == nullptr) {
+		ENA_ERROR_LOGC("Failed to alloc global lock\n");
+		goto error;
+	}
+
+	_inputQueueLock = IOLockAlloc();
+	if (_inputQueueLock == nullptr) {
+		ENA_ERROR_LOGC("Failed to alloc input queue lock\n");
+		goto error;
+	}
+
+	_hashFunction = ENAToeplitzHash::withKey(hashFunctionKey, sizeof(hashFunctionKey));
+	if (_hashFunction == nullptr) {
+		ENA_ERROR_LOG("Failed to allocate hash function\n");
+		goto error;
+	}
+
+	_keepAliveTimeout.setSeconds(ENA_DEVICE_KALIVE_TIMEOUT);
+	_missingTxCompletionTimeout.setSeconds(ENA_TX_TIMEOUT);
+	_missingTxCompletionThreshold = ENA_MAX_NUM_OF_TIMEOUTED_PACKETS;
+
+	initAtomicStats((AtomicStat *)&_hwStats, ENAHWStatsNum);
+
+	ENA_DEBUG_LOGC("init() <-----\n");
+	return true;
+
+error:
+	ENA_DEBUG_LOGC("init() <-----\n");
+	return false;
+}
+
+void ENA::free()
+{
+	ENA_DEBUG_LOGC("free() ----->\n");
+
+	if (_globalLock != nullptr) {
+		IOLockLock(_globalLock);
+		ENA_DEBUG_LOGC("free() lock acquired\n");
+	}
+
+	// Disable AENQ timer in case it's enabled before releasing it
+	if ((_aenqTimerEvent != nullptr) && _aenqTimerEvent->isEnabled())
+		_aenqTimerEvent->disable();
+
+	// Release resources initialized in start()
+	SAFE_RELEASE(_resetTask);
+	SAFE_RELEASE(_aenqTimerEvent);
+	SAFE_RELEASE(_aenqWorkLoop);
+	SAFE_RELEASE(_timerEvent);
+	SAFE_RELEASE(_mediumAuto);
+	SAFE_RELEASE(_queues);
+
+	releaseProperties();
+
+	if (testFlag(ENA_FLAG_DEV_INIT)) {
+		ena_com_dev_reset(_enaDev,
+				  testFlag(ENA_FLAG_DEV_RUNNING)
+				      ? ENA_REGS_RESET_NORMAL
+				      : ENA_REGS_RESET_INIT_ERR);
+
+		freeMainInterrupt();
+
+		ena_com_abort_admin_commands(_enaDev);
+		ena_com_wait_for_abort_completion(_enaDev);
+		ena_com_admin_destroy(_enaDev);
+		ena_com_mmio_reg_read_request_destroy(_enaDev);
+		ena_com_rss_destroy(_enaDev);
+	}
+	clearFlag(ENA_FLAG_DEV_RUNNING);
+	clearFlag(ENA_FLAG_DEV_INIT);
+
+	if (_enaDev != nullptr) {
+		IODelete(_enaDev, struct ena_com_dev, 1);
+		_enaDev = nullptr;
+	}
+
+	SAFE_RELEASE(_netif);
+	SAFE_RELEASE(_txQueue);
+
+	releasePCIResources();
+	if (_pciNub != nullptr) {
+		if (_pciNub->isOpen())
+			_pciNub->close(this);
+		_pciNub->release();
+	}
+	SAFE_RELEASE(_workLoop);
+
+	SAFE_RELEASE(_hashFunction);
+	if (_inputQueueLock != nullptr) {
+		IOLockFree(_inputQueueLock);
+		_inputQueueLock = nullptr;
+	}
+
+	// Release resources configured in init()
+	if (_globalLock != nullptr) {
+		IOLockUnlock(_globalLock);
+		IOLockFree(_globalLock);
+		_globalLock = nullptr;
+	}
+
+	super::free();
+	ENA_DEBUG_LOGC("free() <-----\n");
+}
+
+bool ENA::start(IOService *provider)
+{
+	IOTimerEventSource::Action timerService;
+	IOTimerEventSource::Action aenqTimerService;
+	ENATask::Action resetAction;
+	struct ena_com_dev_get_features_ctx features;
+	UInt32 ioQueueNum, queueSize;
+	UInt16 txSglSize, rxSglSize;
+	bool wdState;
+
+	ENA_DEBUG_LOG("start() ----->\n");
+
+	IOLockLock(_globalLock);
+	ENA_DEBUG_LOG("start() lock acquired\n");
+
+	// Save reference to the provider and use RTTI to check if this is PCI nub
+	_pciNub = OSDynamicCast(IOPCIDevice, provider);
+	if (_pciNub == nullptr) {
+		ENA_ERROR_LOG("Failed to cast provider\n");
+		goto error_unlock;
+	}
+	// From now the nub pointer belongs to the driver and must
+	// be released by the driver
+	_pciNub->retain();
+
+	// Append bus:dev.fun to the original class name.
+	snprintf(_devName, sizeof(_devName), "%s %02x:%02x.%02x", super::getName(),
+		 _pciNub->getBusNumber(), _pciNub->getDeviceNumber(), _pciNub->getFunctionNumber());
+
+	if (!super::start(provider)) {
+		ENA_ERROR_LOG("Start of the super class failed\n");
+		goto error_unlock;
+	}
+
+	if (!_pciNub->open(this)) {
+		ENA_ERROR_LOG("Cannot open PCI device\n");
+		goto error_stop;
+	}
+
+	// Driver specific resources
+	_enaDev = IONew(struct ena_com_dev, 1);
+	if (_enaDev == nullptr) {
+		ENA_ERROR_LOG("Failed to allocate memory for the ena_com device\n");
+		goto error_stop;
+	}
+	memset(_enaDev, 0, sizeof(*_enaDev));
+
+	_enaDev->dmadev = _pciNub;
+
+	initPCIConfigSpace();
+	if (!allocatePCIResources()) {
+		ENA_ERROR_LOG("Failed to allocate PCI resources\n");
+		goto error_stop;
+	}
+
+	_enaDev->reg_bar = (u8 *)_regMap->getVirtualAddress();
+	if (!_enaDev->reg_bar) {
+		ENA_ERROR_LOG("Failed to remap regs bar\n");
+		goto error_stop;
+	}
+
+	if(!initDevice(&features, wdState)) {
+		ENA_ERROR_LOG("Failed to allocate resources for IO queues\n");
+		goto error_stop;
+	}
+	setFlag(ENA_FLAG_DEV_INIT);
+
+	_enaDev->tx_mem_queue_type = ENA_ADMIN_PLACEMENT_POLICY_HOST;
+	_enaDev->intr_moder_tx_interval = ENA_INTR_INITIAL_TX_INTERVAL_USECS;
+
+	ioQueueNum = calcIOQueueNum(features);
+	queueSize = calcIOQueueSize(features, &txSglSize, &rxSglSize);
+
+	if ((queueSize == 0) || (ioQueueNum == 0)) {
+		ENA_ERROR_LOG("Invalid queues configuration: queue size=%u; number of queues=%u\n",
+			      queueSize, ioQueueNum);
+		goto error_stop;
+	}
+
+	memcpy(_macAddr.bytes, features.dev_attr.mac_addr, kIOEthernetAddressSize);
+
+	setSupportedOffloads(features.offload);
+
+	// Driver can handle Tx mbufs which are not physically contiguous
+	_featuresMask |= kIONetworkFeatureMultiPages;
+
+	ENA_DEBUG_LOG("Features mask: 0x%x, Tx checksum mask: 0x%x, Rx checksum mask: 0x%x\n",
+		  _featuresMask, _txChecksumMask, _rxChecksumMask);
+
+	_maxMTU = features.dev_attr.max_mtu;
+
+	_numQueues = ioQueueNum;
+	_queueSize = queueSize;
+	_maxTxSglSize = txSglSize;
+	_maxRxSglSize = rxSglSize;
+	if (wdState)
+		setFlag(ENA_FLAG_WATCHDOG_ACTIVE);
+
+	if (!allocateIOQueues()) {
+		ENA_ERROR_LOG("Failed to allocate the IO queues\n");
+		goto error_stop;
+	}
+
+	if (!setupMainInterrupt()) {
+		ENA_ERROR_LOG("Setup main interrupt failed\n");
+		goto error_stop;
+	}
+
+	if (!requestMainInterrupt()) {
+		ENA_ERROR_LOG("Setting main interrupt failed\n");
+		goto error_stop;
+	}
+
+	if (!rssInitDefault()) {
+		ENA_ERROR_LOG("Failed to initialize RSS\n");
+		goto error_stop;
+	}
+
+	// ENA can be used only with ENAParallelOutputQueue for multiqueue support
+	_txQueue = createParallelOutputQueue();
+	if (_txQueue == nullptr) {
+		ENA_ERROR_LOG("Failed to create parallel output queue\n");
+		goto error_stop;
+	}
+
+	_mediumAuto = IONetworkMedium::medium(kIOMediumEthernetAuto, 0);
+	if (_mediumAuto == nullptr) {
+		ENA_ERROR_LOG("Failed to create auto negotiated medium\n");
+		goto error_stop;
+	}
+
+	// ENAParallelOutputQueue can contain multiple subqueues. As they can hold a lot of resources,
+	// they should be activated as late as possible with minimal required kernel memory.
+	if (!_txQueue->setActiveSubQueues(ioQueueNum)) {
+		ENA_ERROR_LOG("Failed to activate parallel output queue with %d subqueues\n", ioQueueNum);
+		goto error_stop;
+	}
+
+	_pciNub->close(this);
+
+	timerService = OSMemberFunctionCast(IOTimerEventSource::Action,
+					    this,
+					    &ENA::timerService);
+	_timerEvent = IOTimerEventSource::timerEventSource(
+		kIOTimerEventSourceOptionsPriorityKernelHigh,
+		this,
+		timerService);
+	if (_timerEvent == nullptr) {
+		ENA_ERROR_LOG("Failed to create timer service\n");
+		goto error_stop;
+	}
+	// Use the controller work loop for timer event synchronization
+	_workLoop->addEventSource(_timerEvent);
+
+	_aenqWorkLoop = IOWorkLoop::workLoop();
+	if (_aenqWorkLoop == nullptr) {
+		ENA_ERROR_LOG("Failed to create auto admin workloop\n");
+		goto error_stop;
+	}
+
+	aenqTimerService = OSMemberFunctionCast(IOTimerEventSource::Action,
+						this,
+						&ENA::aenqTimerService);
+
+	_aenqTimerEvent = IOTimerEventSource::timerEventSource(
+		kIOTimerEventSourceOptionsPriorityKernelHigh,
+		this,
+		aenqTimerService);
+	if (_aenqTimerEvent == nullptr) {
+		ENA_ERROR_LOG("Failed to create admin timer service\n");
+		goto error_stop;
+	}
+
+	_aenqWorkLoop->addEventSource(_aenqTimerEvent);
+
+	resetAction = OSMemberFunctionCast(ENATask::Action,
+					   this,
+					   &ENA::resetAction);
+	_resetTask = ENATask::withAction(this, resetAction);
+	if (_resetTask == nullptr) {
+		ENA_ERROR_LOG("Failed to create reset task\n");
+		goto error_stop;
+	}
+
+	_lastKeepAliveTime.setNow();
+
+	ena_com_admin_aenq_enable(_enaDev);
+
+	setLinkStatus(kIONetworkLinkValid);
+
+	if (!attachInterface((IONetworkInterface **)&_netif, true)) {
+		ENA_ERROR_LOG("Cannot attach Ethernet interface\n");
+		goto error_stop;
+	}
+
+	_resetTask->enable();
+
+	setFlag(ENA_FLAG_DEV_RUNNING);
+
+	_aenqTimerEvent->enable();
+	_aenqTimerEvent->setTimeoutMS(ENA_AENQ_TIMER_SERVICE_TIMEOUT_MS);
+
+	ENA_LOG("Device has been started, driver version: %s\n", OSKextGetCurrentVersionString());
+
+	IOLockUnlock(_globalLock);
+
+	ENA_DEBUG_LOG("start() <-----\n");
+	return true;
+
+error_stop:
+	super::stop(provider);
+error_unlock:
+	IOLockUnlock(_globalLock);
+	ENA_DEBUG_LOG("start() <-----\n");
+	return false;
+}
+
+void ENA::stop(IOService *provider)
+{
+	ENA_DEBUG_LOG("stop() ----->\n");
+
+	// As the stop() is only being called after start() finished
+	// successfully, it is safe to disable reset task in order to prevent
+	// deadlocks with the global lock inside the free().
+	// In a situation when the _resetTask would still be running and in the
+	// meantime the free() would take the global lock, the
+	// SAFE_RELEASE(_resetTask) could cause a dead lock because it needs to
+	// disable the reset task first, which needs to take an internal lock.
+	// The internal lock is released when the currently running method is
+	// being finished.
+	_resetTask->disable();
+
+	IOLockLock(_globalLock);
+	ENA_DEBUG_LOG("stop() lock acquired\n");
+
+	super::stop(provider);
+
+	IOLockUnlock(_globalLock);
+	ENA_DEBUG_LOG("stop() <-----\n");
+}
+
+/*
+ * Note: all calls to this functions should be protected by holding the common
+ * lock, for example: _globalLock.
+ */
+IOReturn ENA::enableLocked(IONetworkInterface *netif)
+{
+	IOReturn ret;
+
+	if (!_pciNub->open(this)) {
+		ENA_ERROR_LOG("Cannot open PCI device\n");
+		ret = kIOReturnError;
+		goto error;
+	}
+
+	if (!enableAllIOQueues()) {
+		ENA_ERROR_LOG("Failed to enable IO queues\n");
+		ret = kIOReturnError;
+		goto err_close_pci;
+	}
+
+	if (!rssConfigure()) {
+		ENA_ERROR_LOG("Failed to configure RSS\n");
+		ret = kIOReturnError;
+		goto err_disable_queues;
+	}
+
+	if (!_txQueue->setCapacity(_queueSize) || !_txQueue->start()) {
+		ENA_ERROR_LOG("Failed to start Tx output queue\n");
+		ret = kIOReturnError;
+		goto err_disable_queues;
+	}
+
+	setFlag(ENA_FLAG_DEV_UP);
+
+	unmaskAllIOInterrupts();
+
+	if (testFlag(ENA_FLAG_LINK_UP))
+		setLinkStatus(kIONetworkLinkValid | kIONetworkLinkActive, _mediumAuto);
+
+
+	_lastMonitoredQueueID = 0;
+
+	// Activate timer service only if the device is running.
+	// If this flag is not set, it means that the driver is being
+	// reset and timer service will be activated afterwards.
+	if (testFlag(ENA_FLAG_DEV_RUNNING)) {
+		_timerEvent->enable();
+		_timerEvent->setTimeoutMS(ENA_TIMER_SERVICE_TIMEOUT_MS);
+	}
+
+	return kIOReturnSuccess;
+
+err_disable_queues:
+	disableAllIOQueues();
+err_close_pci:
+	_pciNub->close(this);
+error:
+	return ret;
+}
+
+IOReturn ENA::enable(IONetworkInterface *netif)
+{
+	IOReturn ret;
+
+	ENA_DEBUG_LOG("enable() ----->\n");
+	IOLockLock(_globalLock);
+	ENA_DEBUG_LOG("enable() lock acquired\n");
+
+	ret = enableLocked(netif);
+
+	ENA_LOG("Device has been enabled\n");
+
+	IOLockUnlock(_globalLock);
+	ENA_DEBUG_LOG("enable() <-----\n");
+
+	return ret;
+}
+
+/*
+ * Note: all calls to this functions should be protected by holding the common
+ * lock, for example: _globalLock.
+ */
+IOReturn ENA::disableLocked(IONetworkInterface *netif)
+{
+	int rc;
+
+	_timerEvent->disable();
+
+	setLinkStatus(kIONetworkLinkValid);
+
+	_txQueue->stop();
+	_txQueue->flush();
+
+	if (testFlag(ENA_FLAG_TRIGGER_RESET)) {
+		rc = ena_com_dev_reset(_enaDev, _resetReason);
+		if (rc != 0)
+			ENA_ERROR_LOG("Device reset failed\n");
+		ena_com_set_admin_running_state(_enaDev, false);
+	}
+
+	clearFlag(ENA_FLAG_DEV_UP);
+
+	disableAllIOQueues();
+
+	_pciNub->close(this);
+
+	return kIOReturnSuccess;
+}
+
+IOReturn ENA::disable(IONetworkInterface *netif)
+{
+	IOReturn ret;
+
+	ENA_DEBUG_LOG("disable() ----->\n");
+	IOLockLock(_globalLock);
+	ENA_DEBUG_LOG("disable() lock acquired\n");
+
+	ret = disableLocked(netif);
+
+	ENA_LOG("Device has been disabled\n");
+
+	IOLockUnlock(_globalLock);
+	ENA_DEBUG_LOG("disable() <-----\n");
+
+	return ret;
+}
+
+IOReturn ENA::setMulticastMode(bool active)
+{
+	// ENA doesn't need to configure the multicast - but success have to been
+	// returned in order to correctly load the interface.
+	return kIOReturnSuccess;
+}
+
+IOReturn ENA::setPromiscuousMode(bool active)
+{
+	// There is nothing to do in the HW for promiscuous mode, but this method
+	// have to return success in order to correctly load the interface.
+	return kIOReturnSuccess;
+}
+
+IOReturn ENA::setMaxPacketSize(UInt32 maxSize)
+{
+	int rc, mtu;
+
+	mtu = maxSize - kIOEthernetCRCSize - sizeof(struct ether_header);
+
+	rc = ena_com_set_dev_mtu(_enaDev, mtu);
+	if (unlikely(rc != 0)) {
+		ENA_ERROR_LOG("Failed to set MTU to %d\n", mtu);
+		return kIOReturnError;
+	}
+
+	ENA_DEBUG_LOG("Set MTU to %d\n", mtu);
+	return kIOReturnSuccess;
+}
+
+IOReturn ENA::getMaxPacketSize(UInt32 *maxSize) const
+{
+	ENA_DEBUG_LOG("getMaxPacketSize()\n");
+
+	*maxSize = _maxMTU + kIOEthernetCRCSize + sizeof(struct ether_header);
+
+	return kIOReturnSuccess;
+}
+
+bool ENA::configureInterface(IONetworkInterface *netif)
+{
+	IONetworkData *data;
+	if (!super::configureInterface(netif))
+		return false;
+
+	data = netif->getNetworkData(kIONetworkStatsKey);
+	if (!data || !(_netStats = (IONetworkStats *)data->getBuffer())) {
+		ENA_ERROR_LOG("There are no network statistics\n");
+		return false;
+	}
+
+	return true;
+}
+
+bool ENA::handleMainInterrupt(IOFilterInterruptEventSource *src)
+{
+	// Because of Darwin limitations in terms of MSI-x handlers (only single
+	// one is supported), everything must be handled within the one handler.
+	// This routine is executing async tasks - IO queues.
+	ENAQueue *queue;
+
+	atomic_store(&_interruptHandlersRemaining, _numQueues);
+
+	if (likely(testFlag(ENA_FLAG_DEV_UP))) {
+		for (int i = 0; i < _numQueues; ++i) {
+			queue = OSDynamicCast(ENAQueue, _queues->getObject(i));
+			queue->interruptOccurred();
+		}
+	}
+
+	// Return false, as we've done all processing there and scheduled our own tasks.
+	return false;
+}
+
+IOReturn ENA::getHardwareAddress(IOEthernetAddress *addrP)
+{
+	*addrP = _macAddr;
+	return kIOReturnSuccess;
+}
+
+bool ENA::createWorkLoop()
+{
+	// Create new work loop for the driver instance. Not creating new work
+	// loop will result in using global work loop of the IOKit.
+	_workLoop = IOWorkLoop::workLoop();
+	return (_workLoop != nullptr);
+}
+
+IOWorkLoop *ENA::getWorkLoop() const
+{
+	// Get work loop specific for the driver instance,
+	// instead of the global one
+	return _workLoop;
+}
+
+IOOutputQueue *ENA::getOutputQueue() const
+{
+	return _txQueue;
+}
+
+struct ena_com_dev * ENA::getENADevice()
+{
+	return _enaDev;
+}
+
+IOPCIDevice * ENA::getProvider()
+{
+	return _pciNub;
+}
+
+IOEthernetInterface * ENA::getEthernetInterface()
+{
+	return _netif;
+}
+
+IONetworkStats * ENA::getNetworkStats()
+{
+	return _netStats;
+}
+
+bool ENA::initEventSources(IOService *provider)
+{
+	if (_workLoop == nullptr)
+		return false;
+	return true;
+}
+
+bool ENA::allocateIOQueues()
+{
+	ENAQueue *queue;
+	ENARingTx::TxConfig txConfig;
+	ENARingRx::RxConfig rxConfig;
+	bool success = true;
+
+	_queues = OSArray::withCapacity(_numQueues);
+	if (_queues == nullptr) {
+		ENA_DEBUG_LOG("Cannot allocate array for the IO queues\n");
+		return false;
+	}
+
+	// Configuration for Tx queue
+	txConfig.memQueueType = _enaDev->tx_mem_queue_type;
+	txConfig.queueSize = _queueSize;
+	txConfig.maxSegmentsNumber = _maxTxSglSize;
+	txConfig.maxSegmentSize = txBufMaxSize;
+	txConfig.packetCleanupBudget = ENA_TX_BUDGET;
+
+	// Configuration for Rx queue
+	rxConfig.memQueueType = ENA_ADMIN_PLACEMENT_POLICY_HOST;
+	rxConfig.queueSize = _queueSize;
+	rxConfig.maxSegmentsNumber = _maxRxSglSize;
+	rxConfig.maxSegmentSize = MBIGCLBYTES;
+	rxConfig.packetCleanupBudget = ENA_RX_BUDGET;
+
+	for (size_t i = 0; i < _numQueues; i++) {
+		// Set the IDs for both queues
+		txConfig.qid = i;
+		rxConfig.qid = i;
+		queue = ENAQueue::withConfig(this, &txConfig, &rxConfig);
+		if (queue == nullptr) {
+			ENA_DEBUG_LOG("Cannot allocate queue\n");
+			success = false;
+			break;
+		}
+
+		if (!_queues->setObject(queue)) {
+			queue->release();
+			ENA_DEBUG_LOG("Cannot add queue to array\n");
+			success = false;
+			break;
+		}
+
+		// As OSArray retains the objects, we need to release the queue.
+		queue->release();
+	}
+
+	// This will also release all queues currently held in the OSArray.
+	if (!success)
+		SAFE_RELEASE(_queues);
+
+	return success;
+}
+
+UInt32 ENA::calcIOQueueNum(const struct ena_com_dev_get_features_ctx &features)
+{
+	UInt32 ioTxSQNum, ioTxCQNum, ioRxNum, ioQueueNum;
+	UInt32 ncpu = 0;
+	size_t ncpuSize = sizeof(ncpu);
+	int rv;
+
+	rv = sysctlbyname("hw.ncpu", &ncpu, &ncpuSize, nullptr, 0);
+	assert(rv == 0);
+
+	if (_enaDev->supported_features & BIT(ENA_ADMIN_MAX_QUEUES_EXT)) {
+		ioRxNum = min(features.max_queue_ext.max_queue_ext.max_rx_sq_num,
+			      features.max_queue_ext.max_queue_ext.max_rx_cq_num);
+		ioTxSQNum = features.max_queue_ext.max_queue_ext.max_tx_sq_num;
+		ioTxCQNum = features.max_queue_ext.max_queue_ext.max_tx_cq_num;
+	} else {
+		ioTxSQNum = features.max_queues.max_sq_num;
+		ioTxCQNum = features.max_queues.max_cq_num;
+		ioRxNum = min(ioTxSQNum, ioTxCQNum);
+	}
+
+	if (_enaDev->tx_mem_queue_type == ENA_ADMIN_PLACEMENT_POLICY_DEV) {
+		ioTxSQNum = features.llq.max_llq_num;
+	}
+
+	ioQueueNum = min(ENA_MAX_NUM_IO_QUEUES, ncpu);
+	ioQueueNum = min(ioQueueNum, ioRxNum);
+	ioQueueNum = min(ioQueueNum, ioTxSQNum);
+	ioQueueNum = min(ioQueueNum, ioTxCQNum);
+	ioQueueNum = min(ioQueueNum, maxSupportedIOQueues);
+
+	return ioQueueNum;
+}
+
+UInt32 ENA::calcIOQueueSize(const struct ena_com_dev_get_features_ctx &features,
+			    UInt16 *txSglSize,
+			    UInt16 *rxSglSize)
+{
+	UInt32 queueSize = ENA_DEFAULT_RING_SIZE;
+
+	if (_enaDev->supported_features & BIT(ENA_ADMIN_MAX_QUEUES_EXT)) {
+		const struct ena_admin_queue_ext_feature_fields *max_queue_ext =
+		&features.max_queue_ext.max_queue_ext;
+		queueSize = min(queueSize, max_queue_ext->max_rx_cq_depth);
+		queueSize = min(queueSize, max_queue_ext->max_rx_sq_depth);
+		queueSize = min(queueSize, max_queue_ext->max_tx_cq_depth);
+
+		if (_enaDev->tx_mem_queue_type == ENA_ADMIN_PLACEMENT_POLICY_DEV) {
+			queueSize = min(queueSize, features.llq.max_llq_depth);
+		} else {
+			queueSize = min(queueSize, max_queue_ext->max_tx_sq_depth);
+		}
+
+		*txSglSize = min(enaPktMaxBufs,
+				 features.max_queue_ext.max_queue_ext.max_per_packet_tx_descs);
+		*rxSglSize = min(enaPktMaxBufs,
+				 features.max_queue_ext.max_queue_ext.max_per_packet_rx_descs);
+	} else {
+		const struct ena_admin_queue_feature_desc *max_queues =
+		&features.max_queues;
+		queueSize = min(queueSize, max_queues->max_cq_depth);
+		if (_enaDev->tx_mem_queue_type == ENA_ADMIN_PLACEMENT_POLICY_DEV) {
+			queueSize = min(queueSize, features.llq.max_llq_depth);
+		}
+		else {
+			queueSize = min(queueSize, max_queues->max_sq_depth);
+		}
+
+		*txSglSize = min(enaPktMaxBufs,
+				 features.max_queues.max_packet_tx_descs);
+		*rxSglSize = min(enaPktMaxBufs,
+				 features.max_queues.max_packet_rx_descs);
+	}
+
+	// Round queue size to power of 2
+	if (unlikely(queueSize == 0)) {
+		ENA_DEBUG_LOG("Invalid queue size\n");
+		return 0;
+	} else {
+		queueSize = 1U << (31 -__builtin_clz(queueSize));
+	}
+
+	return queueSize;
+}
+
+void ENA::setSupportedOffloads(const struct ena_admin_feature_offload_desc &offloads)
+{
+	if (offloads.tx & ENA_ADMIN_FEATURE_OFFLOAD_DESC_TX_L3_CSUM_IPV4_MASK)
+		_txChecksumMask |= kChecksumIP;
+
+	if (offloads.tx & ENA_ADMIN_FEATURE_OFFLOAD_DESC_TX_L4_IPV6_CSUM_PART_MASK)
+		_txChecksumMask |= kChecksumTCPNoPseudoHeader | kChecksumUDPNoPseudoHeader;
+
+	if (offloads.tx & ENA_ADMIN_FEATURE_OFFLOAD_DESC_TX_L4_IPV4_CSUM_FULL_MASK)
+		_txChecksumMask |= kChecksumTCP | kChecksumUDP;
+
+	if (offloads.tx & ENA_ADMIN_FEATURE_OFFLOAD_DESC_TX_L4_IPV6_CSUM_FULL_MASK)
+		_txChecksumMask |= kChecksumTCPIPv6 | kChecksumUDPIPv6;
+
+	if (offloads.rx_supported & ENA_ADMIN_FEATURE_OFFLOAD_DESC_RX_L3_CSUM_IPV4_MASK)
+		_rxChecksumMask |= kChecksumIP;
+
+	if (offloads.rx_supported & ENA_ADMIN_FEATURE_OFFLOAD_DESC_RX_L4_IPV4_CSUM_MASK)
+		_rxChecksumMask |= kChecksumTCP | kChecksumUDP;
+
+	if (offloads.rx_supported & ENA_ADMIN_FEATURE_OFFLOAD_DESC_RX_L4_IPV6_CSUM_MASK)
+		_rxChecksumMask |= kChecksumTCPIPv6 | kChecksumUDPIPv6;
+
+	// Just for a workaround, we would enable TX IPv4 and TCP Checksum offloads as we know the HW supports it
+	// Till we support ENAv2 which also enable supporting RX CSUM, we advertise supporting RX CSUM but will set that the
+	// offloading was not performed for each packet.
+	// We have to so since Mac OS doesn't allow to support only TX or RX checksum.
+	_txChecksumMask |= ENA_SUPPORTED_OFFLOADS;
+	_rxChecksumMask |= ENA_SUPPORTED_OFFLOADS;
+}
+
+IOReturn ENA::getChecksumSupport(UInt32 *checksumMask, UInt32 checksumFamily, bool isOutput)
+{
+	if (checksumFamily != kChecksumFamilyTCPIP)
+		return kIOReturnUnsupported;
+
+	*checksumMask	= isOutput ? _txChecksumMask : _rxChecksumMask;
+
+	return kIOReturnSuccess;
+}
+
+UInt32 ENA::getFeatures() const
+{
+	return _featuresMask;
+}
+
+void ENA::initPCIConfigSpace()
+{
+	// PCI configuration
+	UInt16 cmd = _pciNub->configRead16(kIOPCIConfigCommand);
+	cmd |= (kIOPCICommandBusMaster |
+		kIOPCICommandMemorySpace |
+		kIOPCICommandMemWrInvalidate); // Tell the bus master to write minimum of one cache line
+	cmd &= ~kIOPCICommandIOSpace;
+
+	_pciNub->configWrite16(kIOPCIConfigCommand, cmd);
+	ENA_DEBUG_LOG("PCI CMD = %04x\n", _pciNub->configRead16(kIOPCIConfigCommand));
+}
+
+bool ENA::allocatePCIResources()
+{
+	// Map BAR with registers
+	_regMap = _pciNub->mapDeviceMemoryWithRegister(ENA_REG_BAR);
+	if (_regMap == nullptr) {
+		ENA_ERROR_LOG("PCI BAR@%x mapping error\n", ENA_REG_BAR);
+		return false;
+	}
+
+	_memMap = nullptr;
+
+	return true;
+}
+
+void ENA::releasePCIResources()
+{
+	SAFE_RELEASE(_regMap);
+	SAFE_RELEASE(_memMap);
+}
+
+int ENA::configHostInfo()
+{
+	struct ena_admin_host_info *hostInfo;
+	size_t nKernelVersion, nKernelVersionStr, nOSDistStr, nNumCPUs;
+	UInt32 numCPUs;
+	int rc, rv;
+	int driverVersion[3];
+
+	// Set sizes of system control getters
+	nNumCPUs = sizeof(numCPUs);
+	nKernelVersion = sizeof(hostInfo->kernel_ver);
+	nKernelVersionStr = sizeof(hostInfo->kernel_ver_str);
+	nOSDistStr = sizeof(hostInfo->os_dist_str);
+
+	// Allocate only the host info
+	rc = ena_com_allocate_host_info(_enaDev);
+	if (unlikely(rc)) {
+		ENA_ERROR_LOG("Cannot set host info, err: %d\n", rc);
+		return rc;
+	}
+
+	hostInfo = _enaDev->host_attr.host_info;
+
+	hostInfo->os_type = ENA_ADMIN_OS_MACOS;
+
+	// Get Os version
+	rv = sysctlbyname("kern.osproductversion", &hostInfo->os_dist_str, &nOSDistStr, nullptr, 0);
+	assert(rv == 0);
+	hostInfo->os_dist = 0; // os_dist is not relevant as there are no distributions in Mac OS
+
+	// Get Kernel version
+	rv = sysctlbyname("kern.osrelease", &hostInfo->kernel_ver_str, &nKernelVersionStr, nullptr, 0);
+	assert(rv == 0);
+	rv = sysctlbyname("kern.osrevision", &hostInfo->kernel_ver, &nKernelVersion, nullptr, 0);
+	assert(rv == 0);
+
+	// Get driver version
+	sscanf(OSKextGetCurrentVersionString(), "%d.%d.%d", &driverVersion[0], &driverVersion[1], &driverVersion[2]);
+	hostInfo->driver_version =
+			(driverVersion[0]) |
+			(driverVersion[1] << ENA_ADMIN_HOST_INFO_MINOR_SHIFT) |
+			(driverVersion[2] << ENA_ADMIN_HOST_INFO_SUB_MINOR_SHIFT);
+
+	hostInfo->bdf = (_pciNub->getBusNumber() << ENA_ADMIN_HOST_INFO_BUS_SHIFT) |
+			(_pciNub->getDeviceNumber() << ENA_ADMIN_HOST_INFO_DEVICE_SHIFT) |
+			_pciNub->getFunctionNumber();
+
+	// Get number of CPUs
+	rv = sysctlbyname("hw.ncpu", &numCPUs, &nNumCPUs, nullptr, 0);
+	assert(rv == 0);
+	hostInfo->num_cpus = (UInt16)numCPUs;
+
+	rc = ena_com_set_host_attributes(_enaDev);
+	if (unlikely(rc)) {
+		if (rc == ENA_COM_UNSUPPORTED)
+			ENA_ERROR_LOG("Device doesn't support setting host info\n");
+		else
+			ENA_ERROR_LOG("Cannot set host attributes\n");
+		goto err;
+	}
+
+	return rc;
+
+err:
+	ena_com_delete_host_info(_enaDev);
+
+	return rc;
+}
+
+bool ENA::initDevice(struct ena_com_dev_get_features_ctx *features, bool &wdState)
+{
+	UInt32 aenqGroups;
+	int rc;
+	bool  readlessSupported;
+
+	rc = ena_com_mmio_reg_read_request_init(_enaDev);
+	if (unlikely(rc)) {
+		ENA_ERROR_LOG("Failed to init mmio read less, err: %d\n", rc);
+		return false;
+	}
+
+	readlessSupported = !(_pciNub->configRead8(kIOPCIConfigRevisionID) &
+			      ENA_MMIO_DISABLE_REG_READ);
+	ena_com_set_mmio_read_mode(_enaDev, readlessSupported);
+
+	rc = ena_com_dev_reset(_enaDev, ENA_REGS_RESET_NORMAL);
+	if (rc) {
+		ENA_ERROR_LOG("Can not reset device: err: %d\n", rc);
+		goto err_mmio_read_less;
+	}
+
+	rc = ena_com_validate_version(_enaDev);
+	if (rc) {
+		ENA_ERROR_LOG("Device version is too low, err: %d\n", rc);
+		goto err_mmio_read_less;
+	}
+
+	rc = ena_com_admin_init(_enaDev, &aenqHandlers);
+	if (rc) {
+		ENA_ERROR_LOG("Can not initialize ena admin queue with device, err: %d\n", rc);
+		goto err_mmio_read_less;
+	}
+
+	// To enable the msix interrupts the driver needs to know the number
+	// of queues. So the driver uses polling mode to retrieve this
+	// information
+	ena_com_set_admin_polling_mode(_enaDev, true);
+
+	rc = configHostInfo();
+	if (rc) {
+		ENA_ERROR_LOG("Cannot set host info, err: %d\n", rc);
+		goto err_admin_init;
+	}
+
+	rc = ena_com_get_dev_attr_feat(_enaDev, features);
+	if (rc) {
+		ENA_ERROR_LOG("Cannot get attribute for ena device, err: %d\n", rc);
+		goto err_host_info;
+	}
+
+	aenqGroups = BIT(ENA_ADMIN_FATAL_ERROR) |
+		     BIT(ENA_ADMIN_WARNING) |
+		     BIT(ENA_ADMIN_KEEP_ALIVE);
+	aenqGroups &= features->aenq.supported_groups;
+
+	rc = ena_com_set_aenq_config(_enaDev, aenqGroups);
+	if (rc) {
+		ENA_ERROR_LOG("Cannot configure aenq groups, err: %d\n", rc);
+		goto err_host_info;
+	}
+
+	wdState = !!(aenqGroups & BIT(ENA_ADMIN_KEEP_ALIVE));
+
+	return true;
+
+err_host_info:
+	ena_com_delete_host_info(_enaDev);
+err_admin_init:
+	ena_com_admin_destroy(_enaDev);
+err_mmio_read_less:
+	ena_com_mmio_reg_read_request_destroy(_enaDev);
+
+	return false;
+}
+
+bool ENA::setupMainInterrupt()
+{
+	UInt16 deviceID;
+
+	deviceID = _pciNub->configRead16(kIOPCIConfigDeviceID);
+
+	// Select interrupt source based on device ID
+	// as IOPCIMessagedInterruptController is the correct one to use
+	// For 0x0ec2 --> ENA_MAIN_IRQ_PF_IDX
+	// "IOInterruptControllers" = ("io-apic-0","IOPCIMessagedInterruptController")
+	// For 0xec20 --> ENA_MAIN_IRQ_VF_IDX
+	// "IOInterruptControllers" = ("IOPCIMessagedInterruptController")
+	switch (deviceID) {
+	case PCI_DEV_ID_ENA_PF:
+		_mainIrq.source = ENA_MAIN_IRQ_PF_IDX;
+		break;
+	case PCI_DEV_ID_ENA_VF:
+		_mainIrq.source = ENA_MAIN_IRQ_VF_IDX;
+		break;
+	default:
+		ENA_ERROR_LOG("Unkown device ID 0x%x\n", deviceID);
+		return false;
+	}
+
+	// Pointer to the controller->handleMainInterrupt function (not static one),
+	// this pointer is associated with 'this' object.
+	_mainIrq.handler = OSMemberFunctionCast(
+		IOFilterInterruptAction,
+		this,
+		&ENA::handleMainInterrupt);
+
+	atomic_init(&_interruptHandlersRemaining, 0);
+	return true;
+}
+
+bool ENA::requestMainInterrupt()
+{
+	_mainIrq.workLoop = IOWorkLoop::workLoop();
+	if (_mainIrq.workLoop == nullptr) {
+		ENA_DEBUG_LOG("Cannot allocate work loop for the admin irq\n");
+		return false;
+	}
+
+	_mainIrq.interruptSrc = IOFilterInterruptEventSource::filterInterruptEventSource(
+		this,
+		nullptr,
+		_mainIrq.handler,
+		_pciNub,
+		_mainIrq.source);
+	if (_mainIrq.interruptSrc == nullptr) {
+		ENA_DEBUG_LOG("Failed to add irq event to the workloop: %d\n",
+			  _mainIrq.source);
+		_mainIrq.workLoop->release();
+		_mainIrq.workLoop = nullptr;
+		return false;
+	}
+
+	_mainIrq.workLoop->addEventSource(_mainIrq.interruptSrc);
+	_mainIrq.interruptSrc->enable();
+
+	return true;
+}
+
+
+void ENA::freeMainInterrupt()
+{
+	if (_mainIrq.workLoop != nullptr && _mainIrq.interruptSrc != nullptr)
+		_mainIrq.workLoop->removeEventSource(_mainIrq.interruptSrc);
+	SAFE_RELEASE(_mainIrq.interruptSrc);
+	SAFE_RELEASE(_mainIrq.workLoop);
+}
+
+bool ENA::testFlag(ENAFlags flag)
+{
+	return _flags & (1 << flag);
+}
+
+void ENA::setFlag(ENAFlags flag)
+{
+	_flags |= 1<<flag;
+}
+
+void ENA::clearFlag(ENAFlags flag)
+{
+	_flags &= ~(1<<flag);
+}
+
+void ENA::setupTxChecksum(struct ena_com_tx_ctx &txCtx, mbuf_t m)
+{
+	struct ena_com_tx_meta &meta = txCtx.ena_meta;
+	struct ether_header *etherHeader;
+	struct ip *ip;
+	struct tcphdr *tcpHeader;
+	size_t mlen;
+	UInt32 checksumDemand;
+	UInt32 ipHeaderLen;
+	UInt16 etherType;
+	UInt8 etherHeaderLen;
+	UInt8 *headerPointer;
+
+	getChecksumDemand(m, kChecksumFamilyTCPIP, &checksumDemand);
+
+	if (!(_txChecksumMask & checksumDemand)) {
+		txCtx.meta_valid = false;
+		return;
+	}
+
+	ENA_DEBUG_LOG("Tx checksum demand: 0x%x\n", checksumDemand);
+
+	headerPointer = reinterpret_cast<UInt8 *>(mbuf_data(m));
+	mlen = mbuf_len(m);
+
+	etherHeader = reinterpret_cast<struct ether_header *>(headerPointer);
+	if (etherHeader->ether_type == htons(ETHERTYPE_VLAN)) {
+		etherHeaderLen = etherVLANHeaderLen;
+		etherType = ntohs(*reinterpret_cast<UInt16 *>(headerPointer + etherTypeVLANOffset));
+	} else {
+		etherHeaderLen = ETHER_HDR_LEN;
+		etherType = ntohs(etherHeader->ether_type);
+	}
+
+	// Advance the header pointer for L3 header
+	if (etherHeaderLen == mlen) {
+		m = mbuf_next(m);
+		mlen = mbuf_len(m);
+		headerPointer = reinterpret_cast<UInt8 *>(mbuf_data(m));
+	} else {
+		headerPointer += etherHeaderLen;
+		mlen -= etherHeaderLen;
+	}
+
+	if (checksumDemand & kChecksumIP)
+		txCtx.l3_csum_enable = true;
+
+	if (etherType == ETHERTYPE_IP) {
+		ip = reinterpret_cast<struct ip *>(headerPointer);
+		ipHeaderLen = ip->ip_hl << 2;
+		txCtx.l3_proto = ENA_ETH_IO_L3_PROTO_IPV4;
+		if ((ip->ip_off & htons(IP_DF)) != 0)
+			txCtx.df = 1;
+	} else if (etherType == ETHERTYPE_IPV6) {
+		ipHeaderLen = sizeof(struct ip6_hdr);
+		txCtx.l3_proto = ENA_ETH_IO_L3_PROTO_IPV6;
+	} else {
+		txCtx.meta_valid = false;
+		return;
+	}
+
+	// Advance the header pointer for L4 header
+	if (ipHeaderLen == mlen) {
+		m = mbuf_next(m);
+		headerPointer = reinterpret_cast<UInt8 *>(mbuf_data(m));
+	} else {
+		headerPointer += ipHeaderLen;
+	}
+
+	if (checksumDemand & (kChecksumTCP | kChecksumUDP)) {
+		txCtx.l4_csum_enable = 1;
+	} else if (checksumDemand & (kChecksumTCPNoPseudoHeader | kChecksumUDPNoPseudoHeader)) {
+		txCtx.l4_csum_partial = 1;
+	}
+
+	if (checksumDemand & (kChecksumTCP | kChecksumTCPNoPseudoHeader)) {
+		tcpHeader = reinterpret_cast<struct tcphdr *>(headerPointer);
+		txCtx.l4_proto = ENA_ETH_IO_L4_PROTO_TCP;
+		meta.l4_hdr_len = tcpHeader->th_off;
+	} else if (checksumDemand & (kChecksumUDP | kChecksumUDPNoPseudoHeader)) {
+		txCtx.l4_proto = ENA_ETH_IO_L4_PROTO_UDP;
+		meta.l4_hdr_len = sizeof(struct udphdr) / 4;
+	}
+
+	meta.l3_hdr_len = ipHeaderLen;
+	meta.l3_hdr_offset = etherHeaderLen;
+	txCtx.meta_valid = true;
+}
+
+void ENA::processRxChecksum(struct ena_com_rx_ctx &rxCtx, mbuf_t m)
+{
+	UInt32 result = 0U;
+	UInt32 valid = 0U;
+
+	// L3
+	if (_rxChecksumMask & kChecksumIP) {
+		if (rxCtx.l3_proto == ENA_ETH_IO_L3_PROTO_IPV4) {
+			result |= kChecksumIP;
+
+			if (!rxCtx.l3_csum_err)
+				valid |= kChecksumIP;
+			else
+				ENA_DEBUG_LOG("Rx IP checksum error\n");
+		}
+	}
+
+	// L4
+	if (rxCtx.l4_csum_checked) {
+		if (rxCtx.l4_proto == ENA_ETH_IO_L4_PROTO_TCP) {
+			result |= kChecksumTCP;
+			if (!rxCtx.l4_csum_err) {
+				valid |= kChecksumTCP;
+			} else {
+				ENA_DEBUG_LOG("Rx TCP checksum error\n");
+			}
+		} else if (rxCtx.l4_proto == ENA_ETH_IO_L4_PROTO_UDP) {
+			result |= kChecksumUDP;
+			if (!rxCtx.l4_csum_err) {
+				valid |= kChecksumUDP;
+			} else {
+				ENA_DEBUG_LOG("Rx TCP checksum error\n");
+			}
+		}
+	}
+
+	ENA_DEBUG_LOG("Rx checksum result: 0x%x, valid: 0x%x\n", result, valid);
+
+	setChecksumResult(m, kChecksumFamilyTCPIP, result, valid);
+}
+
+bool ENA::enableAllIOQueues()
+{
+	ENAQueue *queue;
+	ENARingTx *txRing;
+
+	for (int i = 0; i < _numQueues; ++i) {
+		queue = OSDynamicCast(ENAQueue, _queues->getObject(i));
+		if (!queue->enable()) {
+			ENA_ERROR_LOG("Failed to enable IO queue %d\n", i);
+			disableAllIOQueues();
+			return false;
+		}
+		txRing = queue->getTxRing();
+		txRing->setupMissingTxCompletion(_missingTxCompletionTimeout,
+						 _missingTxCompletionThreshold);
+	}
+
+	return true;
+}
+
+void ENA::disableAllIOQueues()
+{
+	ENAQueue *queue;
+
+	for (int i = 0; i < _numQueues; ++i) {
+		queue = OSDynamicCast(ENAQueue, _queues->getObject(i));
+		queue->disable();
+	}
+}
+
+void ENA::unmaskAllIOInterrupts() {
+	ENAQueue *queue;
+
+	// Unmask interrupts for all of the IO queues
+	for(int i = 0; i < _numQueues; i++) {
+		queue = OSDynamicCast(ENAQueue, _queues->getObject(i));
+		queue->unmaskIOInterrupt();
+	}
+}
+
+void ENA::checkForMissingKeepAlive()
+{
+	if (!testFlag(ENA_FLAG_WATCHDOG_ACTIVE))
+		return;
+
+	if (unlikely(_lastKeepAliveTime + _keepAliveTimeout <= ENATime::getNow())) {
+		ENA_ERROR_LOG("Keep alive watchdog timeout\n");
+
+		incAtomicStat(&_hwStats.watchdogExpired);
+		triggerReset(ENA_REGS_RESET_KEEP_ALIVE_TO);
+	}
+}
+
+void ENA::checkForAdminComState()
+{
+	if (unlikely(!ena_com_get_admin_running_state(_enaDev))) {
+		ENA_ERROR_LOG("ENA admin queue is not in running state!\n");
+
+		incAtomicStat(&_hwStats.adminQueuePause);
+		triggerReset(ENA_REGS_RESET_ADMIN_TO);
+	}
+}
+
+void ENA::checkForMissingCompletions()
+{
+	int budget, i;
+
+	// Make sure the driver doesn't turn the device in other process
+	atomic_thread_fence(memory_order_acquire);
+
+	if (!testFlag(ENA_FLAG_DEV_UP))
+		return;
+
+	if (testFlag(ENA_FLAG_TRIGGER_RESET))
+		return;
+
+	if (_missingTxCompletionTimeout == ENA_HW_HINTS_NO_TIMEOUT)
+		return;
+
+	budget = min(_numQueues, ENA_MONITORED_QUEUES);
+
+	for (i = 0; i < budget; ++i) {
+		ENAQueue *queue = OSDynamicCast(
+			ENAQueue,
+			_queues->getObject(_lastMonitoredQueueID));
+		ENARingTx *txRing = queue->getTxRing();
+		ENARingRx *rxRing = queue->getRxRing();
+
+		if (unlikely(!txRing->checkForMissingCompletions()))
+			return;
+
+		if (unlikely(!rxRing->checkForInterrupt()))
+			return;
+
+		++_lastMonitoredQueueID;
+		_lastMonitoredQueueID %= _numQueues;
+	}
+}
+
+void ENA::timerService(IOTimerEventSource *timerEvent)
+{
+	ENA_DEBUG_LOG("Timer service executed\n");
+
+	updateStats();
+
+	checkForMissingKeepAlive();
+
+	checkForAdminComState();
+
+	checkForMissingCompletions();
+
+	if (unlikely(testFlag(ENA_FLAG_TRIGGER_RESET))) {
+		ENA_ERROR_LOG("Trigger reset is on with reason: %d\n", _resetReason);
+		_resetTask->callTask();
+	}
+
+	timerEvent->setTimeoutMS(ENA_TIMER_SERVICE_TIMEOUT_MS);
+}
+
+void ENA::aenqTimerService(IOTimerEventSource *timerEvent)
+{
+	ENA_DEBUG_LOG("Admin timer service executed\n");
+
+	if (likely(testFlag(ENA_FLAG_DEV_RUNNING)))
+		ena_com_aenq_intr_handler(_enaDev, this);
+
+	timerEvent->setTimeoutMS(ENA_AENQ_TIMER_SERVICE_TIMEOUT_MS);
+}
+
+void ENA::resetAction()
+{
+	ENA_DEBUG_LOG("Reset action\n");
+
+	if (unlikely(!testFlag(ENA_FLAG_TRIGGER_RESET))) {
+		ENA_ERROR_LOG("Device reset schedule while reset bit is off\n");
+		return;
+	}
+
+	IOLockLock(_globalLock);
+	destroyDevice(false);
+	restoreDevice();
+	IOLockUnlock(_globalLock);
+}
+
+void ENA::triggerReset(enum ena_regs_reset_reason_types resetReason)
+{
+	if (likely(!testFlag(ENA_FLAG_TRIGGER_RESET))) {
+		setFlag(ENA_FLAG_TRIGGER_RESET);
+		_resetReason = resetReason;
+	}
+}
+
+void ENA::destroyDevice(bool graceful)
+{
+	bool devUp;
+
+	if (!testFlag(ENA_FLAG_DEV_RUNNING))
+		return;
+
+	setLinkStatus(kIONetworkLinkValid);
+
+	_timerEvent->cancelTimeout();
+	_aenqTimerEvent->cancelTimeout();
+
+	devUp = testFlag(ENA_FLAG_DEV_UP);
+	if (devUp)
+		setFlag(ENA_FLAG_DEV_UP_BEFORE_RESET);
+	else
+		clearFlag(ENA_FLAG_DEV_UP_BEFORE_RESET);
+
+	if (!graceful)
+		ena_com_set_admin_running_state(_enaDev, false);
+
+	if (devUp)
+		disableLocked(nullptr);
+
+	// Stop the device from sending AENQ events (in case reset flag is set
+	//  and device is up, ena_down() already reset the device.
+	if (!(testFlag(ENA_FLAG_TRIGGER_RESET) && devUp))
+		ena_com_dev_reset(_enaDev, _resetReason);
+
+	freeMainInterrupt();
+
+	ena_com_abort_admin_commands(_enaDev);
+	ena_com_wait_for_abort_completion(_enaDev);
+	ena_com_admin_destroy(_enaDev);
+	ena_com_mmio_reg_read_request_destroy(_enaDev);
+
+	_resetReason = ENA_REGS_RESET_NORMAL;
+
+	clearFlag(ENA_FLAG_TRIGGER_RESET);
+	clearFlag(ENA_FLAG_DEV_RUNNING);
+}
+
+bool ENA::restoreDevice()
+{
+	struct ena_com_dev_get_features_ctx features;
+	bool wdState;
+
+	if (!_pciNub->open(this)) {
+		ENA_ERROR_LOG("Cannot open PCI device\n");
+		goto error;
+	}
+
+	setFlag(ENA_FLAG_ONGOING_RESET);
+	if (!initDevice(&features, wdState)) {
+		ENA_ERROR_LOG("Cannot initialize device\n");
+		goto error;
+	}
+
+	if (!validateDeviceParameters(features)) {
+		ENA_ERROR_LOG("Validation of device parameters failed\n");
+		goto err_device_destroy;
+	}
+
+	if (wdState)
+		setFlag(ENA_FLAG_WATCHDOG_ACTIVE);
+
+	if (!setupMainInterrupt()) {
+		ENA_ERROR_LOG("Setup main interrupt failed\n");
+		goto err_device_destroy;
+	}
+
+	if (!requestMainInterrupt()) {
+		ENA_ERROR_LOG("Setting main interrupt failed\n");
+		goto err_device_destroy;
+	}
+
+	_pciNub->close(this);
+
+	// If the interface was up before the reset bring it up
+	if (testFlag(ENA_FLAG_DEV_UP_BEFORE_RESET)) {
+		IOReturn ret = enableLocked(nullptr);
+		if (ret != kIOReturnSuccess) {
+			ENA_ERROR_LOG("Failed to create I/O queues\n");
+			goto err_disable_msix;
+		}
+	}
+
+	setFlag(ENA_FLAG_DEV_RUNNING);
+
+	clearFlag(ENA_FLAG_ONGOING_RESET);
+	if (testFlag(ENA_FLAG_LINK_UP))
+		setLinkStatus(kIONetworkLinkValid | kIONetworkLinkActive, _mediumAuto);
+
+	ena_com_admin_aenq_enable(_enaDev);
+
+	_aenqTimerEvent->setTimeoutMS(ENA_AENQ_TIMER_SERVICE_TIMEOUT_MS);
+
+	// Update keep alive just before enabling timer service to prevent
+	// false keep alive timeout - it could be possible if reset would take
+	// too much time because of OS instability, as the last keep alives are
+	// being suspended after destroyDevice() is finished.
+	_lastKeepAliveTime.setNow();
+	_timerEvent->enable();
+	_timerEvent->setTimeoutMS(ENA_TIMER_SERVICE_TIMEOUT_MS);
+
+	ENA_LOG("Device reset completed successfully, Driver version: %s\n", OSKextGetCurrentVersionString());
+
+	return true;
+
+err_disable_msix:
+	freeMainInterrupt();
+err_device_destroy:
+	ena_com_abort_admin_commands(_enaDev);
+	ena_com_wait_for_abort_completion(_enaDev);
+	ena_com_admin_destroy(_enaDev);
+	ena_com_dev_reset(_enaDev, ENA_REGS_RESET_DRIVER_INVALID_STATE);
+	ena_com_mmio_reg_read_request_destroy(_enaDev);
+error:
+	clearFlag(ENA_FLAG_DEV_RUNNING);
+	clearFlag(ENA_FLAG_ONGOING_RESET);
+	ENA_ERROR_LOG("Reset attempt failed. Can not reset the device\n");
+
+	if (_pciNub->isOpen())
+		_pciNub->close(this);
+
+	return false;
+}
+
+bool ENA::validateDeviceParameters(const struct ena_com_dev_get_features_ctx &features)
+{
+	if (memcmp(features.dev_attr.mac_addr, _macAddr.bytes, kIOEthernetAddressSize) != 0) {
+		ENA_ERROR_LOG("Error, mac address are different\n");
+		return false;
+	}
+
+	if (features.dev_attr.max_mtu < _currentMTU) {
+		ENA_ERROR_LOG("Error, device max mtu is smaller than interface MTU\n");
+		return false;
+	}
+
+	return true;
+}
+
+void ENA::keepAlive()
+{
+	_lastKeepAliveTime.setNow();
+	ENA_DEBUG_LOG("Keep alive message, saved time: %llu\n", _lastKeepAliveTime.getAbsoluteTime());
+}
+
+void ENA::setRxDrops(UInt64 rxDrops)
+{
+	// Needs explicit conversion, as the inputErrors field is 32bit wide
+	_netStats->inputErrors = static_cast<UInt32>(_rxErrors + rxDrops);
+
+	setAtomicStat(&_hwStats.rxDrops, rxDrops);
+}
+
+void ENA::incrementRxErrors()
+{
+	// TODO: make this atomic upon adding multiqueue support
+	++_rxErrors;
+}
+
+void ENA::setLinkUp()
+{
+	setFlag(ENA_FLAG_LINK_UP);
+	if (!testFlag(ENA_FLAG_ONGOING_RESET))
+		setLinkStatus(kIONetworkLinkValid | kIONetworkLinkActive, _mediumAuto);
+}
+
+void ENA::setLinkDown()
+{
+	clearFlag(ENA_FLAG_LINK_UP);
+	setLinkStatus(kIONetworkLinkValid);
+}
+
+bool ENA::publishProperties()
+{
+	if (!enaProperties.isValid()) {
+		ENA_ERROR_LOG("Cannot publish statistics, missing symbols\n");
+		return false;
+	}
+
+	for (size_t i = 0; i < ENAHWStatsNum; ++i) {
+		_hwStatsProperties[i] = OSNumber::withNumber(0ULL, 64);
+		if (_hwStatsProperties[i] == nullptr) {
+			ENA_ERROR_LOG("Cannot publish HW statistics, failed to allocate OSNumber\n");
+			return false;
+		}
+
+		if (!setProperty(enaProperties.getHWStatsSymbol(i), _hwStatsProperties[i])) {
+			ENA_ERROR_LOG("Cannot publish HW statistics, failed set property\n");
+			return false;
+		}
+
+	}
+
+	for (size_t i = 0; i < ENATxStatsNum; ++i) {
+		_txStatsProperties[i] = getArrayWithNumbers(_numQueues);
+		if (_txStatsProperties[i] == nullptr) {
+			ENA_ERROR_LOG("Cannot publish Tx statistics, failed to allocate array\n");
+			return false;
+		}
+
+		if (!setProperty(enaProperties.getTxStatsSymbol(i), _txStatsProperties[i])) {
+			ENA_ERROR_LOG("Cannot publish Tx statistics, failed set property\n");
+			return false;
+		}
+	}
+
+	for (size_t i = 0; i < ENARxStatsNum; ++i) {
+		_rxStatsProperties[i] = getArrayWithNumbers(_numQueues);
+		if (_rxStatsProperties[i] == nullptr) {
+			ENA_ERROR_LOG("Cannot publish Rx statistics, failed to allocate array\n");
+			return false;
+		}
+
+		if (!setProperty(enaProperties.getRxStatsSymbol(i), _rxStatsProperties[i])) {
+			ENA_ERROR_LOG("Cannot publish Rx statistics, failed set property\n");
+			return false;
+		}
+	}
+
+	if (!super::publishProperties()) {
+		ENA_ERROR_LOG("Failed to publish properties of the base class\n");
+		return false;
+	}
+
+	return true;
+}
+
+void ENA::releaseProperties()
+{
+	for (auto &property : _hwStatsProperties)
+		SAFE_RELEASE(property);
+
+	for (auto &property : _txStatsProperties)
+		SAFE_RELEASE(property);
+
+	for (auto &property : _rxStatsProperties)
+		SAFE_RELEASE(property);
+}
+
+void ENA::updateStats()
+{
+	OSNumber **propertyNumber;
+	ENAQueue *queue;
+	const ENATxStats *txStats;
+	const ENARxStats *rxStats;
+	const AtomicStat *stats;
+	UInt64 totalRxPackets = 0;
+	UInt64 totalTxPackets = 0;
+	UInt64 totalRxBytes = 0;
+	UInt64 totalTxBytes = 0;
+
+	// Sum up total Tx/Rx stats from all of the queues
+	for (unsigned int n = 0; n < _numQueues; ++n) {
+		queue = OSDynamicCast(ENAQueue, _queues->getObject(n));
+		txStats = queue->getTxRing()->getTxStats();
+		rxStats = queue->getRxRing()->getRxStats();
+
+		totalRxPackets += getAtomicStat(&rxStats->count);
+		totalTxPackets += getAtomicStat(&txStats->count);
+		totalRxBytes += getAtomicStat(&rxStats->bytes);
+		totalTxBytes += getAtomicStat(&txStats->bytes);
+	}
+
+	_netStats->inputPackets = (UInt32)totalRxPackets;
+	_netStats->outputPackets = (UInt32)totalTxPackets;
+
+	_hwStats.rxPackets = totalRxPackets;
+	_hwStats.txPackets = totalTxPackets;
+	_hwStats.rxBytes = totalRxBytes;
+	_hwStats.txBytes = totalTxBytes;
+
+	// HW stats
+	stats = (const AtomicStat *)(&_hwStats);
+	propertyNumber = _hwStatsProperties;
+	for (size_t i = 0; i < ENAHWStatsNum; ++i)
+		propertyNumber[i]->setValue(getAtomicStat(&stats[i]));
+
+	// IO stats
+	for (unsigned int n = 0; n < _numQueues; ++n) {
+		queue = OSDynamicCast(ENAQueue, _queues->getObject(n));
+
+		// Tx
+		stats = (const AtomicStat *)queue->getTxRing()->getTxStats();
+		copyStatsFromQueueToProperties(stats, ENATxStatsNum, _txStatsProperties, n);
+
+		// Rx
+		stats = (const AtomicStat *)queue->getRxRing()->getRxStats();
+		copyStatsFromQueueToProperties(stats, ENARxStatsNum, _rxStatsProperties, n);
+	}
+}
+
+ENAHWStats * ENA::getHWStats()
+{
+	return &_hwStats;
+}
+
+ENAParallelOutputQueue *ENA::createParallelOutputQueue()
+{
+	ENAParallelOutputQueue *outputQueue;
+	OSArray *txRings;
+
+	// Parallel output queue needs array with Tx rings which will be
+	// used for transmitting.
+	txRings = OSArray::withCapacity(_queues->getCount());
+	if (txRings == nullptr) {
+		ENA_DEBUG_LOG("Cannot allocate array for the Tx rings\n");
+		return nullptr;
+	}
+
+	for (int i = 0; i < _queues->getCount(); ++i) {
+		ENAQueue *queue = OSDynamicCast(ENAQueue, _queues->getObject(i));
+		// Adding object to array shouldn't fail, as it was allocated
+		// with enough capacity.
+		txRings->setObject(queue->getTxRing());
+	}
+
+	// Create parallel output queue that allows enqueueing mbufs from multiple
+	// threads, manages the flow and calls appropriate xmit function of the ring
+	outputQueue = ENAParallelOutputQueue::withTarget(
+		txRings,
+		(IOOutputAction) &ENARingTx::sendPacket,
+		_hashFunction,
+		_queueSize);
+	// Array with Tx rings is no longer needed
+	txRings->release();
+
+	return outputQueue;
+}
+
+bool ENA::rssInitDefault()
+{
+	int rc;
+
+	rc = ena_com_rss_init(_enaDev, ENA_RX_RSS_TABLE_LOG_SIZE);
+	if (unlikely(rc)) {
+		ENA_ERROR_LOG("Cannot init indirection table\n");
+		return false;
+	}
+
+	for (int i = 0; i < ENA_RX_RSS_TABLE_SIZE; i++) {
+		UInt16 val = i % _numQueues;
+		rc = ena_com_indirect_table_fill_entry(_enaDev, i, ENA_IO_RXQ_IDX(val));
+		if (unlikely(rc != 0)) {
+			ENA_ERROR_LOG("Cannot fill indirect table\n");
+			ena_com_rss_destroy(_enaDev);
+			return false;
+		}
+	}
+
+	rc = ena_com_fill_hash_function(_enaDev, ENA_ADMIN_CRC32, NULL, ENA_HASH_KEY_SIZE, 0xFFFFFFFF);
+	if (unlikely((rc != 0) && (rc != ENA_COM_UNSUPPORTED))) {
+		ENA_ERROR_LOG("Cannot fill hash function\n");
+		ena_com_rss_destroy(_enaDev);
+		return false;
+	}
+
+	rc = ena_com_set_default_hash_ctrl(_enaDev);
+	if (unlikely((rc != 0) && (rc != ENA_COM_UNSUPPORTED))) {
+		ENA_ERROR_LOG("Cannot fill hash control\n");
+		ena_com_rss_destroy(_enaDev);
+		return false;
+	}
+
+	return true;
+}
+
+bool ENA::rssConfigure()
+{
+	int rc;
+
+	// Set indirection table
+	rc = ena_com_indirect_table_set(_enaDev);
+	if (unlikely((rc != 0) && (rc != ENA_COM_UNSUPPORTED)))
+		return false;
+
+	// Configure hash function (if supported)
+	rc = ena_com_set_hash_function(_enaDev);
+	if (unlikely((rc != 0) && (rc != ENA_COM_UNSUPPORTED)))
+		return false;
+
+	// Configure hash inputs (if supported)
+	rc = ena_com_set_hash_ctrl(_enaDev);
+	if (unlikely((rc != 0) && (rc != ENA_COM_UNSUPPORTED)))
+		return false;
+
+	return true;
+}
+
+void ENA::lockInputQueue()
+{
+	IOLockLock(_inputQueueLock);
+}
+
+void ENA::unlockInputQueue()
+{
+	IOLockUnlock(_inputQueueLock);
+}
+
+void ENA::handleInterruptCompleted(ENAQueue* queue)
+{
+	// Check whenever all other interrupt handlers have been finished
+	if (atomic_fetch_sub(&_interruptHandlersRemaining, 1) == 1) {
+		queue->unmaskIOInterrupt(ENA_RX_IRQ_INTERVAL, ENA_TX_IRQ_INTERVAL);
+	}
+}
+
+const char * ENA::getName(const IORegistryPlane * plane) const
+{
+	if (likely(plane == nullptr && _devName[0] != '\0'))
+		return _devName;
+	else
+		return super::getName(plane);
+}
+
+void * ena_mem_alloc_coherent(size_t length,
+			      IOPhysicalAddress *physAddr,
+			      ena_mem_handle_t *memHandle)
+{
+	IOBufferMemoryDescriptor *mem;
+
+	mem = IOBufferMemoryDescriptor::withOptions(
+		kIOMemoryPhysicallyContiguous,
+		length,
+		PAGE_SIZE);
+	if (mem == nullptr)
+		return nullptr;
+
+	if (mem->prepare() != kIOReturnSuccess) {
+		mem->release();
+		return nullptr;
+	}
+
+	*memHandle = mem;
+	*physAddr = mem->getPhysicalAddress();
+
+	return mem->getBytesNoCopy();
+}
+
+void ena_mem_free_coherent(ena_mem_handle_t memHandle)
+{
+	IOBufferMemoryDescriptor *mem = (IOBufferMemoryDescriptor *)memHandle;
+	mem->complete();
+	mem->release();
+}
+
+/******************************************************************************
+ ******************************** AENQ Handlers *******************************
+ *****************************************************************************/
+
+static void ena_update_on_link_change(void *controller_data,
+				      struct ena_admin_aenq_entry *aenq_e)
+{
+	struct ENA *controller = (ENA *)controller_data;
+	struct ena_admin_aenq_link_change_desc *desc;
+	int status;
+
+	desc = (struct ena_admin_aenq_link_change_desc *)aenq_e;
+	status = desc->flags & ENA_ADMIN_AENQ_LINK_CHANGE_DESC_LINK_STATUS_MASK;
+
+	if (status) {
+		ENA_DEBUG_LOG_EXT(controller, "%s - Link up\n", __func__);
+		controller->setLinkUp();
+	} else {
+		ENA_DEBUG_LOG_EXT(controller, "%s - Link down\n", __func__);
+		controller->setLinkDown();
+	}
+}
+
+static void ena_keep_alive_wd(void *controller_data,
+			      struct ena_admin_aenq_entry *aenq_e)
+{
+	ENA *controller = (ENA *)controller_data;
+	struct ena_admin_aenq_keep_alive_desc *desc;
+	UInt64 rxDrops;
+
+	desc = (struct ena_admin_aenq_keep_alive_desc *)aenq_e;
+	controller->keepAlive();
+
+	rxDrops = ((u64)desc->rx_drops_high << 32) | desc->rx_drops_low;
+
+	controller->setRxDrops(rxDrops);
+}
+
+// This handler will called for unknown event group or unimplemented handlers
+static void unimplemented_aenq_handler(void *data,
+				       struct ena_admin_aenq_entry *aenq_e)
+{
+	ENA_ERROR_LOGC("Unknown event was received or event with unimplemented handler\n");
+}
+
+struct ena_aenq_handlers ENA::aenqHandlers = {
+	.handlers = {
+		[ENA_ADMIN_LINK_CHANGE] = ena_update_on_link_change,
+		[ENA_ADMIN_NOTIFICATION] = unimplemented_aenq_handler,
+		[ENA_ADMIN_KEEP_ALIVE] = ena_keep_alive_wd,
+	},
+	.unimplemented_handler = unimplemented_aenq_handler
+};

--- a/kernel/macOS/ena/ENA.hpp
+++ b/kernel/macOS/ena/ENA.hpp
@@ -1,0 +1,303 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef _ENA_HPP
+#define _ENA_HPP
+
+#include "ENAParallelOutputQueue.hpp"
+#include "ENARings.hpp"
+#include "ENATask.hpp"
+#include "ENATime.hpp"
+#include "ENAToeplitzHash.hpp"
+#include "ENAUtils.hpp"
+
+#include "ena_com/ena_com.h"
+
+#include <net/ethernet.h>
+
+#include <IOKit/IOFilterInterruptEventSource.h>
+#include <IOKit/IOTimerEventSource.h>
+
+#include <IOKit/network/IOEthernetInterface.h>
+
+#include <IOKit/pci/IOPCIDevice.h>
+
+#define ENA_IO_TXQ_IDX(q)               (2 * (q))
+#define ENA_IO_RXQ_IDX(q)               (2 * (q) + 1)
+
+#define DEFAULT_TX_QUEUE_SIZE		1024
+#define ENA_DEFAULT_RING_SIZE		1024
+
+#define ENA_RX_RSS_TABLE_LOG_SIZE	7
+#define ENA_RX_RSS_TABLE_SIZE		(1 << ENA_RX_RSS_TABLE_LOG_SIZE)
+
+#define ENA_HASH_KEY_SIZE		40
+
+#define ENA_REG_BAR			kIOPCIConfigBaseAddress0
+#define ENA_MEM_BAR			kIOPCIConfigBaseAddress2
+
+#define ENA_MMIO_DISABLE_REG_READ	BIT(0)
+
+#define ENA_RX_REFILL_THRESH_DIVIDER	8
+
+#define ENA_CLEANUP_BUDGET		8
+
+#define ENA_TX_BUDGET			128
+#define ENA_RX_BUDGET			256
+
+#define ENA_TX_COMMIT			32
+
+#define ENA_RX_IRQ_INTERVAL		20
+#define ENA_TX_IRQ_INTERVAL		50
+
+#define ENA_DEVICE_KALIVE_TIMEOUT	6
+#define ENA_TX_TIMEOUT			5
+#define ENA_MAX_NUM_OF_TIMEOUTED_PACKETS 128
+#define ENA_MONITORED_QUEUES		4
+#define ENA_MAX_NO_INTERRUPT_ITERATIONS	3
+
+#define ENA_TIMER_SERVICE_TIMEOUT_MS		1000
+#define ENA_AENQ_TIMER_SERVICE_TIMEOUT_MS	500
+
+#define PCI_DEV_ID_ENA_PF		0x0ec2
+#define PCI_DEV_ID_ENA_VF		0xec20
+
+#define ENA_MAIN_IRQ_PF_IDX		1
+#define ENA_MAIN_IRQ_VF_IDX		0
+
+#define ENA_MAX_NAME_LEN		32
+
+#define ENA_SUPPORTED_OFFLOADS (kChecksumIP | kChecksumTCP | kChecksumTCPNoPseudoHeader)
+
+// Used key provided Microsoft:
+// https://docs.microsoft.com/en-us/windows-hardware/drivers/network/verifying-the-rss-hash-calculation
+constexpr UInt8 hashFunctionKey[] = {
+	0x6d, 0x5a, 0x56, 0xda, 0x25, 0x5b, 0x0e, 0xc2,
+	0x41, 0x67, 0x25, 0x3d, 0x43, 0xa3, 0x8f, 0xb0,
+	0xd0, 0xca, 0x2b, 0xcb, 0xae, 0x7b, 0x30, 0xb4,
+	0x77, 0xcb, 0x2d, 0xa3, 0x80, 0x30, 0xf2, 0x0c,
+	0x6a, 0x42, 0xb7, 0x3b, 0xbe, 0xac, 0x01, 0xfa,
+};
+
+enum ENAFlags
+{
+	ENA_FLAG_DEV_UP,
+	ENA_FLAG_DEV_INIT,
+	ENA_FLAG_DEV_RUNNING,
+	ENA_FLAG_TRIGGER_RESET,
+	ENA_FLAG_ONGOING_RESET,
+	ENA_FLAG_DEV_UP_BEFORE_RESET,
+	ENA_FLAG_WATCHDOG_ACTIVE,
+	ENA_FLAG_LINK_UP,
+};
+
+// Encapsulates interrupt configuration
+struct ENAIrq
+{
+	int 				source;		// Number of the interrupt source
+	IOFilterInterruptAction		handler;	// Handler executed when interrupt comes
+	IOFilterInterruptEventSource	*interruptSrc;	// Object descripting interrupt event
+	IOWorkLoop			*workLoop;	// Used for interrupt synchronisation
+};
+
+struct ENAHWStats
+{
+	AtomicStat rxPackets;
+	AtomicStat txPackets;
+	AtomicStat rxBytes;
+	AtomicStat txBytes;
+	AtomicStat rxDrops;
+	AtomicStat adminQueuePause;
+	AtomicStat watchdogExpired;
+};
+constexpr size_t ENAHWStatsNum = sizeof(ENAHWStats)/sizeof(AtomicStat);
+
+class ENA : public IOEthernetController
+{
+	OSDeclareDefaultStructors(ENA)
+public:
+	bool init(OSDictionary *properties) APPLE_KEXT_OVERRIDE;
+	void free() APPLE_KEXT_OVERRIDE;
+
+	// Configure the device to a working state
+	bool start(IOService *provider) APPLE_KEXT_OVERRIDE;
+	void stop(IOService *provider) APPLE_KEXT_OVERRIDE;
+
+	// Interface up/down
+	IOReturn enable(IONetworkInterface *netif) APPLE_KEXT_OVERRIDE;
+	IOReturn disable(IONetworkInterface *netif) APPLE_KEXT_OVERRIDE;
+
+	IOReturn getHardwareAddress(IOEthernetAddress *addrP) APPLE_KEXT_OVERRIDE;
+
+	// Override work loop getters/setters for not using global work loop
+	bool createWorkLoop() APPLE_KEXT_OVERRIDE;
+	IOWorkLoop *getWorkLoop() const APPLE_KEXT_OVERRIDE;
+
+	// Return IOOutputQueue created by the ENA driver - override default
+	// implementation as ENA uses output queue which has dependency on
+	// driver resources
+	IOOutputQueue *getOutputQueue() const APPLE_KEXT_OVERRIDE;
+
+	// Interface configuration
+	IOReturn setMulticastMode(bool active) APPLE_KEXT_OVERRIDE;
+	IOReturn setPromiscuousMode(bool active) APPLE_KEXT_OVERRIDE;
+
+	IOReturn setMaxPacketSize(UInt32 maxSize) APPLE_KEXT_OVERRIDE;
+	IOReturn getMaxPacketSize(UInt32 *maxSize) const APPLE_KEXT_OVERRIDE;
+
+	IOReturn getChecksumSupport(UInt32 *checksumMask,
+				    UInt32 checksumFamily,
+				    bool isOutput) APPLE_KEXT_OVERRIDE;
+	UInt32 getFeatures() const APPLE_KEXT_OVERRIDE;
+
+	bool configureInterface(IONetworkInterface *netif) APPLE_KEXT_OVERRIDE;
+
+	// Get the custom name if the plane is 0 (nullptr).
+	// Format of the name is like: AmazonENAEthernet bb:dd.ff
+	// Allows for unique identification of the multiple interfaces in the dmesg.
+	const char * getName(const IORegistryPlane * plane = 0) const APPLE_KEXT_OVERRIDE;
+
+	void setupTxChecksum(struct ena_com_tx_ctx &txCtx, mbuf_t m);
+	void processRxChecksum(struct ena_com_rx_ctx &rxCtx, mbuf_t m);
+
+	bool testFlag(ENAFlags flag);
+
+	bool handleMainInterrupt(IOFilterInterruptEventSource *src);
+	void handleInterruptCompleted(ENAQueue* queue);
+
+	struct ena_com_dev * getENADevice();
+
+	IOPCIDevice * getProvider();
+	IOEthernetInterface * getEthernetInterface();
+	IONetworkStats * getNetworkStats();
+
+	void triggerReset(enum ena_regs_reset_reason_types resetReason);
+
+	void keepAlive();
+	void setRxDrops(UInt64 rxDrops);
+
+	void incrementRxErrors();
+
+	void setLinkUp();
+	void setLinkDown();
+
+	ENAHWStats * getHWStats();
+
+	void lockInputQueue();
+	void unlockInputQueue();
+
+private:
+	struct ena_com_dev 	*_enaDev;
+	OSArray			*_queues;
+	OSArray			*_txStatsProperties[ENATxStatsNum];
+	OSArray			*_rxStatsProperties[ENARxStatsNum];
+	OSNumber		*_hwStatsProperties[ENAHWStatsNum];
+	IOLock			*_globalLock;
+	IOLock			*_inputQueueLock;
+	IOEthernetInterface	*_netif;
+	IOPCIDevice		*_pciNub;
+	IOWorkLoop		*_workLoop;
+	IOWorkLoop		*_aenqWorkLoop;
+	IOMemoryMap		*_regMap; // Register BAR0
+	IOMemoryMap		*_memMap; // Memory BAR2
+	IOEthernetStats 	*_etherStats;
+	IONetworkStats		*_netStats;
+	IONetworkMedium		*_mediumAuto; // For auto-neg medium
+	IOTimerEventSource	*_timerEvent;
+	IOTimerEventSource	*_aenqTimerEvent;
+	ENAParallelOutputQueue	*_txQueue;
+	ENATask			*_resetTask;
+	ENAHash			*_hashFunction;
+	enum ena_regs_reset_reason_types _resetReason;
+	IOEthernetAddress	_macAddr;
+	ENAHWStats		_hwStats;
+	ENAIrq			_mainIrq;
+	ENATime			_lastKeepAliveTime;
+	ENATime			_keepAliveTimeout;
+	ENATime			_missingTxCompletionTimeout;
+	UInt64			_flags;
+	UInt64			_rxErrors;
+	UInt32			_queueSize;
+	UInt32			_numQueues;
+	UInt32			_maxMTU;
+	UInt32			_currentMTU;
+	UInt32			_txChecksumMask;
+	UInt32			_rxChecksumMask;
+	UInt32			_featuresMask;
+	UInt32			_lastMonitoredQueueID;
+	UInt32			_missingTxCompletionThreshold;
+	UInt16			_maxTxSglSize;
+	UInt16			_maxRxSglSize;
+	atomic_int_fast8_t	_interruptHandlersRemaining;
+	char			_devName[ENA_MAX_NAME_LEN];
+
+	static struct ena_aenq_handlers aenqHandlers;
+	constexpr static UInt8 etherVLANTagLen = 4;
+	constexpr static UInt8 etherVLANHeaderLen = ETHER_HDR_LEN + etherVLANTagLen;
+	constexpr static UInt8 etherTypeVLANOffset = ETHER_HDR_LEN + 2;
+
+	// Maximum Tx buffer size is equal to max jumbo MTU (9001) + max ethernet header size
+	constexpr static UInt32 txBufMaxSize = 9001 + etherVLANHeaderLen;
+
+	// Optimal number of IO queues for the best performance results. OS limit.
+	constexpr static UInt32 maxSupportedIOQueues = 1;
+
+	int configHostInfo();
+
+	bool initDevice(struct ena_com_dev_get_features_ctx *features, bool &wdState);
+	bool initEventSources(IOService *provider);
+
+	bool allocateIOQueues();
+
+	void initPCIConfigSpace();
+	bool allocatePCIResources();
+
+	UInt32 calcIOQueueNum(const struct ena_com_dev_get_features_ctx &features);
+	UInt32 calcIOQueueSize(const struct ena_com_dev_get_features_ctx &features,
+			       UInt16 *txSglSize,
+			       UInt16 *rxSglSize);
+	void setSupportedOffloads(const struct ena_admin_feature_offload_desc &offloads);
+
+	bool setupMainInterrupt();
+	bool requestMainInterrupt();
+	void freeMainInterrupt();
+
+	void releasePCIResources();
+
+	void setFlag(ENAFlags flag);
+	void clearFlag(ENAFlags flag);
+
+	bool enableAllIOQueues();
+	void disableAllIOQueues();
+
+	void unmaskAllIOInterrupts();
+
+	void checkForMissingKeepAlive();
+	void checkForAdminComState();
+	void checkForMissingCompletions();
+
+	void timerService(IOTimerEventSource *timerEvent);
+	void aenqTimerService(IOTimerEventSource *timerEvent);
+
+	void resetAction();
+
+	void destroyDevice(bool graceful);
+	bool restoreDevice();
+
+	bool validateDeviceParameters(const struct ena_com_dev_get_features_ctx &features);
+
+	IOReturn enableLocked(IONetworkInterface *netif);
+	IOReturn disableLocked(IONetworkInterface *netif);
+
+	bool publishProperties() APPLE_KEXT_OVERRIDE;
+	void releaseProperties();
+
+	void updateStats();
+
+	ENAParallelOutputQueue *createParallelOutputQueue();
+
+	bool rssInitDefault();
+	bool rssConfigure();
+};
+
+#endif /* _ENA_HPP */

--- a/kernel/macOS/ena/ENAHash.cpp
+++ b/kernel/macOS/ena/ENAHash.cpp
@@ -1,0 +1,69 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+#include "ENAHash.hpp"
+
+#include <IOKit/IOLib.h>
+
+#define super OSObject
+OSDefineMetaClassAndAbstractStructors(ENAHash, OSObject)
+
+bool ENAHash::init(const UInt8 *key, size_t keyLen)
+{
+	if (!super::init())
+		return false;
+
+	_key = IONew(UInt8, keyLen);
+	if (_key == nullptr)
+		return false;
+
+	memcpy(_key, key, keyLen);
+	_keyLen = keyLen;
+
+	return true;
+}
+
+UInt32 ENAHash::getHash(struct in_addr sourceAddr, struct in_addr destAddr)
+{
+	UInt8 data[sizeof(sourceAddr) + sizeof(destAddr)];
+	size_t dataSize;
+
+	dataSize = 0;
+	memcpy(&data[dataSize], &sourceAddr, sizeof(sourceAddr));
+	dataSize += sizeof(sourceAddr);
+	memcpy(&data[dataSize], &destAddr, sizeof(destAddr));
+	dataSize += sizeof(destAddr);
+
+	return getHash(data, dataSize);
+}
+
+UInt32 ENAHash::getHash(struct in_addr sourceAddr,
+		 struct in_addr destAddr,
+		 unsigned short sourcePort,
+		 unsigned short destPort)
+{
+	UInt8 data[sizeof(sourceAddr) + sizeof(destAddr) + sizeof(sourcePort) + sizeof(destPort)];
+	size_t dataSize;
+
+	dataSize = 0;
+	memcpy(&data[dataSize], &sourceAddr, sizeof(sourceAddr));
+	dataSize += sizeof(sourceAddr);
+	memcpy(&data[dataSize], &destAddr, sizeof(destAddr));
+	dataSize += sizeof(destAddr);
+	memcpy(&data[dataSize], &sourcePort, sizeof(sourcePort));
+	dataSize += sizeof(sourcePort);
+	memcpy(&data[dataSize], &destPort, sizeof(destPort));
+	dataSize += sizeof(destPort);
+
+	return getHash(data, dataSize);
+}
+
+void ENAHash::free()
+{
+	if (_key != nullptr) {
+		IODelete(_key, UInt8, _keyLen);
+		_key = nullptr;
+	}
+
+	super::free();
+}

--- a/kernel/macOS/ena/ENAHash.hpp
+++ b/kernel/macOS/ena/ENAHash.hpp
@@ -1,0 +1,61 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef _ENAHASH_HPP__
+#define _ENAHASH_HPP__
+
+#include <netinet/ip.h>
+
+#include <libkern/OSTypes.h>
+#include <libkern/c++/OSObject.h>
+
+class ENAHash : public OSObject
+{
+	OSDeclareDefaultStructors(ENAHash);
+public:
+
+/*!	@function init
+	@abstract Initializes an ENAHash object.
+	@param key Key for hash function.
+	@param keyLen Length of the key in bytes.
+	@result Returns true if initialized successfully, false otherwise.
+*/
+	virtual bool init(const UInt8 *key, size_t keyLen);
+
+/*!	@function getHash
+	@abstract Abstract function for calculating hash for given data.
+	@param data Array of bytes, for which the hash has to be calculated.
+	@param dataSize Size of the data in bytes.
+	@result Returns hash for the data.
+*/
+	virtual UInt32 getHash(const UInt8 *data, size_t dataSize) = 0;
+
+/*!	@function getHash
+	@abstract Calculates hash for 2 tuple of IP packet.
+	@param sourceAddr Source address from the IP header.
+	@param destAddr Destination address from the IP header.
+	@result Returns hash for the 2 tuple.
+*/
+	UInt32 getHash(struct in_addr sourceAddr, struct in_addr destAddr);
+
+/*!	@function getHash
+	@abstract Calculates hash for 4 tuple of IP/TCP IP/UDP packet.
+	@param sourceAddr Source address from the IP header.
+	@param destAddr Destination address from the IP header.
+	@param sourcePort Source port from the TCP/UDP header.
+	@param destPort Destination port from the TCP/UDP header.
+	@result Returns hash for the 4 tuple.
+*/
+	UInt32 getHash(struct in_addr sourceAddr,
+			       struct in_addr destAddr,
+			       unsigned short sourcePort,
+			       unsigned short destPort);
+
+protected:
+	UInt8 *_key;
+	size_t _keyLen;
+
+	virtual void free() APPLE_KEXT_OVERRIDE;
+};
+
+#endif

--- a/kernel/macOS/ena/ENALogs.hpp
+++ b/kernel/macOS/ena/ENALogs.hpp
@@ -1,0 +1,52 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef _ENA_LOGS_HPP
+#define _ENA_LOGS_HPP
+
+#include <IOKit/IOLib.h>
+
+// General purpose logging macros, can be used from any context.
+#define DEV_LOG(label, format, ...) IOLog(OS_STRINGIFY(label)": " format, ##__VA_ARGS__)
+
+// Error log is currently just wrapper around normal log
+#define ERROR_LOG(label, format, ...) DEV_LOG(label, format, ##__VA_ARGS__)
+
+// Enable debug logs only in the Debug configuration
+#ifdef DEBUG
+#define DEBUG_LOG(label, format, ...) DEV_LOG(label, format, ##__VA_ARGS__)
+#else
+#define DEBUG_LOG(label, format, ...) do {} while (0);
+#endif
+
+// ENA specific logs - they should be used only from the AmazonENAController
+// context (ENA_*_LOG macros) or by the classes that have reference to the
+// AmazonENAController object (ENA_*_LOG_EXT macros).
+// In some cases, the ENA object may not have valid name. In that situation,
+// the ENA_*_LOGC macros should be used, which adds constant label before the
+// log message.
+
+#ifndef ENA
+#define ENA AmazonENAEthernet
+#endif
+
+#define ENA_LOG(format, ...) IOLog("%s: " format, getName(), ##__VA_ARGS__)
+#define ENA_LOG_EXT(service, format, ...) IOLog("%s: " format, (service)->getName(), ##__VA_ARGS__)
+#define ENA_LOGC(format, ...) DEV_LOG(ENA, format, ##__VA_ARGS__)
+
+// Error and Debug logs have the same meaning as generic macros above.
+#define ENA_ERROR_LOG(format, ...) ENA_LOG(format, ##__VA_ARGS__)
+#define ENA_ERROR_LOG_EXT(service, format, ...)	ENA_LOG_EXT(service, format, ##__VA_ARGS__)
+#define ENA_ERROR_LOGC(format, ...) ENA_LOGC(format, ##__VA_ARGS__)
+
+#ifdef DEBUG
+#define ENA_DEBUG_LOG(format, ...) ENA_LOG(format, ##__VA_ARGS__)
+#define ENA_DEBUG_LOG_EXT(service, format, ...) ENA_LOG_EXT(service, format, ##__VA_ARGS__)
+#define ENA_DEBUG_LOGC(format, ...) ENA_LOGC(format, ##__VA_ARGS__)
+#else
+#define ENA_DEBUG_LOG(format, ...) do {} while(0)
+#define ENA_DEBUG_LOG_EXT(service, format, ...) do {} while(0)
+#define ENA_DEBUG_LOGC(format, ...) do {} while(0)
+#endif
+
+#endif // ENA_LOGS_HPP

--- a/kernel/macOS/ena/ENANaiveHash.cpp
+++ b/kernel/macOS/ena/ENANaiveHash.cpp
@@ -1,0 +1,33 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+#include "ENANaiveHash.hpp"
+
+#define super ENAHash
+OSDefineMetaClassAndStructors(ENANaiveHash, ENAHash)
+
+ENANaiveHash * ENANaiveHash::withKey(const UInt8 *key, size_t keyLen)
+{
+	ENANaiveHash *naiveHash = new ENANaiveHash;
+
+	if (naiveHash != nullptr && !naiveHash->init(key, keyLen))
+	{
+        	naiveHash->release();
+		naiveHash = nullptr;
+	}
+
+	return naiveHash;
+}
+
+UInt32 ENANaiveHash::getHash(const UInt8 *data, size_t dataSize)
+{
+	UInt32 hash = 0;
+	size_t i;
+
+	for (i = 0; i < _keyLen; i++)
+		hash += _key[i];
+	for (i = 0; i < dataSize; i++)
+		hash += data[i];
+
+	return hash;
+}

--- a/kernel/macOS/ena/ENANaiveHash.hpp
+++ b/kernel/macOS/ena/ENANaiveHash.hpp
@@ -1,0 +1,32 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef _ENANAIVEHASH_HPP__
+#define _ENANAIVEHASH_HPP__
+
+#include "ENAHash.hpp"
+
+class ENANaiveHash : public ENAHash
+{
+	OSDeclareDefaultStructors(ENANaiveHash);
+public:
+
+/*!	@function withKey
+	@abstract Factory method that constructs and initializes an
+	ENAToeplitzHash object.
+	@param key Key for hash function.
+	@param keyLen Length of the key in bytes.
+	@result Returns an ENAToeplitzHash object on success, or 0 otherwise.
+*/
+	static ENANaiveHash * withKey(const UInt8 *key, size_t keyLen);
+
+/*!	@function getHash
+	@abstract Calculates hash for given data naively, summing key and data.
+	@param data Array of bytes, for which the hash has to be calculated.
+	@param dataSize Size of the data in bytes.
+	@result Returns hash calculated using naive algorithm.
+*/
+	UInt32 getHash(const UInt8 *data, size_t dataSize) APPLE_KEXT_OVERRIDE;
+};
+
+#endif

--- a/kernel/macOS/ena/ENAParallelOutputQueue.cpp
+++ b/kernel/macOS/ena/ENAParallelOutputQueue.cpp
@@ -1,0 +1,317 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+#include "ENAParallelOutputQueue.hpp"
+
+#include <net/ethernet.h>
+#include <netinet/tcp.h>
+#include <netinet/udp.h>
+
+#define super IOOutputQueue
+OSDefineMetaClassAndStructors(ENAParallelOutputQueue, IOOutputQueue)
+
+#define QUEUE_LOCK	IOLockLock(_queueLock)
+#define QUEUE_UNLOCK	IOLockUnlock(_queueLock)
+
+ENAParallelOutputQueue * ENAParallelOutputQueue::withTarget(
+		OSArray *targets,
+		IOOutputAction action,
+		ENAHash *hash,
+		UInt32 capacity,
+		UInt32 priorities)
+{
+	ENAParallelOutputQueue* queue = new ENAParallelOutputQueue;
+
+	if (queue != nullptr && !queue->init(targets, action, hash, capacity, priorities)) {
+		queue->release();
+		queue = nullptr;
+	}
+
+	return queue;
+}
+
+bool ENAParallelOutputQueue::init(OSArray *targets,
+				  IOOutputAction action,
+				  ENAHash *hash,
+				  UInt32 capacity,
+				  UInt32 priorities)
+{
+	if (!super::init())
+		return false;
+
+	if ((targets == nullptr) || (targets->getCount() == 0) || (action == nullptr) ||
+	    (hash == nullptr) || (priorities == 0) || (priorities > 256))
+		return false;
+
+	_targets = targets;
+	_targetsCount = targets->getCount();
+	_action = action;
+	_hash = hash;
+	_capacity = capacity;
+	_priorities = priorities;
+
+	_targets->retain();
+	_hash->retain();
+
+	_queueLock = IOLockAlloc();
+	if (_queueLock == nullptr)
+		return false;
+
+	_outputQueues = OSArray::withCapacity(_targetsCount);
+	if (_outputQueues == nullptr)
+		return false;
+
+	for (int i = 0; i < _targetsCount; ++i) {
+		OSObject *target = _targets->getObject(i);
+
+		IOBasicOutputQueue *outputQueue = IOBasicOutputQueue::withTarget(
+				target,
+				_action,
+				_capacity,
+				_priorities);
+		if (outputQueue == nullptr)
+			return false;
+
+		// It cannot fail, as there is already enough capacity reserved.
+		_outputQueues->setObject(outputQueue);
+		// The object is being retained by OSArray, so it can be released.
+		outputQueue->release();
+	}
+
+	return true;
+}
+
+void ENAParallelOutputQueue::free()
+{
+	cancelServiceThread();
+
+	if (_queueLock != nullptr) {
+		flush();
+		IOLockFree(_queueLock);
+		_queueLock = nullptr;
+	}
+
+	if (_outputQueues != nullptr) {
+		_outputQueues->release();
+		_outputQueues = nullptr;
+	}
+
+	if (_hash != nullptr) {
+		_hash->release();
+		_hash = nullptr;
+	}
+
+	if (_targets != nullptr) {
+		_targets->release();
+		_targets = nullptr;
+	}
+
+	super::free();
+}
+
+constexpr int etherVLANTagLen = 4;
+constexpr int etherVLANHeaderLen = ETHER_HDR_LEN + etherVLANTagLen;
+constexpr int etherTypeVLANOffset = ETHER_HDR_LEN + 2;
+
+UInt32 ENAParallelOutputQueue::enqueue(mbuf_t mbuf, void * param)
+{
+	struct ether_header *etherHeader;
+	struct ip *ip;
+	struct tcphdr *tcpHeader;
+	struct udphdr *udpHeader;
+	struct in_addr sourceAddr;
+	struct in_addr destAddr;
+	IOBasicOutputQueue *outputQueue;
+	mbuf_t m;
+	size_t mlen;
+	int etherHeaderLen;
+	int ipHeaderLen = 0;
+	int targetQueue;
+	UInt32 ret;
+	UInt32 hash;
+	unsigned short sourcePort;
+	unsigned short destPort;
+	UInt16 etherType;
+	UInt8 *headerPointer;
+	u_char ipProto = 0;
+
+	assert(mbuf_flags(mbuf) & MBUF_PKTHDR);
+	assert(_active > 0);
+
+	m = mbuf;
+	headerPointer = reinterpret_cast<UInt8 *>(mbuf_data(m));
+	mlen = mbuf_len(m);
+
+	etherHeader = reinterpret_cast<struct ether_header *>(headerPointer);
+	if (etherHeader->ether_type == htons(ETHERTYPE_VLAN)) {
+		etherHeaderLen = etherVLANHeaderLen;
+		etherType = ntohs(*reinterpret_cast<UInt16 *>(headerPointer + etherTypeVLANOffset));
+	} else {
+		etherHeaderLen = ETHER_HDR_LEN;
+		etherType = ntohs(etherHeader->ether_type);
+	}
+
+	// Advance the header pointer for L3 header
+	if (etherHeaderLen == mlen) {
+		m = mbuf_next(m);
+		mlen = mbuf_len(m);
+		headerPointer = reinterpret_cast<UInt8 *>(mbuf_data(m));
+	} else {
+		headerPointer += etherHeaderLen;
+		mlen -= etherHeaderLen;
+	}
+
+	if (etherType == ETHERTYPE_IP) {
+		ip = reinterpret_cast<struct ip *>(headerPointer);
+		ipHeaderLen = ip->ip_hl << 2;
+		sourceAddr = ip->ip_src;
+		destAddr = ip->ip_dst;
+		ipProto = ip->ip_p;
+
+		// Advance the header pointer for L4 header
+		if (ipHeaderLen == mlen) {
+			m = mbuf_next(m);
+			headerPointer = reinterpret_cast<UInt8 *>(mbuf_data(m));
+		} else {
+			headerPointer += ipHeaderLen;
+		}
+
+		if (ipProto == IPPROTO_TCP) {
+			tcpHeader = reinterpret_cast<struct tcphdr *>(headerPointer);
+			sourcePort = tcpHeader->th_sport;
+			destPort = tcpHeader->th_dport;
+			hash = _hash->getHash(sourceAddr, destAddr, sourcePort, destPort);
+		} else if (ipProto == IPPROTO_UDP) {
+			udpHeader = reinterpret_cast<struct udphdr *>(headerPointer);
+			sourcePort = udpHeader->uh_sport;
+			destPort = udpHeader->uh_dport;
+			hash = _hash->getHash(sourceAddr, destAddr, sourcePort, destPort);
+		} else {
+			hash = _hash->getHash(sourceAddr, destAddr);
+		}
+
+	} else {
+		// As for now, hash calculation for IPv6 is not supported, yet.
+		hash = 0;
+	}
+
+	// Select appropriate queue using hash value.
+	targetQueue = hash % _active;
+
+	outputQueue = OSDynamicCast(IOBasicOutputQueue, _outputQueues->getObject(targetQueue));
+	assertf(outputQueue != nullptr, "IOBasicOutputQueue cannot be null: queue %u\n", targetQueue);
+	ret = outputQueue->enqueue(mbuf, param);
+
+	return ret;
+}
+
+bool ENAParallelOutputQueue::start()
+{
+	bool success = true;
+
+	QUEUE_LOCK;
+	for (int i = 0; i < _targetsCount; ++i) {
+		IOBasicOutputQueue *outputQueue = OSDynamicCast(IOBasicOutputQueue, _outputQueues->getObject(i));
+		assertf(outputQueue != nullptr, "IOBasicOutputQueue cannot be null: queue %u\n", i);
+		success &= outputQueue->start();
+	}
+	QUEUE_UNLOCK;
+
+	return success;
+}
+
+bool ENAParallelOutputQueue::stop()
+{
+	bool success = true;
+
+	QUEUE_LOCK;
+	for (int i = 0; i < _targetsCount; ++i) {
+		IOBasicOutputQueue *outputQueue = OSDynamicCast(IOBasicOutputQueue, _outputQueues->getObject(i));
+		assertf(outputQueue != nullptr, "IOBasicOutputQueue cannot be null: queue %u\n", i);
+		success &= outputQueue->stop();
+	}
+	QUEUE_UNLOCK;
+
+	return true;
+}
+
+bool ENAParallelOutputQueue::service(IOOptionBits options)
+{
+	bool success = true;
+
+	QUEUE_LOCK;
+	// Service only active queues
+	for (int i = 0; i < _active; ++i) {
+		IOBasicOutputQueue *outputQueue = OSDynamicCast(IOBasicOutputQueue, _outputQueues->getObject(i));
+		assertf(outputQueue != nullptr, "IOBasicOutputQueue cannot be null: queue %u\n", i);
+		success &= outputQueue->service(options);
+	}
+	QUEUE_UNLOCK;
+
+	return success;
+}
+
+bool ENAParallelOutputQueue::service(int index, IOOptionBits options)
+{
+	IOBasicOutputQueue *outputQueue = OSDynamicCast(IOBasicOutputQueue, _outputQueues->getObject(index));
+	assertf(outputQueue != nullptr, "IOBasicOutputQueue cannot be null: queue %u\n", index);
+	return outputQueue->service(options);
+}
+
+UInt32 ENAParallelOutputQueue::flush()
+{
+	UInt32 flushCount = 0;
+
+	QUEUE_LOCK;
+	for (int i = 0; i < _targetsCount; ++i) {
+		IOBasicOutputQueue *outputQueue = OSDynamicCast(IOBasicOutputQueue, _outputQueues->getObject(i));
+		assertf(outputQueue != nullptr, "IOBasicOutputQueue cannot be null: queue %u\n", i);
+		flushCount += outputQueue->flush();
+	}
+	QUEUE_UNLOCK;
+
+	return flushCount;
+}
+
+bool ENAParallelOutputQueue::setCapacity(UInt32 capacity)
+{
+	bool success = true;
+
+	QUEUE_LOCK;
+	_capacity = capacity;
+	for (int i = 0; i < _active; ++i) {
+		IOBasicOutputQueue *outputQueue = OSDynamicCast(IOBasicOutputQueue, _outputQueues->getObject(i));
+		assertf(outputQueue != nullptr, "IOBasicOutputQueue cannot be null: queue %u\n", i);
+		success &= outputQueue->setCapacity(_capacity);
+	}
+	QUEUE_UNLOCK;
+
+	return success;
+}
+
+UInt32 ENAParallelOutputQueue::getSize() const
+{
+	UInt32 size = 0;
+
+	for (int i = 0; i < _active; ++i)
+		size += getSize(i);
+
+	return size;
+}
+
+UInt32 ENAParallelOutputQueue::getSize(int index) const
+{
+	IOBasicOutputQueue *outputQueue = OSDynamicCast(IOBasicOutputQueue, _outputQueues->getObject(index));
+	assertf(outputQueue != nullptr, "IOBasicOutputQueue cannot be null: queue %u\n", index);
+	return outputQueue->getSize();
+}
+
+bool ENAParallelOutputQueue::setActiveSubQueues(UInt8 queues)
+{
+	if (queues == 0 || queues > _targetsCount)
+		return false;
+
+	_active = queues;
+
+	return setCapacity(_capacity);
+}

--- a/kernel/macOS/ena/ENAParallelOutputQueue.hpp
+++ b/kernel/macOS/ena/ENAParallelOutputQueue.hpp
@@ -1,0 +1,181 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef _ENAPARALLELOUTPUTQUEUE_HPP_
+#define _ENAPARALLELOUTPUTQUEUE_HPP_
+
+#include "ENAHash.hpp"
+
+#include <IOKit/network/IOBasicOutputQueue.h>
+
+/*! @class ENAParallelOutputQueue
+    @abstract A packets queue that supports multiple producers and multiple
+    consumers in multithreading safe mather.
+    @discussion The class supports multiple consumers support by wrapping
+    multiple IOBasicOutputQueue objects. Whenever the producer enqueues a packet,
+    the mbuf is assigned to the IOBasicOutputQueue using calucalted HASH.
+*/
+class ENAParallelOutputQueue : public IOOutputQueue
+{
+	OSDeclareDefaultStructors(ENAParallelOutputQueue)
+public:
+
+/*!	@function withTarget
+	@abstract Factory method that constructs and initializes an
+	ENAParallelOutputQueue object.
+	@param targets The objects that will handle packets removed from the queues.
+	@param action The pointer to the method of the objects, that should handle
+	the packets removed from the queues.
+	@param hash The pointer to the hashing function, which is going to be
+	used for flow distribution.
+	@param capacity The initial capacity of each output queues.
+	@param priorities The number of traffic priorities supported.
+	@result Returns an ENAParallelOutputQueue object on success, or 0 otherwise.
+*/
+	static ENAParallelOutputQueue * withTarget(OSArray *targets,
+						   IOOutputAction action,
+						   ENAHash *hash,
+                				   UInt32 capacity = 0,
+						   UInt32 priorities = 1);
+
+/*!	@function init
+	@abstract Initializes an ENAParallelOutputQueue object.
+	@param targets The objects that will handle packets removed from the queues.
+	@param action The pointer to the method of the objects, that should handle
+	the packets removed from the queues.
+	@param hash The pointer to the hashing function, which is going to be
+	used for flow distribution.
+	@param capacity The initial capacity of each output queues.
+	@param priorities The number of traffic priorities supported.
+	@result Returns true if initialized successfully, false otherwise.
+*/
+	bool init(OSArray *targets,
+			  IOOutputAction action,
+			  ENAHash *hash,
+                	  UInt32 capacity = 0,
+			  UInt32 priorities = 1);
+
+/*!	@function start
+	@abstract Starts the packet flow between the queue and its targets.
+	@discussion Called by the target to start the queue. This will allow
+	packets to be removed from the queue, and then deliver them to the target.
+	This method starts all allocated sub-queues.
+	@result Returns true if the queue was started successfully, false otherwise.
+*/
+	bool start() APPLE_KEXT_OVERRIDE;
+
+/*!	@function stop
+	@abstract Stops the packet flow between the queue and its target.
+	@discussion This method stops the queue and prevents it from sending
+	packets to its target. This call is synchronous and it may block. After
+	this method returns, the queue will no longer call the registered
+	targets actions, even as new packets are added to the queue. The queue
+	will continue to absorb new packets until the size of the queue reaches
+	its capacity. The registered action must never call stop(), or a deadlock
+	will occur.
+	This method stops all allocated sub-queues.
+	@result Returns the previous running state of the queues, true if one of
+	the the queues was running, false if all the queues were already stopped.
+*/
+	bool stop() APPLE_KEXT_OVERRIDE;
+
+/*!	@function service
+	@abstract Services queues that were stalled by the targets.
+	@discussion This method calls service() for each active sub-queues,
+	which indicates that all of them are ready to accept new packets.
+	@param options Options for the service request.
+	@result Returns true if one the queue was stalled and there were packets
+	sitting in the queue awaiting for delivery, false otherwise.
+*/
+	bool service(IOOptionBits options = 0) APPLE_KEXT_OVERRIDE;
+
+/*!	@function service
+	@abstract Services a queue that was stalled by the target.
+	@discussion A target that stalls the queue must call service() when
+	it becomes ready to accept more packets. Calling this method when the
+	queue is not stalled is harmless.
+	@param index Index of the sub-queue that should be serviced.
+	@param options Options for the service request.
+	@result Returns true if the queue was stalled and there were packets
+	sitting in the queue awaiting for delivery, false otherwise.
+*/
+	bool service(int index, IOOptionBits options = 0);
+
+/*!	@function enqueue
+	@abstract Adds a packet, or a chain of packets, to the sub-queue.
+	@discussion This method is called by a client to add a packet, or a
+	chain of packets, to the queue. A packet is described by an mbuf chain,
+	while a chain of packets is constructed by linking multiple mbuf chains
+	via the m_nextpkt field. This method can be called by multiple client
+	threads. Sub-queue is being choosen basing on hash calculated from:
+	  * Source IP + Destination IP for IPv4 packets
+	  * Source IP + Destination IP + Source port + Destination port
+	    for IPv4/(TCP|UDP) packets
+	@param mbuf A single packet, or a chain of packets.
+	@param param A parameter provided by the caller.
+	@result Always returns 0.
+*/
+	UInt32 enqueue(mbuf_t mbuf, void * param) APPLE_KEXT_OVERRIDE;
+
+/*!	@function flush
+	@abstract Drops and frees all packets which are currently held by all the sub-queues.
+	@discussion To ensure that all packets are removed from the queue,
+	stop() should be called prior to flush(), to make sure there are
+	no packets in-flight and being delivered to the target.
+	@result Returns the number of packets that were dropped and freed.
+*/
+	UInt32 flush() APPLE_KEXT_OVERRIDE;
+
+/*!	@function setCapacity
+	@abstract Changes the number of packets that each sub-queue can hold
+	before it begins to drop the excessed packets.
+	@param capacity The new desired capacity.
+	@result Returns true if the new capacity was accepted, false otherwise.
+*/
+	bool setCapacity(UInt32 capacity) APPLE_KEXT_OVERRIDE;
+
+/*!	@function getCapacity
+	@abstract Gets the number of packets that each sub-queue can hold.
+	@discussion The sub-queue will begin to drop incoming packets when the
+	size of the sub-queue reaches its capacity.
+	@result Returns the current each sub-queue capacity.
+*/
+	UInt32 getCapacity() const APPLE_KEXT_OVERRIDE;
+
+/*!	@function getSize
+	@abstract Gets the number of packets which are currently held in all sub-queues.
+	@result Returns the size of all sub-queues.
+*/
+	UInt32 getSize() const APPLE_KEXT_OVERRIDE;
+
+/*!	@function getSize
+	@abstract Gets the number of packets which are currently held in the given sub-queue.
+	@param index Index of the sub-queue.
+	@result Returns the size of the given sub-queue.
+*/
+	UInt32 getSize(int index) const;
+
+/*!	@function setActiveSubQueues
+	@abstract Set number of active sub-queues.
+	@discussion Only sub-queues which are active will have allocated mbuf's
+	queues to preserve memory. The mbuf's are being assigned only to active queues.
+	@param queues Number of sub-queues to activate
+	@results Returns true if is activated successfully, false otherwise.
+*/
+	bool setActiveSubQueues(UInt8 queues);
+
+private:
+	OSArray		*_outputQueues;
+	OSArray		*_targets;
+	IOLock		*_queueLock;
+	IOOutputAction  _action;
+	ENAHash		*_hash;
+	UInt8		_targetsCount;
+	UInt32		_priorities;
+	UInt32		_capacity;
+	UInt8		_active;
+
+	void free() APPLE_KEXT_OVERRIDE;
+};
+
+#endif

--- a/kernel/macOS/ena/ENAProperties.cpp
+++ b/kernel/macOS/ena/ENAProperties.cpp
@@ -1,0 +1,98 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+#include "ENAProperties.hpp"
+
+#include "ENALogs.hpp"
+
+#define EP_ERROR_LOG(format, ...) ERROR_LOG(ENAProperties, format, ##__VA_ARGS__)
+
+// HW stats
+const char * ENAProperties::_HWStatsNames[ENAHWStatsNum] = {
+	"ENARxPacketsTotal",
+	"ENATxPacketsTotal",
+	"ENARxBytesTotal",
+	"ENATxBytesTotal",
+	"ENARxDropsTotal",
+	"ENAAdminQueuePause",
+	"ENAWatchdogExpired",
+};
+
+// Tx stats
+const char * ENAProperties::_TxStatsNames[ENATxStatsNum] = {
+	"ENATxCount",
+	"ENATxBytes",
+	"ENATxPrepareContextErrors",
+	"ENATxDMAMappingErrors",
+	"ENATxDoorbells",
+	"ENATxMissingCompletions",
+	"ENATxBadRequestedID",
+	"ENATxQueueWakeups",
+	"ENATxQueueStops",
+};
+
+// Rx stats
+const char * ENAProperties::_RxStatsNames[ENARxStatsNum] = {
+	"ENARxCount",
+	"ENARxBytes",
+	"ENARxPartialRefills",
+	"ENARxBadChecksum",
+	"ENARxMbufAllocationFails",
+	"ENARxDMAMappingErrors",
+	"ENARxBadRequestedID",
+	"ENARxBadDescriptorNumber",
+};
+
+ENAProperties::ENAProperties() : _valid(false)
+{
+	for (size_t i = 0; i < ENAHWStatsNum; ++i) {
+		_hwStatsSymbols[i] = OSSymbol::withCString(_HWStatsNames[i]);
+		if (_hwStatsSymbols[i] == nullptr) {
+			EP_ERROR_LOG("Failed to allocate HW stats symbols\n");
+			return;
+		}
+	}
+
+	for (size_t i = 0; i < ENATxStatsNum; ++i) {
+		_txStatsSymbols[i] = OSSymbol::withCString(_TxStatsNames[i]);
+		if (_txStatsSymbols[i] == nullptr) {
+			EP_ERROR_LOG("Failed to allocate Tx stats symbols\n");
+			return;
+		}
+	}
+
+	for (size_t i = 0; i < ENARxStatsNum; ++i) {
+		_rxStatsSymbols[i] = OSSymbol::withCString(_RxStatsNames[i]);
+		if (_rxStatsSymbols[i] == nullptr) {
+			EP_ERROR_LOG("Failed to allocate Rx stats symbols\n");
+			return;
+		}
+	}
+
+	_valid = true;
+}
+
+ENAProperties::~ENAProperties()
+{
+	for (auto &symbol : _hwStatsSymbols)
+		SAFE_RELEASE(symbol);
+
+	for (auto &symbol : _txStatsSymbols)
+		SAFE_RELEASE(symbol);
+
+	for (auto &symbol : _rxStatsSymbols)
+		SAFE_RELEASE(symbol);
+}
+
+void copyStatsFromQueueToProperties(const AtomicStat *stats,
+				    size_t count,
+				    OSArray **queuesProperties,
+				    unsigned int queueID)
+{
+	OSNumber *propertyNumber;
+
+	for (size_t i = 0; i < count; ++i) {
+		propertyNumber = OSDynamicCast(OSNumber, queuesProperties[i]->getObject(queueID));
+		propertyNumber->setValue(getAtomicStat(&stats[i]));
+	}
+}

--- a/kernel/macOS/ena/ENAProperties.hpp
+++ b/kernel/macOS/ena/ENAProperties.hpp
@@ -1,0 +1,66 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef _ENAPROPERTIES_HPP
+#define _ENAPROPERTIES_HPP
+
+#include "ENA.hpp"
+#include "ENARings.hpp"
+
+class ENAProperties
+{
+public:
+	ENAProperties();
+	~ENAProperties();
+
+	bool isValid() const;
+
+	const OSSymbol * getHWStatsSymbol(size_t i) const;
+	const OSSymbol * getTxStatsSymbol(size_t i) const;
+	const OSSymbol * getRxStatsSymbol(size_t i) const;
+
+private:
+	bool _valid;
+	const OSSymbol *_hwStatsSymbols[ENAHWStatsNum];
+	const OSSymbol *_txStatsSymbols[ENATxStatsNum];
+	const OSSymbol *_rxStatsSymbols[ENARxStatsNum];
+
+	static const char *_HWStatsNames[ENAHWStatsNum];
+	static const char *_TxStatsNames[ENATxStatsNum];
+	static const char *_RxStatsNames[ENARxStatsNum];
+};
+
+/***********************************************************
+ * Interface functions
+ ***********************************************************/
+
+void copyStatsFromQueueToProperties(const AtomicStat *stats,
+				    size_t count,
+				    OSArray **queuesProperties,
+				    unsigned int queueID);
+
+/***********************************************************
+ * Inline definitions
+ ***********************************************************/
+
+inline bool ENAProperties::isValid() const
+{
+	return _valid;
+}
+
+inline const OSSymbol * ENAProperties::getTxStatsSymbol(size_t i) const
+{
+	return _txStatsSymbols[i];
+}
+
+inline const OSSymbol * ENAProperties::getRxStatsSymbol(size_t i) const
+{
+	return _rxStatsSymbols[i];
+}
+
+inline const OSSymbol * ENAProperties::getHWStatsSymbol(size_t i) const
+{
+	return _hwStatsSymbols[i];
+}
+
+#endif

--- a/kernel/macOS/ena/ENARings.cpp
+++ b/kernel/macOS/ena/ENARings.cpp
@@ -1,0 +1,1010 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+#include "ENARings.hpp"
+
+#include "ENA.hpp"
+#include "ENALogs.hpp"
+
+#include <sys/param.h>
+
+/***********************************************************
+ * ENARing definition
+ ***********************************************************/
+
+OSDefineMetaClassAndAbstractStructors(ENARing, OSObject)
+
+bool ENARing::init(ENA *controller, ENARing::Config *config)
+{
+	if (!OSObject::init())
+		return false;
+
+	_mbufCursor = IOMbufNaturalMemoryCursor::withSpecification(
+		config->maxSegmentSize,
+		config->maxSegmentsNumber);
+	if (_mbufCursor == nullptr) {
+		ENA_ERROR_LOG_EXT(_controller, "Failed to create mbuf memory cursor\n");
+		return false;
+	}
+	_qid = config->qid;
+
+	_controller = controller;
+
+	_memQueueType = config->memQueueType;
+	_queueSize = config->queueSize;
+	_maxSegNum = config->maxSegmentsNumber;
+	_packetCleanupBudget = config->packetCleanupBudget;
+	_firstInterrupt = false;
+
+	return true;
+}
+
+void ENARing::free()
+{
+	SAFE_RELEASE(_mbufCursor);
+
+	OSObject::free();
+}
+
+bool ENARing::enable()
+{
+	_freeIDs = IONew(UInt16, _queueSize);
+	if (_freeIDs == nullptr) {
+		ENA_DEBUG_LOG_EXT(_controller, "Cannot allocate freeIDs\n");
+		return false;
+	}
+
+	for (UInt16 i = 0; i < _queueSize; ++i)
+		_freeIDs[i] = i;
+
+	// Reset the ring indexes
+	_nextToClean = 0;
+	_nextToUse = 0;
+
+	if (!createIOQueue()) {
+		ENA_DEBUG_LOG_EXT(_controller, "Failed to create ena_com IO queues\n");
+		return false;
+	}
+
+	return true;
+}
+
+void ENARing::disable()
+{
+	if (_freeIDs != nullptr) {
+		IODelete(_freeIDs, UInt16, _queueSize);
+		_freeIDs = nullptr;
+	}
+
+	destroyIOQueue();
+
+	freeBuffers();
+}
+
+bool ENARing::createIOQueue()
+{
+	struct ena_com_dev *enaDev = _controller->getENADevice();
+	struct ena_com_create_io_ctx ctx;
+	int rc;
+
+	ctx.qid = _ioqid;
+	ctx.direction = _direction;
+	ctx.queue_size = _queueSize;
+	ctx.mem_queue_type = _memQueueType;
+	// Every IO interrupt must be handled on vector 0 because of Darwin
+	// limitations.
+	ctx.msix_vector = 0;
+
+	ENA_DEBUG_LOG_EXT(_controller,
+		      "Creating IO queues for ring %d: qid %d, dir %d, size %d, type %d\n",
+		      _qid, _ioqid, _direction, _queueSize, _memQueueType);
+
+	rc = ena_com_create_io_queue(enaDev, &ctx);
+	if (rc != 0) {
+		ENA_ERROR_LOG_EXT(_controller,
+			      "Failed to create ena_com IO queue #%d rc: %d\n",
+			      _qid, rc);
+		return false;
+	}
+
+	rc = ena_com_get_io_handlers(enaDev, _ioqid, &_ioSQ, &_ioCQ);
+	if (rc != 0) {
+		ENA_ERROR_LOG_EXT(_controller,
+			      "Failed to get ena_com IO queue's handlers #%d rc: %d\n",
+			      _qid, rc);
+		return false;
+	}
+
+	return true;
+}
+
+void ENARing::destroyIOQueue()
+{
+	if (_ioCQ != nullptr && _ioSQ != nullptr) {
+		ena_com_destroy_io_queue(_controller->getENADevice(), _ioqid);
+		_ioCQ = nullptr;
+		_ioSQ = nullptr;
+	}
+}
+
+void ENARing::advanceIndex(UInt16 &index)
+{
+	index = (index + 1) & (_queueSize - 1);
+}
+
+bool ENARing::validateReqID(UInt16 reqID)
+{
+	if (unlikely(reqID >= _queueSize)) {
+		ENA_ERROR_LOG_EXT(_controller, "Invalid requested ID: %hu\n", reqID);
+		return false;
+	}
+
+	return true;
+}
+
+UInt16 ENARing::getPacketCleanupBudget()
+{
+	return _packetCleanupBudget;
+}
+
+/***********************************************************
+ * ENARingTx definition
+ ***********************************************************/
+
+OSDefineMetaClassAndStructors(ENARingTx, ENARing)
+
+ENARingTx * ENARingTx::withConfig(ENA *controller, ENARingTx::TxConfig *config)
+{
+	ENARingTx *ring = new ENARingTx;
+
+	if (ring != nullptr) {
+		if (!ring->init(controller, config)) {
+			ring->release();
+			ring = nullptr;
+		}
+	}
+
+	return ring;
+}
+
+bool ENARingTx::init(ENA *controller, ENARingTx::TxConfig *config)
+{
+	if (!ENARing::init(controller, config))
+		return false;
+	_direction = ENA_COM_IO_QUEUE_DIRECTION_TX;
+	_ioqid = ENA_IO_TXQ_IDX(_qid);
+	_missingTxCompletionTimeout = ENA_HW_HINTS_NO_TIMEOUT;
+	// By default set the threshold to max, it can be overwritten by the
+	// setupMissingTxCompletion function;
+	_missingTxCompletionThreshold = 0xffffffff;
+	initAtomicStats((AtomicStat *)&_txStats, ENATxStatsNum);
+
+	return true;
+}
+
+bool ENARingTx::enable()
+{
+	ENA_DEBUG_LOG_EXT(_controller, "Enabling Tx ring %d\n", _qid);
+
+	if (!ENARing::enable()) {
+		ENA_DEBUG_LOG_EXT(_controller, "Failed to enable ENARing\n");
+		return false;
+	}
+
+	_bufferInfo = IONew(ENATxBuffer, _queueSize);
+	if (_bufferInfo == nullptr) {
+		ENA_DEBUG_LOG_EXT(_controller, "Failed to allocate buffer info\n");
+		return false;
+	}
+	memset(_bufferInfo, 0 , _queueSize * sizeof(ENATxBuffer));
+
+	_doorbellBurstCount = 0;
+
+	return true;
+}
+
+void ENARingTx::disable()
+{
+	if (_bufferInfo != nullptr) {
+		IODelete(_bufferInfo, ENATxBuffer, _queueSize);
+		_bufferInfo = nullptr;
+	}
+
+	ENARing::disable();
+}
+
+void ENARingTx::freeBuffers()
+{
+	bool printOnce = true;
+
+	if (_bufferInfo == nullptr)
+		return;
+
+	for (int i = 0; i < _queueSize; i++) {
+		ENATxBuffer *txInfo = &_bufferInfo[i];
+
+		if (txInfo->mbuf == nullptr)
+			continue;
+
+		if (printOnce) {
+			ENA_ERROR_LOG_EXT(_controller,
+				      "Free uncompleted Tx mbuf on qid %d, idx 0x%x\n",
+				      _qid, i);
+			printOnce = false;
+		} else {
+			ENA_DEBUG_LOG_EXT(_controller,
+				      "Free uncompleted Tx mbuf on qid %d, idx 0x%x\n",
+				      _qid, i);
+		}
+
+		_controller->freePacket(txInfo->mbuf, 0);
+		txInfo->mbuf = nullptr;
+	}
+}
+
+int ENARingTx::interruptProcess()
+{
+	ENAParallelOutputQueue *outputQueue;
+	ENATxBuffer *txInfo;
+	size_t commit = ENA_TX_COMMIT;
+	int rc;
+	UInt16 packetsDone = 0;
+	UInt16 descsDone = 0;
+	UInt16 reqID;
+	UInt16 ntc;
+
+	_firstInterrupt = true;
+
+	ntc = _nextToClean;
+	do {
+		rc = ena_com_tx_comp_req_id_get(_ioCQ, &reqID);
+		if (rc != 0)
+			break;
+
+		if (!validateReqID(reqID))
+			break;
+
+		txInfo = &_bufferInfo[reqID];
+		_controller->freePacket(txInfo->mbuf);
+		txInfo->mbuf = nullptr;
+		txInfo->timestamp = 0;
+
+		descsDone += txInfo->descs;
+		++packetsDone;
+
+		_freeIDs[ntc] = reqID;
+		advanceIndex(ntc);
+
+		// Update ring state every ENA_TX_COMMIT descriptor.
+		commit--;
+		if (unlikely(commit == 0)) {
+			commit = ENA_TX_COMMIT;
+			_nextToClean = ntc;
+			ena_com_comp_ack(_ioSQ, descsDone);
+			ena_com_update_dev_comp_head(_ioCQ);
+			descsDone = 0;
+		}
+	} while (likely(packetsDone < _packetCleanupBudget));
+
+	// If there is still something to commit update ring state.
+	if (likely(commit != ENA_TX_COMMIT)) {
+		_nextToClean = ntc;
+		ena_com_comp_ack(_ioSQ, descsDone);
+		ena_com_update_dev_comp_head(_ioCQ);
+	}
+
+	// Make the ring update visible to the Tx routine
+	atomic_thread_fence(memory_order_acq_rel);
+	if (unlikely(_txStalled && ena_com_sq_have_enough_space(_ioSQ, _maxSegNum + 2))) {
+		_txStalled = false;
+		outputQueue = OSDynamicCast(ENAParallelOutputQueue,
+					    _controller->getOutputQueue());
+		outputQueue->service(_qid, IOBasicOutputQueue::kServiceAsync);
+		incAtomicStat(&_txStats.queueWakeups);
+	}
+
+	return packetsDone;
+}
+
+bool ENARingTx::checkForMissingCompletions()
+{
+	ENATxBuffer *txBuffer;
+	ENATime lastTime;
+	UInt32 missedTx = 0;
+
+	for (int i = 0; i < _queueSize; ++i) {
+		txBuffer = &_bufferInfo[i];
+		lastTime = txBuffer->timestamp;
+
+		if (lastTime == ENATime(0))
+			// No pending Tx at this location
+			continue;
+
+		if (unlikely(!_firstInterrupt &&
+			     ENATime::getNow() > (lastTime + 2 * _missingTxCompletionTimeout))) {
+			// If after graceful period interrupt is still not
+			// received, we schedule a reset
+			ENA_ERROR_LOG_EXT(_controller,
+				      "Potential MSIX issue on Tx side Queue = %d. Reset the device\n",
+				      _qid);
+			_controller->triggerReset(ENA_REGS_RESET_MISS_INTERRUPT);
+			return false;
+		}
+
+		if (unlikely(ENATime::getNow() > (lastTime + _missingTxCompletionTimeout))) {
+			if (!txBuffer->printOnce)
+				ENA_ERROR_LOG_EXT(_controller,
+					     "Found a Tx that wasn't completed on time, qid %d, index %d.\n",
+					     _qid, i);
+
+			txBuffer->printOnce = true;
+			missedTx++;
+		}
+	}
+
+	if (unlikely(missedTx > _missingTxCompletionThreshold)) {
+		ENA_ERROR_LOG_EXT(_controller,
+			      "The number of lost tx completions is above the threshold (%d > %d). Reset the device\n",
+			      missedTx, _missingTxCompletionThreshold);
+		_controller->triggerReset(ENA_REGS_RESET_MISS_TX_CMPL);
+		return false;
+	}
+
+	addAtomicStat(&_txStats.missingCompletions, missedTx);
+
+	return true;
+}
+
+void ENARingTx::setupMissingTxCompletion(ENATime timeout, UInt32 threshold)
+{
+	_missingTxCompletionTimeout = timeout;
+	_missingTxCompletionThreshold = threshold;
+}
+
+UInt32 ENARingTx::sendPacket(mbuf_t mbuf, void *param)
+{
+	IOPhysicalSegment segments[enaPktMaxBufs];
+	IONetworkStats *netStats;
+	ENAParallelOutputQueue *outputQueue;
+	ENATxBuffer *txInfo;
+	ENAHWStats *hwStats;
+	struct ena_com_tx_ctx enaTxCtx = {};
+	int rc, nbHwDesc;
+	UInt32 ret = kIOReturnOutputSuccess;
+	UInt32 segNum;
+	UInt16 reqID;
+
+	netStats = _controller->getNetworkStats();
+	hwStats = _controller->getHWStats();
+
+	reqID = _freeIDs[_nextToUse];
+	txInfo = &_bufferInfo[reqID];
+
+	// Get segments but reserve 1 descriptor for meta-data
+	segNum = _mbufCursor->getPhysicalSegmentsWithCoalesce(mbuf, segments, _maxSegNum - 1);
+	if (segNum == 0) {
+		ENA_DEBUG_LOG_EXT(_controller, "Failed to map mbuf to segments\n");
+		++netStats->outputErrors;
+		incAtomicStat(&_txStats.dmaMappingErrors);
+		_controller->freePacket(mbuf);
+		return kIOReturnOutputDropped;
+	}
+
+	for (int i = 0; i < segNum; i++) {
+		txInfo->enaBufs[i].len = segments[i].length;
+		txInfo->enaBufs[i].paddr = segments[i].location;
+	}
+
+	enaTxCtx.ena_bufs = txInfo->enaBufs;
+	enaTxCtx.num_bufs = segNum;
+	enaTxCtx.req_id = reqID;
+
+	_controller->setupTxChecksum(enaTxCtx, mbuf);
+
+	rc = ena_com_prepare_tx(_ioSQ, &enaTxCtx, &nbHwDesc);
+	if (unlikely(rc != 0)) {
+		ENA_ERROR_LOG_EXT(_controller, "Failed to prepare Tx bufs on queue %d\n", _qid);
+		++netStats->outputErrors;
+		incAtomicStat(&_txStats.prepareContextErrors);
+		if (rc != ENA_COM_NO_MEM) {
+			_controller->triggerReset(ENA_REGS_RESET_DRIVER_INVALID_STATE);
+		}
+		_controller->freePacket(mbuf);
+		return kIOReturnOutputDropped;
+	}
+
+	ENA_DEBUG_LOG_EXT(_controller, "Tx mbuf on queue %d: %zu bytes, %u segs, %d hwDescs\n",
+		      _qid, mbuf_pkthdr_len(mbuf), segNum, nbHwDesc);
+	incAtomicStat(&_txStats.count);
+	addAtomicStat(&_txStats.bytes, mbuf_pkthdr_len(mbuf));
+
+	++_doorbellBurstCount;
+
+	txInfo->descs = nbHwDesc;
+	txInfo->mbuf = mbuf;
+	txInfo->timestamp.setNow();
+
+	advanceIndex(_nextToUse);
+
+	// This barrier is aimed to perform barrier before reading next_to_completion
+	atomic_thread_fence(memory_order_acquire);
+
+	// Stop the queue when no more space available, the packet can have up
+	// to _maxSegNum + 2. One for the meta descriptor and one for header
+	// (if the header is larger than txMaxHeaderSize - which is not implemented, yet).
+	if (unlikely(!ena_com_sq_have_enough_space(_ioSQ, _maxSegNum + 2))) {
+		ENA_DEBUG_LOG_EXT(_controller, "Tx queue %d stopped\n", _qid);
+		ret |= kIOOutputCommandStall;
+		_txStalled = true;
+		incAtomicStat(&_txStats.queueStops);
+	}
+
+	outputQueue = OSDynamicCast(ENAParallelOutputQueue, _controller->getOutputQueue());
+	if (((ret & kIOOutputCommandMask) == kIOOutputCommandStall) ||
+	    (outputQueue->getSize(_qid) == 0) ||
+	    (_doorbellBurstCount == DOORBELL_BURST_THRESHOLD)) {
+		ena_com_write_sq_doorbell(_ioSQ);
+		incAtomicStat(&_txStats.doorbells);
+		_doorbellBurstCount = 0;
+	}
+
+	return ret;
+}
+
+bool ENARingTx::validateReqID(UInt16 reqID)
+{
+	if (ENARing::validateReqID(reqID)) {
+		ENATxBuffer *txInfo = &_bufferInfo[reqID];
+		if (likely(txInfo->mbuf != nullptr))
+			return true;
+		ENA_ERROR_LOG_EXT(_controller, "TX info doesn't have valid mbuf\n");
+	}
+
+	incAtomicStat(&_txStats.badRequestedID);
+	_controller->triggerReset(ENA_REGS_RESET_INV_TX_REQ_ID);
+
+	return false;
+}
+
+const ENATxStats * ENARingTx::getTxStats() const
+{
+	return &_txStats;
+}
+
+/***********************************************************
+ * ENARingRx definition
+ ***********************************************************/
+
+OSDefineMetaClassAndStructors(ENARingRx, ENARing)
+
+ENARingRx * ENARingRx::withConfig(ENA *controller, ENARingRx::RxConfig *config)
+{
+	ENARingRx *ring = new ENARingRx;
+
+	if (ring != nullptr) {
+		if (!ring->init(controller, config)) {
+			ring->release();
+			ring = nullptr;
+		}
+	}
+
+	return ring;
+}
+
+bool ENARingRx::init(ENA *controller, ENARingRx::RxConfig *config)
+{
+	if (!ENARing::init(controller, config))
+		return false;
+
+
+	_direction = ENA_COM_IO_QUEUE_DIRECTION_RX;
+	_ioqid = ENA_IO_RXQ_IDX(_qid);
+	initAtomicStats((AtomicStat *)&_rxStats, ENARxStatsNum);
+
+	return true;
+}
+
+bool ENARingRx::enable()
+{
+	int toRefill, refilled;
+
+	ENA_DEBUG_LOG_EXT(_controller, "Enabling Rx ring %d\n", _qid);
+
+	if (!ENARing::enable()) {
+		ENA_DEBUG_LOG_EXT(_controller, "Failed to enable ENARing\n");
+		return false;
+	}
+
+	_bufferInfo = IONew(ENARxBuffer, _queueSize);
+	if (_bufferInfo == nullptr) {
+		ENA_DEBUG_LOG_EXT(_controller, "Failed to allocate buffer info\n");
+		return false;
+	}
+	memset(_bufferInfo, 0 , _queueSize * sizeof(ENARxBuffer));
+
+	toRefill = _queueSize - 1;
+	refilled = refillBuffers(toRefill);
+	if (toRefill != refilled) {
+		ENA_ERROR_LOG_EXT(_controller,
+			      "Refilling queue %d failed. Allocated %d buffers from %d\n",
+			      _qid, refilled, toRefill);
+	}
+
+	return true;
+}
+
+void ENARingRx::disable()
+{
+	freeBuffers();
+
+	if (_bufferInfo != nullptr) {
+		IODelete(_bufferInfo, ENARxBuffer, _queueSize);
+		_bufferInfo = nullptr;
+	}
+
+	ENARing::disable();
+}
+
+bool ENARingRx::allocMbuf(ENARxBuffer* rxInfo)
+{
+	IOMemoryCursor::PhysicalSegment seg;
+	errno_t error;
+	unsigned int maxChunks;
+	int nsegs;
+	int mlen;
+
+	// If previously allocated buffer was not used
+	if (rxInfo->mbuf != NULL)
+		return true;
+
+	maxChunks = 1;
+	// There is no guarantee that bigger cluster will be physically contiguous
+	mlen = MBIGCLBYTES;
+	// Get mbuf
+	error = mbuf_allocpacket(MBUF_WAITOK,
+				 mlen,
+				 &maxChunks,
+				 &rxInfo->mbuf);
+	if (error != 0) {
+		ENA_DEBUG_LOG_EXT(_controller,
+			      "Failed to allocate mbuf, error: %d\n", error);
+		incAtomicStat(&_rxStats.mbufAllocationFails);
+		return false;
+	}
+
+	mbuf_pkthdr_setlen(rxInfo->mbuf, mlen);
+	mbuf_setlen(rxInfo->mbuf, mlen);
+
+	// Map packets for DMA - only single segment is allowed. We are using
+	// cursor to make sure that the cluster is physically contiguous
+	nsegs = _mbufCursor->getPhysicalSegmentsWithCoalesce(rxInfo->mbuf, &seg, 1);
+	if (unlikely(nsegs != 1)) {
+		ENA_DEBUG_LOG_EXT(_controller, "Failed to map rx mbuf, nsegs %d\n", nsegs);
+		incAtomicStat(&_rxStats.dmaMappingErrors);
+		_controller->freePacket(rxInfo->mbuf);
+		rxInfo->mbuf = nullptr;
+		return false;
+	}
+
+	rxInfo->enaBuf.paddr = seg.location;
+	rxInfo->enaBuf.len = seg.length;
+
+	return true;
+}
+
+UInt32 ENARingRx::refillBuffers(UInt32 number)
+{
+	ENARxBuffer *rxInfo;
+	UInt32 i;
+	UInt16 reqID;
+	int rc;
+
+	ENA_DEBUG_LOG_EXT(_controller, "Refill of the Rx queue %d\n", _qid);
+	for (i = 0; i < number; i++) {
+		reqID = _freeIDs[_nextToUse];
+		rxInfo = &_bufferInfo[reqID];
+
+		if (!allocMbuf(rxInfo)) {
+			ENA_DEBUG_LOG_EXT(_controller, "Failed to alloc buffer for Rx queue %d\n", _qid);
+			break;
+		}
+
+		rc = ena_com_add_single_rx_desc(_ioSQ, &rxInfo->enaBuf, reqID);
+		if (rc != 0) {
+			ENA_DEBUG_LOG_EXT(_controller, "Failed to add descriptor for Rx queue %d\n", _qid);
+			break;
+		}
+
+		advanceIndex(_nextToUse);
+	}
+
+	if (i < number) {
+		incAtomicStat(&_rxStats.partialRefills);
+		ENA_DEBUG_LOG_EXT(_controller,
+			      "Refilled Rx queue %d with only %d mbufs (from %d)\n",
+			      _qid, i, number);
+	}
+
+	if (i != 0)
+		ena_com_write_sq_doorbell(_ioSQ);
+
+	return i;
+}
+
+void ENARingRx::freeBuffers()
+{
+	if (_bufferInfo == nullptr)
+		return;
+
+	for (int i = 0; i < _queueSize; i++) {
+		ENARxBuffer *rxInfo = &_bufferInfo[i];
+		if (rxInfo->mbuf != nullptr) {
+			_controller->freePacket(rxInfo->mbuf, 0);
+			rxInfo->mbuf = nullptr;
+		}
+	}
+}
+
+bool ENARingRx::validateReqID(UInt16 reqID)
+{
+	if (unlikely(!ENARing::validateReqID(reqID))) {
+		incAtomicStat(&_rxStats.badRequestedID);
+		_controller->triggerReset(ENA_REGS_RESET_INV_RX_REQ_ID);
+		return false;
+	}
+
+	return true;
+}
+
+int ENARingRx::interruptProcess()
+{
+	struct ena_com_rx_ctx enaRxCtx;
+	IOEthernetInterface *netif;
+	IONetworkStats *netStats;
+	ENAHWStats *hwStats;
+	mbuf_t mbuf;
+	UInt64 totalBytesReceived = 0;
+	UInt32 refillThreshold;
+	UInt32 refillRequired;
+	UInt16 totalPacketsReceived;
+	int budget = _packetCleanupBudget;
+	int rc;
+
+	_firstInterrupt = true;
+
+	netif = _controller->getEthernetInterface();
+	netStats = _controller->getNetworkStats();
+	hwStats = _controller->getHWStats();
+
+	enaRxCtx.ena_bufs = _enaBufs;
+	enaRxCtx.max_bufs = _maxSegNum;
+
+	assertf(budget > 0, "Rx budget for queue %d was not set!", _qid);
+	do {
+		enaRxCtx.descs = 0;
+
+		rc = ena_com_rx_pkt(_ioCQ, _ioSQ, &enaRxCtx);
+		if (rc != 0) {
+			ENA_ERROR_LOG_EXT(_controller,
+				      "Failed to get the Rx packet from the device on queue %d, rc: %d\n",
+				      _qid, rc);
+			_controller->incrementRxErrors();
+			incAtomicStat(&_rxStats.badDescriptorNumber);
+			_controller->triggerReset(ENA_REGS_RESET_TOO_MANY_RX_DESCS);
+			return 0;
+		}
+
+		if (enaRxCtx.descs == 0)
+			break;
+
+		ENA_DEBUG_LOG_EXT(
+			_controller,
+			"Rx: queue %d got packet from ENA. descs #: %d l3 proto %d l4 proto %d hash: %x\n",
+			_qid, enaRxCtx.descs, enaRxCtx.l3_proto, enaRxCtx.l4_proto, enaRxCtx.hash);
+
+		// Receive the data from the ring as an mbuf
+		mbuf = rxMbuf(&enaRxCtx);
+		// Exit if we failed to retrieve a buffer
+		if(mbuf == nullptr) {
+			for (int i = 0; i < enaRxCtx.descs; i++) {
+				_freeIDs[_nextToClean] = _enaBufs[i].req_id;
+				advanceIndex(_nextToClean);
+			}
+			_controller->incrementRxErrors();
+			break;
+		}
+		totalBytesReceived += mbuf_pkthdr_len(mbuf);
+
+		// Send the packet to the stack
+		_controller->lockInputQueue();
+		netif->inputPacket(mbuf, 0, IONetworkInterface::kInputOptionQueuePacket);
+		_controller->unlockInputQueue();
+	} while(--budget);
+
+	_controller->lockInputQueue();
+	netif->flushInputQueue();
+	_controller->unlockInputQueue();
+
+	totalPacketsReceived = _packetCleanupBudget - budget;
+
+	addAtomicStat(&_rxStats.bytes, totalBytesReceived);
+	addAtomicStat(&_rxStats.count, totalPacketsReceived);
+
+	refillRequired = ena_com_free_q_entries(_ioSQ);
+	refillThreshold = _queueSize / ENA_RX_REFILL_THRESH_DIVIDER;
+
+	if (refillRequired > refillThreshold) {
+		ena_com_update_dev_comp_head(_ioCQ);
+		refillBuffers(refillRequired);
+	}
+
+	return totalPacketsReceived;
+}
+
+bool ENARingRx::checkForInterrupt()
+{
+	if (likely(_firstInterrupt))
+		return true;
+
+	if (ena_com_cq_empty(_ioCQ))
+		return true;
+
+	++_noInterruptEventCount;
+
+	if (_noInterruptEventCount == ENA_MAX_NO_INTERRUPT_ITERATIONS) {
+		ENA_ERROR_LOG_EXT(_controller,
+			      "Potential MSIX issue on Rx side Queue = %d. Reset the device\n",
+			      _qid);
+
+		_noInterruptEventCount = 0;
+		_controller->triggerReset(ENA_REGS_RESET_MISS_INTERRUPT);
+		return false;
+	}
+
+	return true;
+}
+
+mbuf_t ENARingRx::rxMbuf(struct ena_com_rx_ctx *enaRxCtx)
+{
+	ENARxBuffer *rxInfo;
+	mbuf_t mbuf;
+	size_t totalSize = 0;
+	UInt16 descs;
+	UInt16 ntc, len, reqID;
+	UInt16 buf;
+
+	descs = enaRxCtx->descs;
+	ntc = _nextToClean;
+	rxInfo = &_bufferInfo[ntc];
+
+	if (unlikely(rxInfo->mbuf == nullptr)) {
+		ENA_ERROR_LOG_EXT(_controller, "NULL mbuf in rx_info\n");
+		return nullptr;
+	}
+
+	buf = 0;
+	len = _enaBufs[buf].len;
+	reqID = _enaBufs[buf].req_id;
+	if (unlikely(!validateReqID(reqID)))
+		return nullptr;
+
+	rxInfo = &_bufferInfo[reqID];
+
+	ENA_DEBUG_LOG_EXT(_controller, "rx_info %p, mbuf %p, paddr %lld\n",
+		rxInfo, rxInfo->mbuf, (uintmax_t) rxInfo->enaBuf.paddr);
+
+	mbuf = rxInfo->mbuf;
+	mbuf_setlen(mbuf, len);
+	totalSize += len;
+
+	ENA_DEBUG_LOG_EXT(_controller, "rx mbuf 0x%p, flags=0x%x, len: %d\n",
+		mbuf, mbuf_flags(mbuf), (int) mbuf_pkthdr_len(mbuf));
+
+	rxInfo->mbuf = nullptr;
+	_freeIDs[ntc] = reqID;
+	advanceIndex(ntc);
+
+	// While we have more than 1 descriptors for one rcvd packet, append
+	// other mbufs to the main one
+	while (--descs) {
+		buf++;
+		len = _enaBufs[buf].len;
+		reqID = _enaBufs[buf].req_id;
+		if (unlikely(!validateReqID(reqID))) {
+			_controller->freePacket(mbuf);
+			return nullptr;
+		}
+
+		ENA_DEBUG_LOG_EXT(_controller, "Rx - next decsriptor with len %d\n", len);
+
+		rxInfo = &_bufferInfo[reqID];
+
+		if (unlikely(rxInfo->mbuf == nullptr)) {
+			ENA_ERROR_LOG_EXT(_controller, "NULL mbuf in rx_info\n");
+			// If one of the required mbufs was not allocated yet,
+			// we can break there.
+			// All earlier used descriptors will be reallocated
+			// later and not used mbufs can be reused.
+			// The nextToClean pointer will not be updated in case
+			// of an error, so caller should advance it manually
+			// in error handling routine to keep it up to date
+			// with hw ring.
+			_controller->freePacket(mbuf);
+			return nullptr;
+		}
+		mbuf_setlen(rxInfo->mbuf, len);
+		totalSize += len;
+
+		mbuf = mbuf_concatenate(mbuf, rxInfo->mbuf);
+
+		ENA_DEBUG_LOG_EXT(_controller, "Rx mbuf appended. len %ld\n",
+			      mbuf_pkthdr_len(mbuf));
+
+		rxInfo->mbuf = nullptr;
+
+		_freeIDs[ntc] = reqID;
+		advanceIndex(ntc);
+	}
+
+	mbuf_pkthdr_setlen(mbuf, totalSize);
+	_nextToClean = ntc;
+
+	return mbuf;
+}
+
+const ENARxStats * ENARingRx::getRxStats() const
+{
+	return &_rxStats;
+}
+
+/***********************************************************
+ * ENAQueue definition
+ ***********************************************************/
+
+OSDefineMetaClassAndStructors(ENAQueue, OSObject)
+
+ENAQueue * ENAQueue::withConfig(ENA *controller,
+				ENARingTx::TxConfig *txConfig,
+				ENARingRx::RxConfig *rxConfig)
+{
+	ENAQueue *queue = new ENAQueue;
+
+	if (queue != nullptr) {
+		if (!queue->init(controller, txConfig, rxConfig)) {
+			queue->release();
+			queue = nullptr;
+		}
+	}
+
+	return queue;
+}
+
+bool ENAQueue::init(ENA *controller, ENARingTx::TxConfig *txConfig, ENARingRx::RxConfig *rxConfig)
+{
+	if (!OSObject::init())
+		return false;
+
+	_txRing = ENARingTx::withConfig(controller, txConfig);
+	if (_txRing == nullptr)
+		return false;
+
+	_rxRing = ENARingRx::withConfig(controller, rxConfig);
+	if (_rxRing == nullptr)
+		return false;
+
+	ENATask::Action action = OSMemberFunctionCast(
+		ENATask::Action,
+		this,
+		&ENAQueue::handleInterrupt);
+	_ioTask = ENATask::withAction(this, action);
+	if (_ioTask == nullptr)
+		return false;
+
+	_qid = txConfig->qid;
+	_controller = controller;
+
+	return true;
+}
+
+void ENAQueue::free()
+{
+	SAFE_RELEASE(_ioTask);
+
+	SAFE_RELEASE(_rxRing);
+	SAFE_RELEASE(_txRing);
+
+	OSObject::free();
+}
+
+bool ENAQueue::enable()
+{
+	if (!_txRing->enable()) {
+		ENA_ERROR_LOG_EXT(_controller, "Failed to enable Tx ring\n");
+		return false;
+	}
+
+	if (!_rxRing->enable()) {
+		ENA_ERROR_LOG_EXT(_controller, "Failed to enable Rx ring\n");
+		return false;
+	}
+
+	if (!enableIOInterruptHandler()) {
+		ENA_ERROR_LOG_EXT(_controller, "Failed to enable IO interrupt handlers\n");
+		return false;
+	}
+
+	return true;
+}
+
+void ENAQueue::disable()
+{
+	disableIOInterruptHandler();
+	_txRing->disable();
+	_rxRing->disable();
+}
+
+ENARingTx * ENAQueue::getTxRing()
+{
+	return _txRing;
+}
+
+ENARingRx * ENAQueue::getRxRing()
+{
+	return _rxRing;
+}
+
+UInt16 ENAQueue::getID()
+{
+	return _qid;
+}
+
+void ENAQueue::unmaskIOInterrupt(UInt32 rxDelay, UInt32 txDelay)
+{
+	struct ena_com_io_cq *ioCQ;
+	struct ena_eth_io_intr_reg intrReg;
+	UInt16 ioQID;
+
+	ioQID = ENA_IO_TXQ_IDX(_qid);
+	ioCQ = &_controller->getENADevice()->io_cq_queues[ioQID];
+
+	ena_com_update_intr_reg(&intrReg, rxDelay, txDelay, true);
+	ena_com_unmask_intr(ioCQ, &intrReg);
+}
+
+// This function should be called only from handleMainInterrupt()
+void ENAQueue::interruptOccurred()
+{
+	_ioTask->callTask();
+}
+
+void ENAQueue::handleInterrupt()
+{
+	ENA_DEBUG_LOG_EXT(_controller, "ENAQueue::handleInterrupt for queue %d\n", _qid);
+
+	for (int i = 0; i < ENA_CLEANUP_BUDGET; ++i) {
+		if (unlikely(!_controller->testFlag(ENA_FLAG_DEV_UP)))
+			return;
+
+		int rxc = _rxRing->interruptProcess();
+		int txc = _txRing->interruptProcess();
+
+		// Stay in the loop only if at least one path depleted its budget
+		if (rxc != _rxRing->getPacketCleanupBudget()  &&
+		    txc != _txRing->getPacketCleanupBudget())
+			break;
+	}
+
+	_controller->handleInterruptCompleted(this);
+}
+
+bool ENAQueue::enableIOInterruptHandler()
+{
+	_ioTask->enable();
+
+	return true;
+}
+
+void ENAQueue::disableIOInterruptHandler()
+{
+	_ioTask->disable();
+}

--- a/kernel/macOS/ena/ENARings.hpp
+++ b/kernel/macOS/ena/ENARings.hpp
@@ -1,0 +1,240 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef _ENARINGS_HPP
+#define _ENARINGS_HPP
+
+#include "ENATask.hpp"
+#include "ENATime.hpp"
+#include "ENAUtils.hpp"
+
+#include "ena_com/ena_eth_com.h"
+
+#include <sys/kernel_types.h>
+
+#include <IOKit/network/IOMbufMemoryCursor.h>
+
+constexpr UInt16 enaPktMaxBufs = 19;
+
+/***********************************************************
+ * ENARing class
+ ***********************************************************/
+
+class ENA;
+
+class ENARing : public OSObject
+{
+	OSDeclareAbstractStructors(ENARing)
+public:
+	struct Config
+	{
+		enum ena_admin_placement_policy_type memQueueType;
+		UInt32 queueSize;
+		UInt32 maxSegmentSize;
+		UInt16 maxSegmentsNumber;
+		UInt16 packetCleanupBudget;
+		UInt16 qid;
+	};
+
+	// The enable and the disable should only be called after the ENA
+	// controller was successfully started.
+	virtual bool enable();
+	virtual void disable();
+
+	UInt16 getPacketCleanupBudget();
+
+	virtual int interruptProcess() = 0;
+
+protected:
+	IOMbufNaturalMemoryCursor *_mbufCursor;
+	ENA			*_controller;
+	struct ena_com_io_sq	*_ioSQ;
+	struct ena_com_io_cq	*_ioCQ;
+	enum ena_admin_placement_policy_type _memQueueType;
+	enum queue_direction    _direction;
+	UInt32			_queueSize;
+	UInt16			*_freeIDs;
+	UInt16			_packetCleanupBudget;
+	UInt16			_maxSegNum;	// Maximum number of segments
+	UInt16			_nextToUse;
+	UInt16			_nextToClean;
+	UInt16			_qid;
+	UInt16			_ioqid;
+	bool			_firstInterrupt;
+
+	bool init(ENA *controller, Config *config);
+	virtual void free() APPLE_KEXT_OVERRIDE;
+
+	bool createIOQueue();
+	void destroyIOQueue();
+
+	virtual void freeBuffers() = 0;
+
+	void advanceIndex(UInt16 &index);
+
+	virtual bool validateReqID(UInt16 reqID);
+};
+
+/***********************************************************
+ * ENARingTx class and dependencies
+ ***********************************************************/
+
+struct ENATxBuffer
+{
+	mbuf_t			mbuf;
+	struct ena_com_buf	enaBufs[enaPktMaxBufs];
+	int			descs;
+	ENATime			timestamp;
+	bool			printOnce;
+};
+
+struct ENATxStats
+{
+	AtomicStat count;
+	AtomicStat bytes;
+	AtomicStat prepareContextErrors;
+	AtomicStat dmaMappingErrors;
+	AtomicStat doorbells;
+	AtomicStat missingCompletions;
+	AtomicStat badRequestedID;
+	AtomicStat queueWakeups;
+	AtomicStat queueStops;
+};
+constexpr size_t ENATxStatsNum = sizeof(ENATxStats)/sizeof(AtomicStat);
+
+class ENARingTx : public ENARing
+{
+	OSDeclareDefaultStructors(ENARingTx)
+public:
+	typedef ENARing::Config TxConfig;
+
+	static ENARingTx * withConfig(ENA *controller, TxConfig *config);
+
+	bool enable() APPLE_KEXT_OVERRIDE;
+	void disable() APPLE_KEXT_OVERRIDE;
+
+	int interruptProcess() APPLE_KEXT_OVERRIDE;
+
+	UInt32 sendPacket(mbuf_t mbuf, void *param);
+
+	bool checkForMissingCompletions();
+	void setupMissingTxCompletion(ENATime timeout, UInt32 threshold);
+
+	const ENATxStats * getTxStats() const;
+
+private:
+	ENATxBuffer		*_bufferInfo;
+	ENATxStats		_txStats;
+	ENATime			_missingTxCompletionTimeout;
+	UInt32			_missingTxCompletionThreshold;
+	UInt16			_doorbellBurstCount;
+	bool			_txStalled;
+
+	constexpr static UInt16 DOORBELL_BURST_THRESHOLD = 32;
+
+	bool init(ENA *controller, TxConfig *config);
+	void freeBuffers() APPLE_KEXT_OVERRIDE;
+
+	bool validateReqID(UInt16 reqID) APPLE_KEXT_OVERRIDE;
+};
+
+/***********************************************************
+ * ENARingRx class and dependencies
+ ***********************************************************/
+
+struct ENARxBuffer
+{
+	mbuf_t			mbuf;
+	struct ena_com_buf	enaBuf;
+};
+
+struct ENARxStats
+{
+	AtomicStat count;
+	AtomicStat bytes;
+	AtomicStat partialRefills;
+	AtomicStat badChecksum;
+	AtomicStat mbufAllocationFails;
+	AtomicStat dmaMappingErrors;
+	AtomicStat badRequestedID;
+	AtomicStat badDescriptorNumber;
+};
+constexpr size_t ENARxStatsNum = sizeof(ENARxStats)/sizeof(AtomicStat);
+
+class ENARingRx : public ENARing
+{
+	OSDeclareDefaultStructors(ENARingRx)
+public:
+	typedef ENARing::Config RxConfig;
+
+	static ENARingRx * withConfig(ENA *controller, RxConfig *config);
+
+	bool enable() APPLE_KEXT_OVERRIDE;
+	void disable() APPLE_KEXT_OVERRIDE;
+
+	int interruptProcess() APPLE_KEXT_OVERRIDE;
+
+	bool checkForInterrupt();
+
+	const ENARxStats * getRxStats() const;
+
+private:
+	struct ena_com_rx_buf_info _enaBufs[enaPktMaxBufs];
+	ENARxBuffer		*_bufferInfo;
+	ENARxStats		_rxStats;
+	UInt32			_noInterruptEventCount;
+
+	bool init(ENA *controller, RxConfig *config);
+
+	bool allocMbuf(ENARxBuffer* rxInfo);
+
+	UInt32 refillBuffers(UInt32 number);
+	void freeBuffers() APPLE_KEXT_OVERRIDE;
+
+	bool validateReqID(UInt16 reqID) APPLE_KEXT_OVERRIDE;
+
+	mbuf_t rxMbuf(struct ena_com_rx_ctx *enaRxContext);
+};
+
+/***********************************************************
+ * ENAQueue class
+ ***********************************************************/
+
+class ENAQueue : public OSObject
+{
+	OSDeclareDefaultStructors(ENAQueue)
+public:
+	static ENAQueue * withConfig(ENA *controller,
+				     ENARingTx::TxConfig *txConfig,
+				     ENARingRx::RxConfig *rxConfig);
+
+	bool enable();
+	void disable();
+
+	ENARingTx * getTxRing();
+	ENARingRx * getRxRing();
+
+	UInt16 getID();
+
+	void unmaskIOInterrupt(UInt32 rxDelay = 0, UInt32 txDelay = 0);
+	void interruptOccurred();
+
+private:
+	ENA			*_controller;
+	ENARingTx 		*_txRing;
+	ENARingRx 		*_rxRing;
+	ENATask			*_ioTask;
+	UInt16			_qid;
+
+	bool init(ENA *controller,
+		  ENARingTx::TxConfig *txConfig,
+		  ENARingRx::RxConfig *rxConfig);
+	void free() APPLE_KEXT_OVERRIDE;
+
+	bool enableIOInterruptHandler();
+	void disableIOInterruptHandler();
+
+	void handleInterrupt();
+};
+
+#endif // _ENARINGS_HPP

--- a/kernel/macOS/ena/ENATask.cpp
+++ b/kernel/macOS/ena/ENATask.cpp
@@ -1,0 +1,123 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+#include "ENATask.hpp"
+
+#define super OSObject
+
+OSDefineMetaClassAndStructors(ENATask, super)
+
+ENATask * ENATask::withAction(OSObject *owner, Action action)
+{
+	ENATask *task = new ENATask;
+
+	if (task != nullptr && !task->init(owner, action)) {
+		task->release();
+		return nullptr;
+	}
+
+	return task;
+}
+
+bool ENATask::init(OSObject *owner, Action action)
+{
+	if (!super::init())
+		return false;
+
+	_isEnabled = false;
+	_flagLock = IOSimpleLockAlloc();
+	if (_flagLock == nullptr)
+		return false;
+	IOSimpleLockInit(_flagLock);
+
+	_taskLock = IOLockAlloc();
+	if (_taskLock == nullptr)
+		return false;
+
+	_owner = owner;
+	_handler = action;
+
+	_terminate = false;
+	_workToDo = false;
+	thread_continue_t cptr = OSMemberFunctionCast(thread_continue_t, this, &ENATask::mainThread);
+	if (kernel_thread_start(cptr, this, &_taskThread) != KERN_SUCCESS)
+		return false;
+
+	return true;
+}
+
+void ENATask::free()
+{
+	if (_taskThread != nullptr) {
+		// First entry for the free, called by release(). Perform cleanup
+		// of the working thread by setting terminate flag.
+		disable();
+		lockTask();
+		IOInterruptState is = IOSimpleLockLockDisableInterrupt(_flagLock);
+		_terminate = true;
+		thread_wakeup_one((void *)&_workToDo);
+		IOSimpleLockUnlockEnableInterrupt(_flagLock, is);
+		unlockTask();
+	} else {
+		// The _taskThread is calling free for the second time, as it is
+		// now safe to release rest of the resources when the main thread
+		// is done. The second case is partial initialization.
+		if (_taskLock) {
+			IOLockFree(_taskLock);
+			_taskLock = nullptr;
+		}
+
+		if (_flagLock != nullptr) {
+			IOSimpleLockFree(_flagLock);
+			_flagLock = nullptr;
+		}
+
+		super::free();
+	}
+}
+
+void ENATask::mainThread()
+{
+	// Execute handler as long as there is work to be done
+	while (!_terminate) {
+		IOInterruptState is = IOSimpleLockLockDisableInterrupt(_flagLock);
+		_workToDo = false;
+		IOSimpleLockUnlockEnableInterrupt(_flagLock, is);
+
+		lockTask();
+		if (_isEnabled)
+			_handler(_owner);
+		unlockTask();
+
+		is = IOSimpleLockLockDisableInterrupt(_flagLock);
+		if (!_terminate && !_workToDo) {
+			// Declare, that the thread is going to wait on _workToDo event
+			assert_wait((event_t *) &_workToDo, THREAD_UNINT);
+			IOSimpleLockUnlockEnableInterrupt(_flagLock, is);
+
+			thread_continue_t cptr = NULL;
+
+			cptr = OSMemberFunctionCast(
+				thread_continue_t, this, &ENATask::mainThread);
+			// Reschedule process and wait for the event - when the
+			// event occurs, it will discard current kernel stack
+			// of the thread and run below function
+			thread_block_parameter(cptr, this);
+			/* NOT REACHED */
+		}
+
+		// At this point there is either more work to be done or thread
+		// must commit suicide. But no matter what, clear the simple
+		// lock and retore the interrupt state
+		IOSimpleLockUnlockEnableInterrupt(_flagLock, is);
+	}
+
+	thread_t thread = _taskThread;
+	_taskThread = nullptr;
+	// Commit suicide - the second call of free from thread context is
+	// cleaning up rest of the resources.
+	free();
+
+	thread_deallocate(thread);
+	thread_terminate(thread);
+}

--- a/kernel/macOS/ena/ENATask.hpp
+++ b/kernel/macOS/ena/ENATask.hpp
@@ -1,0 +1,82 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef _ENATASK_HPP
+#define _ENATASK_HPP
+
+#include <libkern/c++/OSObject.h>
+
+#include <IOKit/IOLib.h>
+
+class ENATask : public OSObject
+{
+	OSDeclareAbstractStructors(ENATask)
+public:
+	typedef void (*Action)(OSObject *owner);
+
+	static ENATask *withAction(OSObject *owner, Action action);
+
+	bool init(OSObject *owner, Action action);
+
+	void enable();
+	void disable();
+
+	void callTask();
+
+private:
+	OSObject		*_owner;
+	IOLock			*_taskLock;
+	IOSimpleLock		*_flagLock;
+	IOThread		_taskThread;
+	Action			_handler;
+	bool			_workToDo;
+	bool			_terminate;
+	bool			_isEnabled;
+
+	void free() APPLE_KEXT_OVERRIDE;
+
+	void mainThread();
+
+	void lockTask();
+	void unlockTask();
+};
+
+/***********************************************************
+ * Inline definitions
+ ***********************************************************/
+
+inline void ENATask::lockTask()
+{
+	IOLockLock(_taskLock);
+}
+
+inline void ENATask::unlockTask()
+{
+	IOLockUnlock(_taskLock);
+}
+
+inline void ENATask::enable()
+{
+	lockTask();
+	_isEnabled = true;
+	unlockTask();
+}
+
+inline void ENATask::disable()
+{
+	lockTask();
+	_isEnabled = false;
+	unlockTask();
+}
+
+inline void ENATask::callTask()
+{
+	if (_taskThread != nullptr) {
+		IOInterruptState is = IOSimpleLockLockDisableInterrupt(_flagLock);
+		_workToDo = true;
+		thread_wakeup_one((void *)&_workToDo);
+		IOSimpleLockUnlockEnableInterrupt(_flagLock, is);
+	}
+}
+
+#endif // _ENATASK_HPP

--- a/kernel/macOS/ena/ENATime.hpp
+++ b/kernel/macOS/ena/ENATime.hpp
@@ -1,0 +1,247 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef _ENATIME_HPP
+#define _ENATIME_HPP
+
+#include <kern/clock.h>
+
+#include <libkern/OSTypes.h>
+
+class ENATime
+{
+public:
+	static ENATime getNow();
+
+	ENATime() = default;
+	ENATime(AbsoluteTime time);
+
+	ENATime & setNow();
+	ENATime & addAbsoluteTimeFromNow(AbsoluteTime time);
+	ENATime & addSecondsFromNow(UInt64 seconds);
+	ENATime & addMillisecondsFromNow(UInt64 milliseconds);
+	ENATime & addMicrosecondsFromNow(UInt64 microseconds);
+
+	ENATime & addAbsoluteTime(AbsoluteTime time);
+	ENATime & addSeconds(UInt64 seconds);
+	ENATime & addMilliseconds(UInt64 milliseconds);
+	ENATime & addMicroseconds(UInt64 microseconds);
+
+	ENATime & setAbsoluteTime(UInt64 time);
+	ENATime & setSeconds(UInt64 seconds);
+	ENATime & setMilliseconds(UInt64 milliseconds);
+	ENATime & setMicroseconds(UInt64 microseconds);
+
+	AbsoluteTime getAbsoluteTime();
+	uint64_t getSeconds();
+	uint64_t getMilliseconds();
+	uint64_t getMicroseconds();
+
+	ENATime & operator=(AbsoluteTime time);
+
+	ENATime & operator+=(const ENATime &other);
+	ENATime & operator-=(const ENATime &other);
+	ENATime & operator*=(const ENATime &other);
+
+	ENATime operator+(const ENATime &second) const;
+	ENATime operator-(const ENATime &second) const;
+	ENATime operator*(int value) const;
+
+	bool operator>(const ENATime &second) const;
+	bool operator>=(const ENATime &second) const;
+	bool operator<(const ENATime &second) const;
+	bool operator<=(const ENATime &second) const;
+	bool operator==(const ENATime &second) const;
+	bool operator==(AbsoluteTime absoluteTime) const;
+	bool operator!=(const ENATime &second) const;
+
+private:
+	AbsoluteTime _time;
+};
+
+/***********************************************************
+ * Interface functions
+ ***********************************************************/
+
+bool operator==(AbsoluteTime absoluteTime, const ENATime &enaTime);
+ENATime operator*(int value, const ENATime &time);
+
+/***********************************************************
+ * Inline definitions
+ ***********************************************************/
+
+inline ENATime::ENATime(AbsoluteTime time) : _time(time)
+{
+
+}
+
+inline ENATime ENATime::getNow()
+{
+	return ENATime(mach_absolute_time());
+}
+
+inline ENATime & ENATime::setNow()
+{
+	_time = mach_absolute_time();
+	return *this;
+}
+
+inline ENATime & ENATime::addAbsoluteTimeFromNow(AbsoluteTime time)
+{
+	_time = mach_absolute_time() + time;
+	return *this;
+}
+
+inline ENATime & ENATime::addSecondsFromNow(UInt64 seconds)
+{
+	addMillisecondsFromNow(seconds*1000);
+	return *this;
+}
+
+inline ENATime & ENATime::addMillisecondsFromNow(UInt64 milliseconds)
+{
+	addMicrosecondsFromNow(milliseconds*1000);
+	return *this;
+}
+
+inline ENATime & ENATime::addMicrosecondsFromNow(UInt64 microseconds)
+{
+	nanoseconds_to_absolutetime(microseconds*1000, &_time);
+	_time += mach_absolute_time();
+	return *this;
+}
+
+inline ENATime & ENATime::setAbsoluteTime(UInt64 time)
+{
+	_time = time;
+	return *this;
+}
+
+inline ENATime & ENATime::setSeconds(UInt64 seconds)
+{
+	setMilliseconds(seconds*1000);
+	return *this;
+}
+
+inline ENATime & ENATime::setMilliseconds(UInt64 milliseconds)
+{
+	setMicroseconds(milliseconds*1000);
+	return *this;
+}
+
+inline ENATime & ENATime::setMicroseconds(UInt64 microseconds)
+{
+	nanoseconds_to_absolutetime(microseconds*1000, &_time);
+	return *this;
+}
+
+inline UInt64 ENATime::getAbsoluteTime()
+{
+	return _time;
+}
+
+inline UInt64 ENATime::getSeconds()
+{
+	return getMilliseconds()/1000;
+}
+
+inline UInt64 ENATime::getMilliseconds()
+{
+	return getMicroseconds()/1000;
+}
+
+inline UInt64 ENATime::getMicroseconds()
+{
+	UInt64 microseconds;
+	absolutetime_to_nanoseconds(_time, &microseconds);
+
+	// Convert nanoseconds to microseconds
+	microseconds /= 1000;
+	return microseconds;
+}
+
+inline ENATime & ENATime::operator+=(const ENATime &other)
+{
+	_time += other._time;
+	return *this;
+}
+
+inline ENATime & ENATime::operator-=(const ENATime &other)
+{
+	_time -= other._time;
+	return *this;
+}
+
+inline ENATime & ENATime::operator*=(const ENATime &other)
+{
+	_time *= other._time;
+	return *this;
+}
+
+inline ENATime & ENATime::operator=(AbsoluteTime time)
+{
+	_time = time;
+	return *this;
+}
+
+inline bool ENATime::operator>(const ENATime &second) const
+{
+	return !(*this <= second);
+}
+
+inline bool ENATime::operator>=(const ENATime &second) const
+{
+	return !(*this < second);
+}
+
+inline bool ENATime::operator<(const ENATime &second) const
+{
+	return _time < second._time;
+}
+
+inline bool ENATime::operator<=(const ENATime &second) const
+{
+	return (*this < second || *this == second);
+}
+
+inline bool ENATime::operator==(const ENATime &second) const
+{
+	return _time == second._time;
+}
+
+inline bool ENATime::operator==(AbsoluteTime absoluteTime) const
+{
+	return _time == absoluteTime;
+}
+
+inline bool ENATime::operator!=(const ENATime &second) const
+{
+	return !(*this == second);
+}
+
+inline ENATime ENATime::operator+(const ENATime &second) const
+{
+	return ENATime(_time + second._time);
+}
+
+inline ENATime ENATime::operator-(const ENATime &second) const
+{
+	return ENATime(_time - second._time);
+}
+
+inline ENATime ENATime::operator*(int value) const
+{
+	return ENATime(_time * value);
+}
+
+inline bool operator==(AbsoluteTime absoluteTime, const ENATime &enaTime)
+{
+	return enaTime == absoluteTime;
+}
+
+inline ENATime operator*(int value, const ENATime &time)
+{
+	return time * value;
+}
+
+#endif // _ENATIME_HPP

--- a/kernel/macOS/ena/ENAToeplitzHash.cpp
+++ b/kernel/macOS/ena/ENAToeplitzHash.cpp
@@ -1,0 +1,45 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+#include "ENAToeplitzHash.hpp"
+
+#define super ENAHash
+OSDefineMetaClassAndStructors(ENAToeplitzHash, ENAHash)
+
+ENAToeplitzHash * ENAToeplitzHash::withKey(const UInt8 *key, size_t keyLen)
+{
+	ENAToeplitzHash *toeplitzHash = new ENAToeplitzHash;
+
+	if (toeplitzHash != nullptr && !toeplitzHash->init(key, keyLen))
+	{
+		toeplitzHash->release();
+		toeplitzHash = nullptr;
+	}
+
+	return toeplitzHash;
+}
+
+UInt32 ENAToeplitzHash::getHash(const UInt8 *data, size_t dataSize)
+{
+	UInt32 keyWindow;
+	UInt32 hash = 0;
+	UInt32 i, b;
+
+	keyWindow = (_key[0] << 24) + (_key[1] << 16) + (_key[2] << 8) + _key[3];
+
+	// Iterate over data
+	for (i = 0; i < dataSize; ++i) {
+		// Iterate over byte
+		for (b = 0; b < 8; ++b) {
+			if (data[i] & (1 << (7 - b)))
+				hash ^= keyWindow;
+			keyWindow <<= 1;
+
+			// Read next bit of the key if possible
+			if ((i + 4) < _keyLen && (_key[i + 4] & (1 << (7 - b))))
+				keyWindow |= 1;
+		}
+	}
+
+	return hash;
+}

--- a/kernel/macOS/ena/ENAToeplitzHash.hpp
+++ b/kernel/macOS/ena/ENAToeplitzHash.hpp
@@ -1,0 +1,32 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef _ENATOEPLITZHASH_HPP__
+#define _ENATOEPLITZHASH_HPP__
+
+#include "ENAHash.hpp"
+
+class ENAToeplitzHash : public ENAHash
+{
+	OSDeclareDefaultStructors(ENAToeplitzHash);
+public:
+
+/*!	@function withKey
+	@abstract Factory method that constructs and initializes an
+	ENAToeplitzHash object.
+	@param key Key for hash function.
+	@param keyLen Length of the key in bytes.
+	@result Returns an ENAToeplitzHash object on success, or 0 otherwise.
+*/
+	static ENAToeplitzHash * withKey(const UInt8 *key, size_t keyLen);
+
+/*!	@function getHash
+	@abstract Calculates hash for given data using Toeplitz algorithm.
+	@param data Array of bytes, for which the hash has to be calculated.
+	@param dataSize Size of the data in bytes.
+	@result Returns hash calculated using Toeplitz algorithm.
+*/
+	UInt32 getHash(const UInt8 *data, size_t dataSize) APPLE_KEXT_OVERRIDE;
+};
+
+#endif

--- a/kernel/macOS/ena/ENAUtils.cpp
+++ b/kernel/macOS/ena/ENAUtils.cpp
@@ -1,0 +1,24 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+#include "ENAUtils.hpp"
+
+#include <libkern/c++/OSNumber.h>
+
+OSArray *getArrayWithNumbers(unsigned int count)
+{
+	OSArray *array = OSArray::withCapacity(count);
+	if (array == nullptr)
+		return nullptr;
+
+	for (size_t n = 0; n < count; ++n) {
+		OSNumber *number = OSNumber::withNumber(0ULL, 64);
+		if (number == nullptr) {
+			array->release();
+			return nullptr;
+		}
+		array->setObject(number);
+	}
+
+	return array;
+}

--- a/kernel/macOS/ena/ENAUtils.hpp
+++ b/kernel/macOS/ena/ENAUtils.hpp
@@ -1,0 +1,51 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef _ENAUTILS_HPP
+#define _ENAUTILS_HPP
+
+#include <libkern/OSTypes.h>
+#include <libkern/c++/OSArray.h>
+
+#include <stdatomic.h>
+
+#define SAFE_RELEASE(o) do {		\
+	if (o != nullptr) {		\
+		(o)->release();		\
+		(o) = nullptr;		\
+	}				\
+} while(0)
+
+#define ENA AmazonENAEthernet
+
+typedef atomic_uint_fast64_t AtomicStat;
+
+static inline void initAtomicStats(AtomicStat *stats, size_t count)
+{
+	for (size_t i = 0; i < count; ++i, ++stats)
+		atomic_init(stats, 0);
+}
+
+static inline void addAtomicStat(AtomicStat *stat, UInt64 value)
+{
+	atomic_fetch_add_explicit(stat, value, memory_order_relaxed);
+}
+
+static inline void incAtomicStat(AtomicStat *stat)
+{
+	atomic_fetch_add_explicit(stat, 1, memory_order_relaxed);
+}
+
+static inline UInt64 getAtomicStat(const AtomicStat *stat)
+{
+	return atomic_load_explicit(stat, memory_order_relaxed);
+}
+
+static inline void setAtomicStat(AtomicStat *stat, UInt64 value)
+{
+	return atomic_store_explicit(stat, value, memory_order_relaxed);
+}
+
+OSArray *getArrayWithNumbers(unsigned int count);
+
+#endif // _ENAUTILS_HPP

--- a/kernel/macOS/ena/Info.plist
+++ b/kernel/macOS/ena/Info.plist
@@ -1,0 +1,59 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>$(DEVELOPMENT_LANGUAGE)</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>KEXT</string>
+	<key>CFBundleShortVersionString</key>
+	<string>${MODULE_VERSION}</string>
+	<key>CFBundleVersion</key>
+	<string>${MODULE_VERSION}</string>
+	<key>IOKitPersonalities</key>
+	<dict>
+		<key>AmazonENAEthernet</key>
+		<dict>
+			<key>CFBundleIdentifier</key>
+			<string>${PRODUCT_BUNDLE_IDENTIFIER}</string>
+			<key>IOClass</key>
+			<string>AmazonENAEthernet</string>
+			<key>IOKitDebug</key>
+			<integer>0</integer>
+			<key>IOPCIMatch</key>
+			<string>0x0ec21d0f 0xec201d0f</string>
+			<key>IOPCITunnelCompatible</key>
+			<true/>
+			<key>IOProviderClass</key>
+			<string>IOPCIDevice</string>
+		</dict>
+	</dict>
+	<key>NSHumanReadableCopyright</key>
+	<string>Copyright © 2020 Amazon. All rights reserved.</string>
+	<key>OSBundleLibraries</key>
+	<dict>
+		<key>com.apple.iokit.IONetworkingFamily</key>
+		<string>3.4</string>
+		<key>com.apple.iokit.IOPCIFamily</key>
+		<string>2.9</string>
+		<key>com.apple.kpi.bsd</key>
+		<string>18.2</string>
+		<key>com.apple.kpi.iokit</key>
+		<string>18.2</string>
+		<key>com.apple.kpi.libkern</key>
+		<string>18.2</string>
+		<key>com.apple.kpi.mach</key>
+		<string>18.2</string>
+	</dict>
+	<key>OSBundleRequired</key>
+	<string>Root</string>
+</dict>
+</plist>

--- a/kernel/macOS/ena/LICENSE
+++ b/kernel/macOS/ena/LICENSE
@@ -1,0 +1,177 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS

--- a/kernel/macOS/ena/NOTICE
+++ b/kernel/macOS/ena/NOTICE
@@ -1,0 +1,2 @@
+AmazonENAEthernet
+Copyright 2019-2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.

--- a/kernel/macOS/ena/README
+++ b/kernel/macOS/ena/README
@@ -1,0 +1,90 @@
+macOS kernel extension for Elastic Network Adapter (ENA) family:
+================================================================
+
+Version:
+========
+v1.5.0
+
+Supported macOS Versions:
+=========================
+- macOS Mojave   10.14.x
+- macOS Catalina 10.15.x
+
+Overview:
+=========
+ENA is a networking interface designed to make good use of modern CPU
+features and system architectures.
+
+The ENA device exposes a lightweight management interface with a
+minimal set of memory mapped registers and extendable command set
+through an Admin Queue.
+
+Driver compilation:
+===================
+Prerequisites:
+--------------
+Compatible macOS SDK and Xcode
+i.e.	for macOS 10.14.6, use Xcode 10.3
+	for macOS 10.15.7, use Xcode 12.1
+
+Compilation:
+------------
+1. Enter the ena directory and execute xcodebuild:
+$ cd amzn-drivers/kernel/macOS/ena/
+$ xcodebuild
+2. When xcodebuild completes the compilation, AmazonENAEthernet.kext is created inside the folder build/Release/
+
+* The driver is not signed and can't be loaded without SIP (System Integrity Protection) disabled.
+
+Driver installation:
+====================
+Adjusting the driver for loading:
+---------------------------------
+$ cd ./build/Release/
+$ sudo chown -R root:wheel AmazonENAEthernet.kext
+
+Loading driver (Kernel extension):
+----------------------------------
+$ sudo kextload AmazonENAEthernet.kext
+
+For automatic driver load upon OS boot:
+---------------------------------------
+$ sudo cp -r AmazonENAEthernet.kext /Library/Extensions
+
+ENA Source Code Directory Structure:
+====================================
+ENA.[cpp|hpp]				- Main macOS kernel driver.
+ENAHash.[cpp|hpp]			- ENAHash class, interface for calculating hash for packets.
+ENALogs.hpp				- Definition of the logging functions.
+ENANaiveHash.[cpp|hpp]			- ENANaiveHash class, implements naive hash calculation.
+ENAParallelOutputQueue.[cpp|hpp]	- ENAParallelOutputQueue class, responsible for the Output queue (TX).
+ENAProperties.[cpp|hpp]			- ENAProperties class, holds the ENA statistics / properties reported to the OS.
+ENARings.[cpp|hpp]			- Rings-related classes, holds the data structures for the I/O flows.
+ENATask.[cpp|hpp]			- ENATask class, a mechanism for handling tasks asynchronously.
+ENATime.hpp				- ENATime class, responsible for time operations.
+ENAToeplitzHash.[cpp|hpp]		- ENAToeplitzHash class, implements Toeplitz hash calculation.
+ENAUtils.[cpp|hpp]			- Common util functions.
+Info.plist				- Information property list.
+AmazonENAEthernet.xcodeproj/		- Xcode project files.
+ena_com/				- ENA device hardware abstraction layer.
+
+
+Driver tunables:
+================
+Change MTU:
+-----------
+The driver supports an arbitrarily large MTU with a maximum that is
+negotiated with the device. The driver configures MTU using the
+SetFeature command (ENA_ADMIN_MTU property).
+command: networksetup -setMTU <hardwareport or device name> <value>
+
+Statistics:
+===========
+The user can obtain ENA device and driver statistics using ioreg utility.
+command: ioreg -n AmazonENAEthernet -r
+
+Stateless Offloads:
+===================
+The ENA driver supports:
+- IPv4 header checksum offload (TX only)
+- TCP/UDP over IPv4 checksum offloads (TX only)

--- a/kernel/macOS/ena/RELEASENOTES.md
+++ b/kernel/macOS/ena/RELEASENOTES.md
@@ -1,0 +1,8 @@
+# ENA macOS Kernel Extension Release Notes
+
+## Supported Kernel Versions
+* macOS Mojave   10.14.x
+* macOS Catalina 10.15.x
+
+## r1.5.0 release notes
+Initial commit of the macOS driver.

--- a/kernel/macOS/ena/ena_com/ena_com.c
+++ b/kernel/macOS/ena/ena_com/ena_com.c
@@ -1,0 +1,3075 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+#include "ena_com.h"
+
+/*****************************************************************************/
+/*****************************************************************************/
+
+/* Timeout in micro-sec */
+#define ADMIN_CMD_TIMEOUT_US (3000000)
+
+#define ENA_ASYNC_QUEUE_DEPTH 16
+#define ENA_ADMIN_QUEUE_DEPTH 32
+
+#ifdef ENA_EXTENDED_STATS
+
+#define ENA_HISTOGRAM_ACTIVE_MASK_OFFSET 0xF08
+#define ENA_EXTENDED_STAT_GET_FUNCT(_funct_queue) (_funct_queue & 0xFFFF)
+#define ENA_EXTENDED_STAT_GET_QUEUE(_funct_queue) (_funct_queue >> 16)
+
+#endif /* ENA_EXTENDED_STATS */
+
+#define ENA_CTRL_MAJOR		0
+#define ENA_CTRL_MINOR		0
+#define ENA_CTRL_SUB_MINOR	1
+
+#define MIN_ENA_CTRL_VER \
+	(((ENA_CTRL_MAJOR) << \
+	(ENA_REGS_CONTROLLER_VERSION_MAJOR_VERSION_SHIFT)) | \
+	((ENA_CTRL_MINOR) << \
+	(ENA_REGS_CONTROLLER_VERSION_MINOR_VERSION_SHIFT)) | \
+	(ENA_CTRL_SUB_MINOR))
+
+#define ENA_DMA_ADDR_TO_UINT32_LOW(x)	((u32)((u64)(x)))
+#define ENA_DMA_ADDR_TO_UINT32_HIGH(x)	((u32)(((u64)(x)) >> 32))
+
+#define ENA_MMIO_READ_TIMEOUT 0xFFFFFFFF
+
+#define ENA_COM_BOUNCE_BUFFER_CNTRL_CNT	4
+
+#define ENA_REGS_ADMIN_INTR_MASK 1
+
+#define ENA_MIN_ADMIN_POLL_US 100
+
+#define ENA_MAX_ADMIN_POLL_US 5000
+
+/*****************************************************************************/
+/*****************************************************************************/
+/*****************************************************************************/
+
+enum ena_cmd_status {
+	ENA_CMD_SUBMITTED,
+	ENA_CMD_COMPLETED,
+	/* Abort - canceled by the driver */
+	ENA_CMD_ABORTED,
+};
+
+struct ena_comp_ctx {
+	ena_wait_event_t wait_event;
+	struct ena_admin_acq_entry *user_cqe;
+	u32 comp_size;
+	enum ena_cmd_status status;
+	/* status from the device */
+	u8 comp_status;
+	u8 cmd_opcode;
+	bool occupied;
+};
+
+struct ena_com_stats_ctx {
+	struct ena_admin_aq_get_stats_cmd get_cmd;
+	struct ena_admin_acq_get_stats_resp get_resp;
+};
+
+static int ena_com_mem_addr_set(struct ena_com_dev *ena_dev,
+				       struct ena_common_mem_addr *ena_addr,
+				       dma_addr_t addr)
+{
+	if ((addr & GENMASK_ULL(ena_dev->dma_addr_bits - 1, 0)) != addr) {
+		ena_trc_err(ena_dev, "DMA address has more bits that the device supports\n");
+		return ENA_COM_INVAL;
+	}
+
+	ena_addr->mem_addr_low = lower_32_bits(addr);
+	ena_addr->mem_addr_high = (u16)upper_32_bits(addr);
+
+	return 0;
+}
+
+static int ena_com_admin_init_sq(struct ena_com_admin_queue *admin_queue)
+{
+	struct ena_com_dev *ena_dev = admin_queue->ena_dev;
+	struct ena_com_admin_sq *sq = &admin_queue->sq;
+	u16 size = ADMIN_SQ_SIZE(admin_queue->q_depth);
+
+	ENA_MEM_ALLOC_COHERENT(admin_queue->q_dmadev, size, sq->entries, sq->dma_addr,
+			       sq->mem_handle);
+
+	if (!sq->entries) {
+		ena_trc_err(ena_dev, "Memory allocation failed\n");
+		return ENA_COM_NO_MEM;
+	}
+
+	sq->head = 0;
+	sq->tail = 0;
+	sq->phase = 1;
+
+	sq->db_addr = NULL;
+
+	return 0;
+}
+
+static int ena_com_admin_init_cq(struct ena_com_admin_queue *admin_queue)
+{
+	struct ena_com_dev *ena_dev = admin_queue->ena_dev;
+	struct ena_com_admin_cq *cq = &admin_queue->cq;
+	u16 size = ADMIN_CQ_SIZE(admin_queue->q_depth);
+
+	ENA_MEM_ALLOC_COHERENT(admin_queue->q_dmadev, size, cq->entries, cq->dma_addr,
+			       cq->mem_handle);
+
+	if (!cq->entries)  {
+		ena_trc_err(ena_dev, "Memory allocation failed\n");
+		return ENA_COM_NO_MEM;
+	}
+
+	cq->head = 0;
+	cq->phase = 1;
+
+	return 0;
+}
+
+static int ena_com_admin_init_aenq(struct ena_com_dev *ena_dev,
+				   struct ena_aenq_handlers *aenq_handlers)
+{
+	struct ena_com_aenq *aenq = &ena_dev->aenq;
+	u32 addr_low, addr_high, aenq_caps;
+	u16 size;
+
+	ena_dev->aenq.q_depth = ENA_ASYNC_QUEUE_DEPTH;
+	size = ADMIN_AENQ_SIZE(ENA_ASYNC_QUEUE_DEPTH);
+	ENA_MEM_ALLOC_COHERENT(ena_dev->dmadev, size,
+			aenq->entries,
+			aenq->dma_addr,
+			aenq->mem_handle);
+
+	if (!aenq->entries) {
+		ena_trc_err(ena_dev, "Memory allocation failed\n");
+		return ENA_COM_NO_MEM;
+	}
+
+	aenq->head = aenq->q_depth;
+	aenq->phase = 1;
+
+	addr_low = ENA_DMA_ADDR_TO_UINT32_LOW(aenq->dma_addr);
+	addr_high = ENA_DMA_ADDR_TO_UINT32_HIGH(aenq->dma_addr);
+
+	ENA_REG_WRITE32(ena_dev->bus, addr_low, ena_dev->reg_bar + ENA_REGS_AENQ_BASE_LO_OFF);
+	ENA_REG_WRITE32(ena_dev->bus, addr_high, ena_dev->reg_bar + ENA_REGS_AENQ_BASE_HI_OFF);
+
+	aenq_caps = 0;
+	aenq_caps |= ena_dev->aenq.q_depth & ENA_REGS_AENQ_CAPS_AENQ_DEPTH_MASK;
+	aenq_caps |= (sizeof(struct ena_admin_aenq_entry) <<
+		ENA_REGS_AENQ_CAPS_AENQ_ENTRY_SIZE_SHIFT) &
+		ENA_REGS_AENQ_CAPS_AENQ_ENTRY_SIZE_MASK;
+	ENA_REG_WRITE32(ena_dev->bus, aenq_caps, ena_dev->reg_bar + ENA_REGS_AENQ_CAPS_OFF);
+
+	if (unlikely(!aenq_handlers)) {
+		ena_trc_err(ena_dev, "AENQ handlers pointer is NULL\n");
+		return ENA_COM_INVAL;
+	}
+
+	aenq->aenq_handlers = aenq_handlers;
+
+	return 0;
+}
+
+static void comp_ctxt_release(struct ena_com_admin_queue *queue,
+				     struct ena_comp_ctx *comp_ctx)
+{
+	comp_ctx->occupied = false;
+	ATOMIC32_DEC(&queue->outstanding_cmds);
+}
+
+static struct ena_comp_ctx *get_comp_ctxt(struct ena_com_admin_queue *admin_queue,
+					  u16 command_id, bool capture)
+{
+	if (unlikely(command_id >= admin_queue->q_depth)) {
+		ena_trc_err(admin_queue->ena_dev,
+			    "Command id is larger than the queue size. cmd_id: %u queue size %d\n",
+			    command_id, admin_queue->q_depth);
+		return NULL;
+	}
+
+	if (unlikely(!admin_queue->comp_ctx)) {
+		ena_trc_err(admin_queue->ena_dev,
+			    "Completion context is NULL\n");
+		return NULL;
+	}
+
+	if (unlikely(admin_queue->comp_ctx[command_id].occupied && capture)) {
+		ena_trc_err(admin_queue->ena_dev,
+			    "Completion context is occupied\n");
+		return NULL;
+	}
+
+	if (capture) {
+		ATOMIC32_INC(&admin_queue->outstanding_cmds);
+		admin_queue->comp_ctx[command_id].occupied = true;
+	}
+
+	return &admin_queue->comp_ctx[command_id];
+}
+
+static struct ena_comp_ctx *__ena_com_submit_admin_cmd(struct ena_com_admin_queue *admin_queue,
+						       struct ena_admin_aq_entry *cmd,
+						       size_t cmd_size_in_bytes,
+						       struct ena_admin_acq_entry *comp,
+						       size_t comp_size_in_bytes)
+{
+	struct ena_comp_ctx *comp_ctx;
+	u16 tail_masked, cmd_id;
+	u16 queue_size_mask;
+	u16 cnt;
+
+	queue_size_mask = admin_queue->q_depth - 1;
+
+	tail_masked = admin_queue->sq.tail & queue_size_mask;
+
+	/* In case of queue FULL */
+	cnt = (u16)ATOMIC32_READ(&admin_queue->outstanding_cmds);
+	if (cnt >= admin_queue->q_depth) {
+		ena_trc_dbg(admin_queue->ena_dev, "Admin queue is full.\n");
+		admin_queue->stats.out_of_space++;
+		return ERR_PTR(ENA_COM_NO_SPACE);
+	}
+
+	cmd_id = admin_queue->curr_cmd_id;
+
+	cmd->aq_common_descriptor.flags |= admin_queue->sq.phase &
+		ENA_ADMIN_AQ_COMMON_DESC_PHASE_MASK;
+
+	cmd->aq_common_descriptor.command_id |= cmd_id &
+		ENA_ADMIN_AQ_COMMON_DESC_COMMAND_ID_MASK;
+
+	comp_ctx = get_comp_ctxt(admin_queue, cmd_id, true);
+	if (unlikely(!comp_ctx))
+		return ERR_PTR(ENA_COM_INVAL);
+
+	comp_ctx->status = ENA_CMD_SUBMITTED;
+	comp_ctx->comp_size = (u32)comp_size_in_bytes;
+	comp_ctx->user_cqe = comp;
+	comp_ctx->cmd_opcode = cmd->aq_common_descriptor.opcode;
+
+	ENA_WAIT_EVENT_CLEAR(comp_ctx->wait_event);
+
+	memcpy(&admin_queue->sq.entries[tail_masked], cmd, cmd_size_in_bytes);
+
+	admin_queue->curr_cmd_id = (admin_queue->curr_cmd_id + 1) &
+		queue_size_mask;
+
+	admin_queue->sq.tail++;
+	admin_queue->stats.submitted_cmd++;
+
+	if (unlikely((admin_queue->sq.tail & queue_size_mask) == 0))
+		admin_queue->sq.phase = !admin_queue->sq.phase;
+
+	ENA_DB_SYNC(&admin_queue->sq.mem_handle);
+	ENA_REG_WRITE32(admin_queue->bus, admin_queue->sq.tail,
+			admin_queue->sq.db_addr);
+
+	return comp_ctx;
+}
+
+static int ena_com_init_comp_ctxt(struct ena_com_admin_queue *admin_queue)
+{
+	struct ena_com_dev *ena_dev = admin_queue->ena_dev;
+	size_t size = admin_queue->q_depth * sizeof(struct ena_comp_ctx);
+	struct ena_comp_ctx *comp_ctx;
+	u16 i;
+
+	admin_queue->comp_ctx = ENA_MEM_ALLOC(admin_queue->q_dmadev, size);
+	if (unlikely(!admin_queue->comp_ctx)) {
+		ena_trc_err(ena_dev, "Memory allocation failed\n");
+		return ENA_COM_NO_MEM;
+	}
+
+	for (i = 0; i < admin_queue->q_depth; i++) {
+		comp_ctx = get_comp_ctxt(admin_queue, i, false);
+		if (comp_ctx)
+			ENA_WAIT_EVENT_INIT(comp_ctx->wait_event);
+	}
+
+	return 0;
+}
+
+static struct ena_comp_ctx *ena_com_submit_admin_cmd(struct ena_com_admin_queue *admin_queue,
+						     struct ena_admin_aq_entry *cmd,
+						     size_t cmd_size_in_bytes,
+						     struct ena_admin_acq_entry *comp,
+						     size_t comp_size_in_bytes)
+{
+	unsigned long flags = 0;
+	struct ena_comp_ctx *comp_ctx;
+
+	ENA_SPINLOCK_LOCK(admin_queue->q_lock, flags);
+	if (unlikely(!admin_queue->running_state)) {
+		ENA_SPINLOCK_UNLOCK(admin_queue->q_lock, flags);
+		return ERR_PTR(ENA_COM_NO_DEVICE);
+	}
+	comp_ctx = __ena_com_submit_admin_cmd(admin_queue, cmd,
+					      cmd_size_in_bytes,
+					      comp,
+					      comp_size_in_bytes);
+	if (IS_ERR(comp_ctx))
+		admin_queue->running_state = false;
+	ENA_SPINLOCK_UNLOCK(admin_queue->q_lock, flags);
+
+	return comp_ctx;
+}
+
+static int ena_com_init_io_sq(struct ena_com_dev *ena_dev,
+			      struct ena_com_create_io_ctx *ctx,
+			      struct ena_com_io_sq *io_sq)
+{
+	size_t size;
+	int dev_node = 0;
+
+	memset(&io_sq->desc_addr, 0x0, sizeof(io_sq->desc_addr));
+
+	io_sq->dma_addr_bits = (u8)ena_dev->dma_addr_bits;
+	io_sq->desc_entry_size =
+		(io_sq->direction == ENA_COM_IO_QUEUE_DIRECTION_TX) ?
+		sizeof(struct ena_eth_io_tx_desc) :
+		sizeof(struct ena_eth_io_rx_desc);
+
+	size = io_sq->desc_entry_size * io_sq->q_depth;
+	io_sq->bus = ena_dev->bus;
+
+	if (io_sq->mem_queue_type == ENA_ADMIN_PLACEMENT_POLICY_HOST) {
+		ENA_MEM_ALLOC_COHERENT_NODE(ena_dev->dmadev,
+					    size,
+					    io_sq->desc_addr.virt_addr,
+					    io_sq->desc_addr.phys_addr,
+					    io_sq->desc_addr.mem_handle,
+					    ctx->numa_node,
+					    dev_node);
+		if (!io_sq->desc_addr.virt_addr) {
+			ENA_MEM_ALLOC_COHERENT(ena_dev->dmadev,
+					       size,
+					       io_sq->desc_addr.virt_addr,
+					       io_sq->desc_addr.phys_addr,
+					       io_sq->desc_addr.mem_handle);
+		}
+
+		if (!io_sq->desc_addr.virt_addr) {
+			ena_trc_err(ena_dev, "Memory allocation failed\n");
+			return ENA_COM_NO_MEM;
+		}
+	}
+
+	if (io_sq->mem_queue_type == ENA_ADMIN_PLACEMENT_POLICY_DEV) {
+		/* Allocate bounce buffers */
+		io_sq->bounce_buf_ctrl.buffer_size =
+			ena_dev->llq_info.desc_list_entry_size;
+		io_sq->bounce_buf_ctrl.buffers_num =
+			ENA_COM_BOUNCE_BUFFER_CNTRL_CNT;
+		io_sq->bounce_buf_ctrl.next_to_use = 0;
+
+		size = io_sq->bounce_buf_ctrl.buffer_size *
+			io_sq->bounce_buf_ctrl.buffers_num;
+
+		ENA_MEM_ALLOC_NODE(ena_dev->dmadev,
+				   size,
+				   io_sq->bounce_buf_ctrl.base_buffer,
+				   ctx->numa_node,
+				   dev_node);
+		if (!io_sq->bounce_buf_ctrl.base_buffer)
+			io_sq->bounce_buf_ctrl.base_buffer = ENA_MEM_ALLOC(ena_dev->dmadev, size);
+
+		if (!io_sq->bounce_buf_ctrl.base_buffer) {
+			ena_trc_err(ena_dev, "Bounce buffer memory allocation failed\n");
+			return ENA_COM_NO_MEM;
+		}
+
+		memcpy(&io_sq->llq_info, &ena_dev->llq_info,
+		       sizeof(io_sq->llq_info));
+
+		/* Initiate the first bounce buffer */
+		io_sq->llq_buf_ctrl.curr_bounce_buf =
+			ena_com_get_next_bounce_buffer(&io_sq->bounce_buf_ctrl);
+		memset(io_sq->llq_buf_ctrl.curr_bounce_buf,
+		       0x0, io_sq->llq_info.desc_list_entry_size);
+		io_sq->llq_buf_ctrl.descs_left_in_line =
+			io_sq->llq_info.descs_num_before_header;
+		io_sq->disable_meta_caching =
+			io_sq->llq_info.disable_meta_caching;
+
+		if (io_sq->llq_info.max_entries_in_tx_burst > 0)
+			io_sq->entries_in_tx_burst_left =
+				io_sq->llq_info.max_entries_in_tx_burst;
+	}
+
+	io_sq->tail = 0;
+	io_sq->next_to_comp = 0;
+	io_sq->phase = 1;
+
+	return 0;
+}
+
+static int ena_com_init_io_cq(struct ena_com_dev *ena_dev,
+			      struct ena_com_create_io_ctx *ctx,
+			      struct ena_com_io_cq *io_cq)
+{
+	size_t size;
+	int prev_node = 0;
+
+	memset(&io_cq->cdesc_addr, 0x0, sizeof(io_cq->cdesc_addr));
+
+	/* Use the basic completion descriptor for Rx */
+	io_cq->cdesc_entry_size_in_bytes =
+		(io_cq->direction == ENA_COM_IO_QUEUE_DIRECTION_TX) ?
+		sizeof(struct ena_eth_io_tx_cdesc) :
+		sizeof(struct ena_eth_io_rx_cdesc_base);
+
+	size = io_cq->cdesc_entry_size_in_bytes * io_cq->q_depth;
+	io_cq->bus = ena_dev->bus;
+
+	ENA_MEM_ALLOC_COHERENT_NODE(ena_dev->dmadev,
+			size,
+			io_cq->cdesc_addr.virt_addr,
+			io_cq->cdesc_addr.phys_addr,
+			io_cq->cdesc_addr.mem_handle,
+			ctx->numa_node,
+			prev_node);
+	if (!io_cq->cdesc_addr.virt_addr) {
+		ENA_MEM_ALLOC_COHERENT(ena_dev->dmadev,
+				       size,
+				       io_cq->cdesc_addr.virt_addr,
+				       io_cq->cdesc_addr.phys_addr,
+				       io_cq->cdesc_addr.mem_handle);
+	}
+
+	if (!io_cq->cdesc_addr.virt_addr) {
+		ena_trc_err(ena_dev, "Memory allocation failed\n");
+		return ENA_COM_NO_MEM;
+	}
+
+	io_cq->phase = 1;
+	io_cq->head = 0;
+
+	return 0;
+}
+
+static void ena_com_handle_single_admin_completion(struct ena_com_admin_queue *admin_queue,
+						   struct ena_admin_acq_entry *cqe)
+{
+	struct ena_comp_ctx *comp_ctx;
+	u16 cmd_id;
+
+	cmd_id = cqe->acq_common_descriptor.command &
+		ENA_ADMIN_ACQ_COMMON_DESC_COMMAND_ID_MASK;
+
+	comp_ctx = get_comp_ctxt(admin_queue, cmd_id, false);
+	if (unlikely(!comp_ctx)) {
+		ena_trc_err(admin_queue->ena_dev,
+			    "comp_ctx is NULL. Changing the admin queue running state\n");
+		admin_queue->running_state = false;
+		return;
+	}
+
+	comp_ctx->status = ENA_CMD_COMPLETED;
+	comp_ctx->comp_status = cqe->acq_common_descriptor.status;
+
+	if (comp_ctx->user_cqe)
+		memcpy(comp_ctx->user_cqe, (void *)cqe, comp_ctx->comp_size);
+
+	if (!admin_queue->polling)
+		ENA_WAIT_EVENT_SIGNAL(comp_ctx->wait_event);
+}
+
+static void ena_com_handle_admin_completion(struct ena_com_admin_queue *admin_queue)
+{
+	struct ena_admin_acq_entry *cqe = NULL;
+	u16 comp_num = 0;
+	u16 head_masked;
+	u8 phase;
+
+	head_masked = admin_queue->cq.head & (admin_queue->q_depth - 1);
+	phase = admin_queue->cq.phase;
+
+	cqe = &admin_queue->cq.entries[head_masked];
+
+	/* Go over all the completions */
+	while ((READ_ONCE8(cqe->acq_common_descriptor.flags) &
+			ENA_ADMIN_ACQ_COMMON_DESC_PHASE_MASK) == phase) {
+		/* Do not read the rest of the completion entry before the
+		 * phase bit was validated
+		 */
+		dma_rmb();
+		ena_com_handle_single_admin_completion(admin_queue, cqe);
+
+		head_masked++;
+		comp_num++;
+		if (unlikely(head_masked == admin_queue->q_depth)) {
+			head_masked = 0;
+			phase = !phase;
+		}
+
+		cqe = &admin_queue->cq.entries[head_masked];
+	}
+
+	admin_queue->cq.head += comp_num;
+	admin_queue->cq.phase = phase;
+	admin_queue->sq.head += comp_num;
+	admin_queue->stats.completed_cmd += comp_num;
+}
+
+static int ena_com_comp_status_to_errno(struct ena_com_admin_queue *admin_queue,
+					u8 comp_status)
+{
+	if (unlikely(comp_status != 0))
+		ena_trc_err(admin_queue->ena_dev,
+			    "Admin command failed[%u]\n", comp_status);
+
+	switch (comp_status) {
+	case ENA_ADMIN_SUCCESS:
+		return ENA_COM_OK;
+	case ENA_ADMIN_RESOURCE_ALLOCATION_FAILURE:
+		return ENA_COM_NO_MEM;
+	case ENA_ADMIN_UNSUPPORTED_OPCODE:
+		return ENA_COM_UNSUPPORTED;
+	case ENA_ADMIN_BAD_OPCODE:
+	case ENA_ADMIN_MALFORMED_REQUEST:
+	case ENA_ADMIN_ILLEGAL_PARAMETER:
+	case ENA_ADMIN_UNKNOWN_ERROR:
+		return ENA_COM_INVAL;
+	case ENA_ADMIN_RESOURCE_BUSY:
+		return ENA_COM_TRY_AGAIN;
+	}
+
+	return ENA_COM_INVAL;
+}
+
+static void ena_delay_exponential_backoff_us(u32 exp, u32 delay_us)
+{
+	delay_us = ENA_MAX32(ENA_MIN_ADMIN_POLL_US, delay_us);
+	delay_us = ENA_MIN32(delay_us * (1U << exp), ENA_MAX_ADMIN_POLL_US);
+	ENA_USLEEP(delay_us);
+}
+
+static int ena_com_wait_and_process_admin_cq_polling(struct ena_comp_ctx *comp_ctx,
+						     struct ena_com_admin_queue *admin_queue)
+{
+	unsigned long flags = 0;
+	ena_time_t timeout;
+	int ret;
+	u32 exp = 0;
+
+	timeout = ENA_GET_SYSTEM_TIMEOUT(admin_queue->completion_timeout);
+
+	while (1) {
+		ENA_SPINLOCK_LOCK(admin_queue->q_lock, flags);
+		ena_com_handle_admin_completion(admin_queue);
+		ENA_SPINLOCK_UNLOCK(admin_queue->q_lock, flags);
+
+		if (comp_ctx->status != ENA_CMD_SUBMITTED)
+			break;
+
+		if (ENA_TIME_EXPIRE(timeout)) {
+			ena_trc_err(admin_queue->ena_dev,
+				    "Wait for completion (polling) timeout\n");
+			/* ENA didn't have any completion */
+			ENA_SPINLOCK_LOCK(admin_queue->q_lock, flags);
+			admin_queue->stats.no_completion++;
+			admin_queue->running_state = false;
+			ENA_SPINLOCK_UNLOCK(admin_queue->q_lock, flags);
+
+			ret = ENA_COM_TIMER_EXPIRED;
+			goto err;
+		}
+
+		ena_delay_exponential_backoff_us(exp++,
+						 admin_queue->ena_dev->ena_min_poll_delay_us);
+	}
+
+	if (unlikely(comp_ctx->status == ENA_CMD_ABORTED)) {
+		ena_trc_err(admin_queue->ena_dev, "Command was aborted\n");
+		ENA_SPINLOCK_LOCK(admin_queue->q_lock, flags);
+		admin_queue->stats.aborted_cmd++;
+		ENA_SPINLOCK_UNLOCK(admin_queue->q_lock, flags);
+		ret = ENA_COM_NO_DEVICE;
+		goto err;
+	}
+
+	ENA_WARN(comp_ctx->status != ENA_CMD_COMPLETED,
+		 admin_queue->ena_dev, "Invalid comp status %d\n",
+		 comp_ctx->status);
+
+	ret = ena_com_comp_status_to_errno(admin_queue, comp_ctx->comp_status);
+err:
+	comp_ctxt_release(admin_queue, comp_ctx);
+	return ret;
+}
+
+/**
+ * Set the LLQ configurations of the firmware
+ *
+ * The driver provides only the enabled feature values to the device,
+ * which in turn, checks if they are supported.
+ */
+static int ena_com_set_llq(struct ena_com_dev *ena_dev)
+{
+	struct ena_com_admin_queue *admin_queue;
+	struct ena_admin_set_feat_cmd cmd;
+	struct ena_admin_set_feat_resp resp;
+	struct ena_com_llq_info *llq_info = &ena_dev->llq_info;
+	int ret;
+
+	memset(&cmd, 0x0, sizeof(cmd));
+	admin_queue = &ena_dev->admin_queue;
+
+	cmd.aq_common_descriptor.opcode = ENA_ADMIN_SET_FEATURE;
+	cmd.feat_common.feature_id = ENA_ADMIN_LLQ;
+
+	cmd.u.llq.header_location_ctrl_enabled = llq_info->header_location_ctrl;
+	cmd.u.llq.entry_size_ctrl_enabled = llq_info->desc_list_entry_size_ctrl;
+	cmd.u.llq.desc_num_before_header_enabled = llq_info->descs_num_before_header;
+	cmd.u.llq.descriptors_stride_ctrl_enabled = llq_info->desc_stride_ctrl;
+
+	cmd.u.llq.accel_mode.u.set.enabled_flags =
+		BIT(ENA_ADMIN_DISABLE_META_CACHING) |
+		BIT(ENA_ADMIN_LIMIT_TX_BURST);
+
+	ret = ena_com_execute_admin_command(admin_queue,
+					    (struct ena_admin_aq_entry *)&cmd,
+					    sizeof(cmd),
+					    (struct ena_admin_acq_entry *)&resp,
+					    sizeof(resp));
+
+	if (unlikely(ret))
+		ena_trc_err(ena_dev, "Failed to set LLQ configurations: %d\n", ret);
+
+	return ret;
+}
+
+static int ena_com_config_llq_info(struct ena_com_dev *ena_dev,
+				   struct ena_admin_feature_llq_desc *llq_features,
+				   struct ena_llq_configurations *llq_default_cfg)
+{
+	struct ena_com_llq_info *llq_info = &ena_dev->llq_info;
+	struct ena_admin_accel_mode_get llq_accel_mode_get;
+	u16 supported_feat;
+	int rc;
+
+	memset(llq_info, 0, sizeof(*llq_info));
+
+	supported_feat = llq_features->header_location_ctrl_supported;
+
+	if (likely(supported_feat & llq_default_cfg->llq_header_location)) {
+		llq_info->header_location_ctrl =
+			llq_default_cfg->llq_header_location;
+	} else {
+		ena_trc_err(ena_dev, "Invalid header location control, supported: 0x%x\n",
+			    supported_feat);
+		return -EINVAL;
+	}
+
+	if (likely(llq_info->header_location_ctrl == ENA_ADMIN_INLINE_HEADER)) {
+		supported_feat = llq_features->descriptors_stride_ctrl_supported;
+		if (likely(supported_feat & llq_default_cfg->llq_stride_ctrl)) {
+			llq_info->desc_stride_ctrl = llq_default_cfg->llq_stride_ctrl;
+		} else	{
+			if (supported_feat & ENA_ADMIN_MULTIPLE_DESCS_PER_ENTRY) {
+				llq_info->desc_stride_ctrl = ENA_ADMIN_MULTIPLE_DESCS_PER_ENTRY;
+			} else if (supported_feat & ENA_ADMIN_SINGLE_DESC_PER_ENTRY) {
+				llq_info->desc_stride_ctrl = ENA_ADMIN_SINGLE_DESC_PER_ENTRY;
+			} else {
+				ena_trc_err(ena_dev, "Invalid desc_stride_ctrl, supported: 0x%x\n",
+					    supported_feat);
+				return -EINVAL;
+			}
+
+			ena_trc_err(ena_dev, "Default llq stride ctrl is not supported, performing fallback, default: 0x%x, supported: 0x%x, used: 0x%x\n",
+				    llq_default_cfg->llq_stride_ctrl,
+				    supported_feat,
+				    llq_info->desc_stride_ctrl);
+		}
+	} else {
+		llq_info->desc_stride_ctrl = 0;
+	}
+
+	supported_feat = llq_features->entry_size_ctrl_supported;
+	if (likely(supported_feat & llq_default_cfg->llq_ring_entry_size)) {
+		llq_info->desc_list_entry_size_ctrl = llq_default_cfg->llq_ring_entry_size;
+		llq_info->desc_list_entry_size = llq_default_cfg->llq_ring_entry_size_value;
+	} else {
+		if (supported_feat & ENA_ADMIN_LIST_ENTRY_SIZE_128B) {
+			llq_info->desc_list_entry_size_ctrl = ENA_ADMIN_LIST_ENTRY_SIZE_128B;
+			llq_info->desc_list_entry_size = 128;
+		} else if (supported_feat & ENA_ADMIN_LIST_ENTRY_SIZE_192B) {
+			llq_info->desc_list_entry_size_ctrl = ENA_ADMIN_LIST_ENTRY_SIZE_192B;
+			llq_info->desc_list_entry_size = 192;
+		} else if (supported_feat & ENA_ADMIN_LIST_ENTRY_SIZE_256B) {
+			llq_info->desc_list_entry_size_ctrl = ENA_ADMIN_LIST_ENTRY_SIZE_256B;
+			llq_info->desc_list_entry_size = 256;
+		} else {
+			ena_trc_err(ena_dev, "Invalid entry_size_ctrl, supported: 0x%x\n",
+				    supported_feat);
+			return -EINVAL;
+		}
+
+		ena_trc_err(ena_dev, "Default llq ring entry size is not supported, performing fallback, default: 0x%x, supported: 0x%x, used: 0x%x\n",
+			    llq_default_cfg->llq_ring_entry_size,
+			    supported_feat,
+			    llq_info->desc_list_entry_size);
+	}
+	if (unlikely(llq_info->desc_list_entry_size & 0x7)) {
+		/* The desc list entry size should be whole multiply of 8
+		 * This requirement comes from __iowrite64_copy()
+		 */
+		ena_trc_err(ena_dev, "Illegal entry size %d\n",
+			    llq_info->desc_list_entry_size);
+		return -EINVAL;
+	}
+
+	if (llq_info->desc_stride_ctrl == ENA_ADMIN_MULTIPLE_DESCS_PER_ENTRY)
+		llq_info->descs_per_entry = llq_info->desc_list_entry_size /
+			sizeof(struct ena_eth_io_tx_desc);
+	else
+		llq_info->descs_per_entry = 1;
+
+	supported_feat = llq_features->desc_num_before_header_supported;
+	if (likely(supported_feat & llq_default_cfg->llq_num_decs_before_header)) {
+		llq_info->descs_num_before_header = llq_default_cfg->llq_num_decs_before_header;
+	} else {
+		if (supported_feat & ENA_ADMIN_LLQ_NUM_DESCS_BEFORE_HEADER_2) {
+			llq_info->descs_num_before_header = ENA_ADMIN_LLQ_NUM_DESCS_BEFORE_HEADER_2;
+		} else if (supported_feat & ENA_ADMIN_LLQ_NUM_DESCS_BEFORE_HEADER_1) {
+			llq_info->descs_num_before_header = ENA_ADMIN_LLQ_NUM_DESCS_BEFORE_HEADER_1;
+		} else if (supported_feat & ENA_ADMIN_LLQ_NUM_DESCS_BEFORE_HEADER_4) {
+			llq_info->descs_num_before_header = ENA_ADMIN_LLQ_NUM_DESCS_BEFORE_HEADER_4;
+		} else if (supported_feat & ENA_ADMIN_LLQ_NUM_DESCS_BEFORE_HEADER_8) {
+			llq_info->descs_num_before_header = ENA_ADMIN_LLQ_NUM_DESCS_BEFORE_HEADER_8;
+		} else {
+			ena_trc_err(ena_dev, "Invalid descs_num_before_header, supported: 0x%x\n",
+				    supported_feat);
+			return -EINVAL;
+		}
+
+		ena_trc_err(ena_dev, "Default llq num descs before header is not supported, performing fallback, default: 0x%x, supported: 0x%x, used: 0x%x\n",
+			    llq_default_cfg->llq_num_decs_before_header,
+			    supported_feat,
+			    llq_info->descs_num_before_header);
+	}
+	/* Check for accelerated queue supported */
+	llq_accel_mode_get = llq_features->accel_mode.u.get;
+
+	llq_info->disable_meta_caching =
+		!!(llq_accel_mode_get.supported_flags &
+		   BIT(ENA_ADMIN_DISABLE_META_CACHING));
+
+	if (llq_accel_mode_get.supported_flags & BIT(ENA_ADMIN_LIMIT_TX_BURST))
+		llq_info->max_entries_in_tx_burst =
+			llq_accel_mode_get.max_tx_burst_size /
+			llq_default_cfg->llq_ring_entry_size_value;
+
+	rc = ena_com_set_llq(ena_dev);
+	if (rc)
+		ena_trc_err(ena_dev, "Cannot set LLQ configuration: %d\n", rc);
+
+	return rc;
+}
+
+static int ena_com_wait_and_process_admin_cq_interrupts(struct ena_comp_ctx *comp_ctx,
+							struct ena_com_admin_queue *admin_queue)
+{
+	unsigned long flags = 0;
+	int ret;
+
+	ENA_WAIT_EVENT_WAIT(comp_ctx->wait_event,
+			    admin_queue->completion_timeout);
+
+	/* In case the command wasn't completed find out the root cause.
+	 * There might be 2 kinds of errors
+	 * 1) No completion (timeout reached)
+	 * 2) There is completion but the device didn't get any msi-x interrupt.
+	 */
+	if (unlikely(comp_ctx->status == ENA_CMD_SUBMITTED)) {
+		ENA_SPINLOCK_LOCK(admin_queue->q_lock, flags);
+		ena_com_handle_admin_completion(admin_queue);
+		admin_queue->stats.no_completion++;
+		ENA_SPINLOCK_UNLOCK(admin_queue->q_lock, flags);
+
+		if (comp_ctx->status == ENA_CMD_COMPLETED) {
+			ena_trc_err(admin_queue->ena_dev,
+				    "The ena device sent a completion but the driver didn't receive a MSI-X interrupt (cmd %d), autopolling mode is %s\n",
+				    comp_ctx->cmd_opcode, admin_queue->auto_polling ? "ON" : "OFF");
+			/* Check if fallback to polling is enabled */
+			if (admin_queue->auto_polling)
+				admin_queue->polling = true;
+		} else {
+			ena_trc_err(admin_queue->ena_dev,
+				    "The ena device didn't send a completion for the admin cmd %d status %d\n",
+				    comp_ctx->cmd_opcode, comp_ctx->status);
+		}
+		/* Check if shifted to polling mode.
+		 * This will happen if there is a completion without an interrupt
+		 * and autopolling mode is enabled. Continuing normal execution in such case
+		 */
+		if (!admin_queue->polling) {
+			admin_queue->running_state = false;
+			ret = ENA_COM_TIMER_EXPIRED;
+			goto err;
+		}
+	}
+
+	ret = ena_com_comp_status_to_errno(admin_queue, comp_ctx->comp_status);
+err:
+	comp_ctxt_release(admin_queue, comp_ctx);
+	return ret;
+}
+
+/* This method read the hardware device register through posting writes
+ * and waiting for response
+ * On timeout the function will return ENA_MMIO_READ_TIMEOUT
+ */
+static u32 ena_com_reg_bar_read32(struct ena_com_dev *ena_dev, u16 offset)
+{
+	struct ena_com_mmio_read *mmio_read = &ena_dev->mmio_read;
+	volatile struct ena_admin_ena_mmio_req_read_less_resp *read_resp =
+		mmio_read->read_resp;
+	u32 mmio_read_reg, ret, i;
+	unsigned long flags = 0;
+	u32 timeout = mmio_read->reg_read_to;
+
+	ENA_MIGHT_SLEEP();
+
+	if (timeout == 0)
+		timeout = ENA_REG_READ_TIMEOUT;
+
+	/* If readless is disabled, perform regular read */
+	if (!mmio_read->readless_supported)
+		return ENA_REG_READ32(ena_dev->bus, ena_dev->reg_bar + offset);
+
+	ENA_SPINLOCK_LOCK(mmio_read->lock, flags);
+	mmio_read->seq_num++;
+
+	read_resp->req_id = mmio_read->seq_num + 0xDEAD;
+	mmio_read_reg = (offset << ENA_REGS_MMIO_REG_READ_REG_OFF_SHIFT) &
+			ENA_REGS_MMIO_REG_READ_REG_OFF_MASK;
+	mmio_read_reg |= mmio_read->seq_num &
+			ENA_REGS_MMIO_REG_READ_REQ_ID_MASK;
+
+	ENA_REG_WRITE32(ena_dev->bus, mmio_read_reg,
+			ena_dev->reg_bar + ENA_REGS_MMIO_REG_READ_OFF);
+
+	for (i = 0; i < timeout; i++) {
+		if (READ_ONCE16(read_resp->req_id) == mmio_read->seq_num)
+			break;
+
+		ENA_UDELAY(1);
+	}
+
+	if (unlikely(i == timeout)) {
+		ena_trc_err(ena_dev, "Reading reg failed for timeout. expected: req id[%hu] offset[%hu] actual: req id[%hu] offset[%hu]\n",
+			    mmio_read->seq_num,
+			    offset,
+			    read_resp->req_id,
+			    read_resp->reg_off);
+		ret = ENA_MMIO_READ_TIMEOUT;
+		goto err;
+	}
+
+	if (read_resp->reg_off != offset) {
+		ena_trc_err(ena_dev, "Read failure: wrong offset provided\n");
+		ret = ENA_MMIO_READ_TIMEOUT;
+	} else {
+		ret = read_resp->reg_val;
+	}
+err:
+	ENA_SPINLOCK_UNLOCK(mmio_read->lock, flags);
+
+	return ret;
+}
+
+/* There are two types to wait for completion.
+ * Polling mode - wait until the completion is available.
+ * Async mode - wait on wait queue until the completion is ready
+ * (or the timeout expired).
+ * It is expected that the IRQ called ena_com_handle_admin_completion
+ * to mark the completions.
+ */
+static int ena_com_wait_and_process_admin_cq(struct ena_comp_ctx *comp_ctx,
+					     struct ena_com_admin_queue *admin_queue)
+{
+	if (admin_queue->polling)
+		return ena_com_wait_and_process_admin_cq_polling(comp_ctx,
+								 admin_queue);
+
+	return ena_com_wait_and_process_admin_cq_interrupts(comp_ctx,
+							    admin_queue);
+}
+
+static int ena_com_destroy_io_sq(struct ena_com_dev *ena_dev,
+				 struct ena_com_io_sq *io_sq)
+{
+	struct ena_com_admin_queue *admin_queue = &ena_dev->admin_queue;
+	struct ena_admin_aq_destroy_sq_cmd destroy_cmd;
+	struct ena_admin_acq_destroy_sq_resp_desc destroy_resp;
+	u8 direction;
+	int ret;
+
+	memset(&destroy_cmd, 0x0, sizeof(destroy_cmd));
+
+	if (io_sq->direction == ENA_COM_IO_QUEUE_DIRECTION_TX)
+		direction = ENA_ADMIN_SQ_DIRECTION_TX;
+	else
+		direction = ENA_ADMIN_SQ_DIRECTION_RX;
+
+	destroy_cmd.sq.sq_identity |= (direction <<
+		ENA_ADMIN_SQ_SQ_DIRECTION_SHIFT) &
+		ENA_ADMIN_SQ_SQ_DIRECTION_MASK;
+
+	destroy_cmd.sq.sq_idx = io_sq->idx;
+	destroy_cmd.aq_common_descriptor.opcode = ENA_ADMIN_DESTROY_SQ;
+
+	ret = ena_com_execute_admin_command(admin_queue,
+					    (struct ena_admin_aq_entry *)&destroy_cmd,
+					    sizeof(destroy_cmd),
+					    (struct ena_admin_acq_entry *)&destroy_resp,
+					    sizeof(destroy_resp));
+
+	if (unlikely(ret && (ret != ENA_COM_NO_DEVICE)))
+		ena_trc_err(ena_dev, "Failed to destroy io sq error: %d\n", ret);
+
+	return ret;
+}
+
+static void ena_com_io_queue_free(struct ena_com_dev *ena_dev,
+				  struct ena_com_io_sq *io_sq,
+				  struct ena_com_io_cq *io_cq)
+{
+	size_t size;
+
+	if (io_cq->cdesc_addr.virt_addr) {
+		size = io_cq->cdesc_entry_size_in_bytes * io_cq->q_depth;
+
+		ENA_MEM_FREE_COHERENT(ena_dev->dmadev,
+				      size,
+				      io_cq->cdesc_addr.virt_addr,
+				      io_cq->cdesc_addr.phys_addr,
+				      io_cq->cdesc_addr.mem_handle);
+
+		io_cq->cdesc_addr.virt_addr = NULL;
+	}
+
+	if (io_sq->desc_addr.virt_addr) {
+		size = io_sq->desc_entry_size * io_sq->q_depth;
+
+		ENA_MEM_FREE_COHERENT(ena_dev->dmadev,
+				      size,
+				      io_sq->desc_addr.virt_addr,
+				      io_sq->desc_addr.phys_addr,
+				      io_sq->desc_addr.mem_handle);
+
+		io_sq->desc_addr.virt_addr = NULL;
+	}
+
+	if (io_sq->bounce_buf_ctrl.base_buffer) {
+		ENA_MEM_FREE(ena_dev->dmadev,
+			     io_sq->bounce_buf_ctrl.base_buffer,
+			     (io_sq->llq_info.desc_list_entry_size * ENA_COM_BOUNCE_BUFFER_CNTRL_CNT));
+		io_sq->bounce_buf_ctrl.base_buffer = NULL;
+	}
+}
+
+static int wait_for_reset_state(struct ena_com_dev *ena_dev, u32 timeout,
+				u16 exp_state)
+{
+	u32 val, exp = 0;
+	ena_time_t timeout_stamp;
+
+	/* Convert timeout from resolution of 100ms to us resolution. */
+	timeout_stamp = ENA_GET_SYSTEM_TIMEOUT(100 * 1000 * timeout);
+
+	while (1) {
+		val = ena_com_reg_bar_read32(ena_dev, ENA_REGS_DEV_STS_OFF);
+
+		if (unlikely(val == ENA_MMIO_READ_TIMEOUT)) {
+			ena_trc_err(ena_dev, "Reg read timeout occurred\n");
+			return ENA_COM_TIMER_EXPIRED;
+		}
+
+		if ((val & ENA_REGS_DEV_STS_RESET_IN_PROGRESS_MASK) ==
+			exp_state)
+			return 0;
+
+		if (ENA_TIME_EXPIRE(timeout_stamp))
+			return ENA_COM_TIMER_EXPIRED;
+
+		ena_delay_exponential_backoff_us(exp++, ena_dev->ena_min_poll_delay_us);
+	}
+}
+
+static bool ena_com_check_supported_feature_id(struct ena_com_dev *ena_dev,
+					       enum ena_admin_aq_feature_id feature_id)
+{
+	u32 feature_mask = 1 << feature_id;
+
+	/* Device attributes is always supported */
+	if ((feature_id != ENA_ADMIN_DEVICE_ATTRIBUTES) &&
+	    !(ena_dev->supported_features & feature_mask))
+		return false;
+
+	return true;
+}
+
+static int ena_com_get_feature_ex(struct ena_com_dev *ena_dev,
+				  struct ena_admin_get_feat_resp *get_resp,
+				  enum ena_admin_aq_feature_id feature_id,
+				  dma_addr_t control_buf_dma_addr,
+				  u32 control_buff_size,
+				  u8 feature_ver)
+{
+	struct ena_com_admin_queue *admin_queue;
+	struct ena_admin_get_feat_cmd get_cmd;
+	int ret;
+
+	if (!ena_com_check_supported_feature_id(ena_dev, feature_id)) {
+		ena_trc_dbg(ena_dev, "Feature %d isn't supported\n", feature_id);
+		return ENA_COM_UNSUPPORTED;
+	}
+
+	memset(&get_cmd, 0x0, sizeof(get_cmd));
+	admin_queue = &ena_dev->admin_queue;
+
+	get_cmd.aq_common_descriptor.opcode = ENA_ADMIN_GET_FEATURE;
+
+	if (control_buff_size)
+		get_cmd.aq_common_descriptor.flags =
+			ENA_ADMIN_AQ_COMMON_DESC_CTRL_DATA_INDIRECT_MASK;
+	else
+		get_cmd.aq_common_descriptor.flags = 0;
+
+	ret = ena_com_mem_addr_set(ena_dev,
+				   &get_cmd.control_buffer.address,
+				   control_buf_dma_addr);
+	if (unlikely(ret)) {
+		ena_trc_err(ena_dev, "Memory address set failed\n");
+		return ret;
+	}
+
+	get_cmd.control_buffer.length = control_buff_size;
+	get_cmd.feat_common.feature_version = feature_ver;
+	get_cmd.feat_common.feature_id = feature_id;
+
+	ret = ena_com_execute_admin_command(admin_queue,
+					    (struct ena_admin_aq_entry *)
+					    &get_cmd,
+					    sizeof(get_cmd),
+					    (struct ena_admin_acq_entry *)
+					    get_resp,
+					    sizeof(*get_resp));
+
+	if (unlikely(ret))
+		ena_trc_err(ena_dev, "Failed to submit get_feature command %d error: %d\n",
+			    feature_id, ret);
+
+	return ret;
+}
+
+static int ena_com_get_feature(struct ena_com_dev *ena_dev,
+			       struct ena_admin_get_feat_resp *get_resp,
+			       enum ena_admin_aq_feature_id feature_id,
+			       u8 feature_ver)
+{
+	return ena_com_get_feature_ex(ena_dev,
+				      get_resp,
+				      feature_id,
+				      0,
+				      0,
+				      feature_ver);
+}
+
+int ena_com_get_current_hash_function(struct ena_com_dev *ena_dev)
+{
+	return ena_dev->rss.hash_func;
+}
+
+static void ena_com_hash_key_fill_default_key(struct ena_com_dev *ena_dev)
+{
+	struct ena_admin_feature_rss_flow_hash_control *hash_key =
+		(ena_dev->rss).hash_key;
+
+	ENA_RSS_FILL_KEY(&hash_key->key, sizeof(hash_key->key));
+	/* The key buffer is stored in the device in an array of
+	 * uint32 elements.
+	 */
+	hash_key->key_parts = ENA_ADMIN_RSS_KEY_PARTS;
+}
+
+static int ena_com_hash_key_allocate(struct ena_com_dev *ena_dev)
+{
+	struct ena_rss *rss = &ena_dev->rss;
+
+	if (!ena_com_check_supported_feature_id(ena_dev, ENA_ADMIN_RSS_HASH_FUNCTION))
+		return ENA_COM_UNSUPPORTED;
+
+	ENA_MEM_ALLOC_COHERENT(ena_dev->dmadev,
+			       sizeof(*rss->hash_key),
+			       rss->hash_key,
+			       rss->hash_key_dma_addr,
+			       rss->hash_key_mem_handle);
+
+	if (unlikely(!rss->hash_key))
+		return ENA_COM_NO_MEM;
+
+	return 0;
+}
+
+static void ena_com_hash_key_destroy(struct ena_com_dev *ena_dev)
+{
+	struct ena_rss *rss = &ena_dev->rss;
+
+	if (rss->hash_key)
+		ENA_MEM_FREE_COHERENT(ena_dev->dmadev,
+				      sizeof(*rss->hash_key),
+				      rss->hash_key,
+				      rss->hash_key_dma_addr,
+				      rss->hash_key_mem_handle);
+	rss->hash_key = NULL;
+}
+
+static int ena_com_hash_ctrl_init(struct ena_com_dev *ena_dev)
+{
+	struct ena_rss *rss = &ena_dev->rss;
+
+	ENA_MEM_ALLOC_COHERENT(ena_dev->dmadev,
+			       sizeof(*rss->hash_ctrl),
+			       rss->hash_ctrl,
+			       rss->hash_ctrl_dma_addr,
+			       rss->hash_ctrl_mem_handle);
+
+	if (unlikely(!rss->hash_ctrl))
+		return ENA_COM_NO_MEM;
+
+	return 0;
+}
+
+static void ena_com_hash_ctrl_destroy(struct ena_com_dev *ena_dev)
+{
+	struct ena_rss *rss = &ena_dev->rss;
+
+	if (rss->hash_ctrl)
+		ENA_MEM_FREE_COHERENT(ena_dev->dmadev,
+				      sizeof(*rss->hash_ctrl),
+				      rss->hash_ctrl,
+				      rss->hash_ctrl_dma_addr,
+				      rss->hash_ctrl_mem_handle);
+	rss->hash_ctrl = NULL;
+}
+
+static int ena_com_indirect_table_allocate(struct ena_com_dev *ena_dev,
+					   u16 log_size)
+{
+	struct ena_rss *rss = &ena_dev->rss;
+	struct ena_admin_get_feat_resp get_resp;
+	size_t tbl_size;
+	int ret;
+
+	ret = ena_com_get_feature(ena_dev, &get_resp,
+				  ENA_ADMIN_RSS_INDIRECTION_TABLE_CONFIG, 0);
+	if (unlikely(ret))
+		return ret;
+
+	if ((get_resp.u.ind_table.min_size > log_size) ||
+	    (get_resp.u.ind_table.max_size < log_size)) {
+		ena_trc_err(ena_dev, "Indirect table size doesn't fit. requested size: %d while min is:%d and max %d\n",
+			    1 << log_size,
+			    1 << get_resp.u.ind_table.min_size,
+			    1 << get_resp.u.ind_table.max_size);
+		return ENA_COM_INVAL;
+	}
+
+	tbl_size = (1ULL << log_size) *
+		sizeof(struct ena_admin_rss_ind_table_entry);
+
+	ENA_MEM_ALLOC_COHERENT(ena_dev->dmadev,
+			     tbl_size,
+			     rss->rss_ind_tbl,
+			     rss->rss_ind_tbl_dma_addr,
+			     rss->rss_ind_tbl_mem_handle);
+	if (unlikely(!rss->rss_ind_tbl))
+		goto mem_err1;
+
+	tbl_size = (1ULL << log_size) * sizeof(u16);
+	rss->host_rss_ind_tbl =
+		ENA_MEM_ALLOC(ena_dev->dmadev, tbl_size);
+	if (unlikely(!rss->host_rss_ind_tbl))
+		goto mem_err2;
+
+	rss->tbl_log_size = log_size;
+
+	return 0;
+
+mem_err2:
+	tbl_size = (1ULL << log_size) *
+		sizeof(struct ena_admin_rss_ind_table_entry);
+
+	ENA_MEM_FREE_COHERENT(ena_dev->dmadev,
+			      tbl_size,
+			      rss->rss_ind_tbl,
+			      rss->rss_ind_tbl_dma_addr,
+			      rss->rss_ind_tbl_mem_handle);
+	rss->rss_ind_tbl = NULL;
+mem_err1:
+	rss->tbl_log_size = 0;
+	return ENA_COM_NO_MEM;
+}
+
+static void ena_com_indirect_table_destroy(struct ena_com_dev *ena_dev)
+{
+	struct ena_rss *rss = &ena_dev->rss;
+	size_t tbl_size = (1ULL << rss->tbl_log_size) *
+		sizeof(struct ena_admin_rss_ind_table_entry);
+
+	if (rss->rss_ind_tbl)
+		ENA_MEM_FREE_COHERENT(ena_dev->dmadev,
+				      tbl_size,
+				      rss->rss_ind_tbl,
+				      rss->rss_ind_tbl_dma_addr,
+				      rss->rss_ind_tbl_mem_handle);
+	rss->rss_ind_tbl = NULL;
+
+	if (rss->host_rss_ind_tbl)
+		ENA_MEM_FREE(ena_dev->dmadev,
+			     rss->host_rss_ind_tbl,
+			     ((1ULL << rss->tbl_log_size) * sizeof(u16)));
+	rss->host_rss_ind_tbl = NULL;
+}
+
+static int ena_com_create_io_sq(struct ena_com_dev *ena_dev,
+				struct ena_com_io_sq *io_sq, u16 cq_idx)
+{
+	struct ena_com_admin_queue *admin_queue = &ena_dev->admin_queue;
+	struct ena_admin_aq_create_sq_cmd create_cmd;
+	struct ena_admin_acq_create_sq_resp_desc cmd_completion;
+	u8 direction;
+	int ret;
+
+	memset(&create_cmd, 0x0, sizeof(create_cmd));
+
+	create_cmd.aq_common_descriptor.opcode = ENA_ADMIN_CREATE_SQ;
+
+	if (io_sq->direction == ENA_COM_IO_QUEUE_DIRECTION_TX)
+		direction = ENA_ADMIN_SQ_DIRECTION_TX;
+	else
+		direction = ENA_ADMIN_SQ_DIRECTION_RX;
+
+	create_cmd.sq_identity |= (direction <<
+		ENA_ADMIN_AQ_CREATE_SQ_CMD_SQ_DIRECTION_SHIFT) &
+		ENA_ADMIN_AQ_CREATE_SQ_CMD_SQ_DIRECTION_MASK;
+
+	create_cmd.sq_caps_2 |= io_sq->mem_queue_type &
+		ENA_ADMIN_AQ_CREATE_SQ_CMD_PLACEMENT_POLICY_MASK;
+
+	create_cmd.sq_caps_2 |= (ENA_ADMIN_COMPLETION_POLICY_DESC <<
+		ENA_ADMIN_AQ_CREATE_SQ_CMD_COMPLETION_POLICY_SHIFT) &
+		ENA_ADMIN_AQ_CREATE_SQ_CMD_COMPLETION_POLICY_MASK;
+
+	create_cmd.sq_caps_3 |=
+		ENA_ADMIN_AQ_CREATE_SQ_CMD_IS_PHYSICALLY_CONTIGUOUS_MASK;
+
+	create_cmd.cq_idx = cq_idx;
+	create_cmd.sq_depth = io_sq->q_depth;
+
+	if (io_sq->mem_queue_type == ENA_ADMIN_PLACEMENT_POLICY_HOST) {
+		ret = ena_com_mem_addr_set(ena_dev,
+					   &create_cmd.sq_ba,
+					   io_sq->desc_addr.phys_addr);
+		if (unlikely(ret)) {
+			ena_trc_err(ena_dev, "Memory address set failed\n");
+			return ret;
+		}
+	}
+
+	ret = ena_com_execute_admin_command(admin_queue,
+					    (struct ena_admin_aq_entry *)&create_cmd,
+					    sizeof(create_cmd),
+					    (struct ena_admin_acq_entry *)&cmd_completion,
+					    sizeof(cmd_completion));
+	if (unlikely(ret)) {
+		ena_trc_err(ena_dev, "Failed to create IO SQ. error: %d\n", ret);
+		return ret;
+	}
+
+	io_sq->idx = cmd_completion.sq_idx;
+
+	io_sq->db_addr = (u32 __iomem *)((uintptr_t)ena_dev->reg_bar +
+		(uintptr_t)cmd_completion.sq_doorbell_offset);
+
+	if (io_sq->mem_queue_type == ENA_ADMIN_PLACEMENT_POLICY_DEV) {
+		io_sq->header_addr = (u8 __iomem *)((uintptr_t)ena_dev->mem_bar
+				+ cmd_completion.llq_headers_offset);
+
+		io_sq->desc_addr.pbuf_dev_addr =
+			(u8 __iomem *)((uintptr_t)ena_dev->mem_bar +
+			cmd_completion.llq_descriptors_offset);
+	}
+
+	ena_trc_dbg(ena_dev, "Created sq[%u], depth[%u]\n", io_sq->idx, io_sq->q_depth);
+
+	return ret;
+}
+
+static int ena_com_ind_tbl_convert_to_device(struct ena_com_dev *ena_dev)
+{
+	struct ena_rss *rss = &ena_dev->rss;
+	struct ena_com_io_sq *io_sq;
+	u16 qid;
+	int i;
+
+	for (i = 0; i < 1 << rss->tbl_log_size; i++) {
+		qid = rss->host_rss_ind_tbl[i];
+		if (qid >= ENA_TOTAL_NUM_QUEUES)
+			return ENA_COM_INVAL;
+
+		io_sq = &ena_dev->io_sq_queues[qid];
+
+		if (io_sq->direction != ENA_COM_IO_QUEUE_DIRECTION_RX)
+			return ENA_COM_INVAL;
+
+		rss->rss_ind_tbl[i].cq_idx = io_sq->idx;
+	}
+
+	return 0;
+}
+
+static void ena_com_update_intr_delay_resolution(struct ena_com_dev *ena_dev,
+						 u16 intr_delay_resolution)
+{
+	u16 prev_intr_delay_resolution = ena_dev->intr_delay_resolution;
+
+	if (unlikely(!intr_delay_resolution)) {
+		ena_trc_err(ena_dev, "Illegal intr_delay_resolution provided. Going to use default 1 usec resolution\n");
+		intr_delay_resolution = ENA_DEFAULT_INTR_DELAY_RESOLUTION;
+	}
+
+	/* update Rx */
+	ena_dev->intr_moder_rx_interval =
+		ena_dev->intr_moder_rx_interval *
+		prev_intr_delay_resolution /
+		intr_delay_resolution;
+
+	/* update Tx */
+	ena_dev->intr_moder_tx_interval =
+		ena_dev->intr_moder_tx_interval *
+		prev_intr_delay_resolution /
+		intr_delay_resolution;
+
+	ena_dev->intr_delay_resolution = intr_delay_resolution;
+}
+
+/*****************************************************************************/
+/*******************************      API       ******************************/
+/*****************************************************************************/
+
+int ena_com_execute_admin_command(struct ena_com_admin_queue *admin_queue,
+				  struct ena_admin_aq_entry *cmd,
+				  size_t cmd_size,
+				  struct ena_admin_acq_entry *comp,
+				  size_t comp_size)
+{
+	struct ena_comp_ctx *comp_ctx;
+	int ret;
+
+	comp_ctx = ena_com_submit_admin_cmd(admin_queue, cmd, cmd_size,
+					    comp, comp_size);
+	if (IS_ERR(comp_ctx)) {
+		if (comp_ctx == ERR_PTR(ENA_COM_NO_DEVICE))
+			ena_trc_dbg(admin_queue->ena_dev,
+				    "Failed to submit command [%ld]\n",
+				    PTR_ERR(comp_ctx));
+		else
+			ena_trc_err(admin_queue->ena_dev,
+				    "Failed to submit command [%ld]\n",
+				    PTR_ERR(comp_ctx));
+
+		return (int)PTR_ERR(comp_ctx);
+	}
+
+	ret = ena_com_wait_and_process_admin_cq(comp_ctx, admin_queue);
+	if (unlikely(ret)) {
+		if (admin_queue->running_state)
+			ena_trc_err(admin_queue->ena_dev,
+				    "Failed to process command. ret = %d\n", ret);
+		else
+			ena_trc_dbg(admin_queue->ena_dev,
+				    "Failed to process command. ret = %d\n", ret);
+	}
+	return ret;
+}
+
+int ena_com_create_io_cq(struct ena_com_dev *ena_dev,
+			 struct ena_com_io_cq *io_cq)
+{
+	struct ena_com_admin_queue *admin_queue = &ena_dev->admin_queue;
+	struct ena_admin_aq_create_cq_cmd create_cmd;
+	struct ena_admin_acq_create_cq_resp_desc cmd_completion;
+	int ret;
+
+	memset(&create_cmd, 0x0, sizeof(create_cmd));
+
+	create_cmd.aq_common_descriptor.opcode = ENA_ADMIN_CREATE_CQ;
+
+	create_cmd.cq_caps_2 |= (io_cq->cdesc_entry_size_in_bytes / 4) &
+		ENA_ADMIN_AQ_CREATE_CQ_CMD_CQ_ENTRY_SIZE_WORDS_MASK;
+	create_cmd.cq_caps_1 |=
+		ENA_ADMIN_AQ_CREATE_CQ_CMD_INTERRUPT_MODE_ENABLED_MASK;
+
+	create_cmd.msix_vector = io_cq->msix_vector;
+	create_cmd.cq_depth = io_cq->q_depth;
+
+	ret = ena_com_mem_addr_set(ena_dev,
+				   &create_cmd.cq_ba,
+				   io_cq->cdesc_addr.phys_addr);
+	if (unlikely(ret)) {
+		ena_trc_err(ena_dev, "Memory address set failed\n");
+		return ret;
+	}
+
+	ret = ena_com_execute_admin_command(admin_queue,
+					    (struct ena_admin_aq_entry *)&create_cmd,
+					    sizeof(create_cmd),
+					    (struct ena_admin_acq_entry *)&cmd_completion,
+					    sizeof(cmd_completion));
+	if (unlikely(ret)) {
+		ena_trc_err(ena_dev, "Failed to create IO CQ. error: %d\n", ret);
+		return ret;
+	}
+
+	io_cq->idx = cmd_completion.cq_idx;
+
+	io_cq->unmask_reg = (u32 __iomem *)((uintptr_t)ena_dev->reg_bar +
+		cmd_completion.cq_interrupt_unmask_register_offset);
+
+	if (cmd_completion.cq_head_db_register_offset)
+		io_cq->cq_head_db_reg =
+			(u32 __iomem *)((uintptr_t)ena_dev->reg_bar +
+			cmd_completion.cq_head_db_register_offset);
+
+	if (cmd_completion.numa_node_register_offset)
+		io_cq->numa_node_cfg_reg =
+			(u32 __iomem *)((uintptr_t)ena_dev->reg_bar +
+			cmd_completion.numa_node_register_offset);
+
+	ena_trc_dbg(ena_dev, "Created cq[%u], depth[%u]\n", io_cq->idx, io_cq->q_depth);
+
+	return ret;
+}
+
+int ena_com_get_io_handlers(struct ena_com_dev *ena_dev, u16 qid,
+			    struct ena_com_io_sq **io_sq,
+			    struct ena_com_io_cq **io_cq)
+{
+	if (qid >= ENA_TOTAL_NUM_QUEUES) {
+		ena_trc_err(ena_dev, "Invalid queue number %d but the max is %d\n",
+			    qid, ENA_TOTAL_NUM_QUEUES);
+		return ENA_COM_INVAL;
+	}
+
+	*io_sq = &ena_dev->io_sq_queues[qid];
+	*io_cq = &ena_dev->io_cq_queues[qid];
+
+	return 0;
+}
+
+void ena_com_abort_admin_commands(struct ena_com_dev *ena_dev)
+{
+	struct ena_com_admin_queue *admin_queue = &ena_dev->admin_queue;
+	struct ena_comp_ctx *comp_ctx;
+	u16 i;
+
+	if (!admin_queue->comp_ctx)
+		return;
+
+	for (i = 0; i < admin_queue->q_depth; i++) {
+		comp_ctx = get_comp_ctxt(admin_queue, i, false);
+		if (unlikely(!comp_ctx))
+			break;
+
+		comp_ctx->status = ENA_CMD_ABORTED;
+
+		ENA_WAIT_EVENT_SIGNAL(comp_ctx->wait_event);
+	}
+}
+
+void ena_com_wait_for_abort_completion(struct ena_com_dev *ena_dev)
+{
+	struct ena_com_admin_queue *admin_queue = &ena_dev->admin_queue;
+	unsigned long flags = 0;
+	u32 exp = 0;
+
+	ENA_SPINLOCK_LOCK(admin_queue->q_lock, flags);
+	while (ATOMIC32_READ(&admin_queue->outstanding_cmds) != 0) {
+		ENA_SPINLOCK_UNLOCK(admin_queue->q_lock, flags);
+		ena_delay_exponential_backoff_us(exp++, ena_dev->ena_min_poll_delay_us);
+		ENA_SPINLOCK_LOCK(admin_queue->q_lock, flags);
+	}
+	ENA_SPINLOCK_UNLOCK(admin_queue->q_lock, flags);
+}
+
+int ena_com_destroy_io_cq(struct ena_com_dev *ena_dev,
+			  struct ena_com_io_cq *io_cq)
+{
+	struct ena_com_admin_queue *admin_queue = &ena_dev->admin_queue;
+	struct ena_admin_aq_destroy_cq_cmd destroy_cmd;
+	struct ena_admin_acq_destroy_cq_resp_desc destroy_resp;
+	int ret;
+
+	memset(&destroy_cmd, 0x0, sizeof(destroy_cmd));
+
+	destroy_cmd.cq_idx = io_cq->idx;
+	destroy_cmd.aq_common_descriptor.opcode = ENA_ADMIN_DESTROY_CQ;
+
+	ret = ena_com_execute_admin_command(admin_queue,
+					    (struct ena_admin_aq_entry *)&destroy_cmd,
+					    sizeof(destroy_cmd),
+					    (struct ena_admin_acq_entry *)&destroy_resp,
+					    sizeof(destroy_resp));
+
+	if (unlikely(ret && (ret != ENA_COM_NO_DEVICE)))
+		ena_trc_err(ena_dev, "Failed to destroy IO CQ. error: %d\n", ret);
+
+	return ret;
+}
+
+bool ena_com_get_admin_running_state(struct ena_com_dev *ena_dev)
+{
+	return ena_dev->admin_queue.running_state;
+}
+
+void ena_com_set_admin_running_state(struct ena_com_dev *ena_dev, bool state)
+{
+	struct ena_com_admin_queue *admin_queue = &ena_dev->admin_queue;
+	unsigned long flags = 0;
+
+	ENA_SPINLOCK_LOCK(admin_queue->q_lock, flags);
+	ena_dev->admin_queue.running_state = state;
+	ENA_SPINLOCK_UNLOCK(admin_queue->q_lock, flags);
+}
+
+void ena_com_admin_aenq_enable(struct ena_com_dev *ena_dev)
+{
+	u16 depth = ena_dev->aenq.q_depth;
+
+	ENA_WARN(ena_dev->aenq.head != depth, ena_dev, "Invalid AENQ state\n");
+
+	/* Init head_db to mark that all entries in the queue
+	 * are initially available
+	 */
+	ENA_REG_WRITE32(ena_dev->bus, depth, ena_dev->reg_bar + ENA_REGS_AENQ_HEAD_DB_OFF);
+}
+
+int ena_com_set_aenq_config(struct ena_com_dev *ena_dev, u32 groups_flag)
+{
+	struct ena_com_admin_queue *admin_queue;
+	struct ena_admin_set_feat_cmd cmd;
+	struct ena_admin_set_feat_resp resp;
+	struct ena_admin_get_feat_resp get_resp;
+	int ret;
+
+	ret = ena_com_get_feature(ena_dev, &get_resp, ENA_ADMIN_AENQ_CONFIG, 0);
+	if (ret) {
+		ena_trc_info(ena_dev, "Can't get aenq configuration\n");
+		return ret;
+	}
+
+	if ((get_resp.u.aenq.supported_groups & groups_flag) != groups_flag) {
+		ena_trc_warn(ena_dev, "Trying to set unsupported aenq events. supported flag: 0x%x asked flag: 0x%x\n",
+			     get_resp.u.aenq.supported_groups,
+			     groups_flag);
+		return ENA_COM_UNSUPPORTED;
+	}
+
+	memset(&cmd, 0x0, sizeof(cmd));
+	admin_queue = &ena_dev->admin_queue;
+
+	cmd.aq_common_descriptor.opcode = ENA_ADMIN_SET_FEATURE;
+	cmd.aq_common_descriptor.flags = 0;
+	cmd.feat_common.feature_id = ENA_ADMIN_AENQ_CONFIG;
+	cmd.u.aenq.enabled_groups = groups_flag;
+
+	ret = ena_com_execute_admin_command(admin_queue,
+					    (struct ena_admin_aq_entry *)&cmd,
+					    sizeof(cmd),
+					    (struct ena_admin_acq_entry *)&resp,
+					    sizeof(resp));
+
+	if (unlikely(ret))
+		ena_trc_err(ena_dev, "Failed to config AENQ ret: %d\n", ret);
+
+	return ret;
+}
+
+int ena_com_get_dma_width(struct ena_com_dev *ena_dev)
+{
+	u32 caps = ena_com_reg_bar_read32(ena_dev, ENA_REGS_CAPS_OFF);
+	u32 width;
+
+	if (unlikely(caps == ENA_MMIO_READ_TIMEOUT)) {
+		ena_trc_err(ena_dev, "Reg read timeout occurred\n");
+		return ENA_COM_TIMER_EXPIRED;
+	}
+
+	width = (caps & ENA_REGS_CAPS_DMA_ADDR_WIDTH_MASK) >>
+		ENA_REGS_CAPS_DMA_ADDR_WIDTH_SHIFT;
+
+	ena_trc_dbg(ena_dev, "ENA dma width: %d\n", width);
+
+	if ((width < 32) || width > ENA_MAX_PHYS_ADDR_SIZE_BITS) {
+		ena_trc_err(ena_dev, "DMA width illegal value: %d\n", width);
+		return ENA_COM_INVAL;
+	}
+
+	ena_dev->dma_addr_bits = width;
+
+	return width;
+}
+
+int ena_com_validate_version(struct ena_com_dev *ena_dev)
+{
+	u32 ver;
+	u32 ctrl_ver;
+	u32 ctrl_ver_masked;
+
+	/* Make sure the ENA version and the controller version are at least
+	 * as the driver expects
+	 */
+	ver = ena_com_reg_bar_read32(ena_dev, ENA_REGS_VERSION_OFF);
+	ctrl_ver = ena_com_reg_bar_read32(ena_dev,
+					  ENA_REGS_CONTROLLER_VERSION_OFF);
+
+	if (unlikely((ver == ENA_MMIO_READ_TIMEOUT) ||
+		     (ctrl_ver == ENA_MMIO_READ_TIMEOUT))) {
+		ena_trc_err(ena_dev, "Reg read timeout occurred\n");
+		return ENA_COM_TIMER_EXPIRED;
+	}
+
+	ena_trc_info(ena_dev, "ENA device version: %d.%d\n",
+		     (ver & ENA_REGS_VERSION_MAJOR_VERSION_MASK) >>
+		     ENA_REGS_VERSION_MAJOR_VERSION_SHIFT,
+		     ver & ENA_REGS_VERSION_MINOR_VERSION_MASK);
+
+	ena_trc_info(ena_dev, "ENA controller version: %d.%d.%d implementation version %d\n",
+		     (ctrl_ver & ENA_REGS_CONTROLLER_VERSION_MAJOR_VERSION_MASK)
+		     >> ENA_REGS_CONTROLLER_VERSION_MAJOR_VERSION_SHIFT,
+		     (ctrl_ver & ENA_REGS_CONTROLLER_VERSION_MINOR_VERSION_MASK)
+		     >> ENA_REGS_CONTROLLER_VERSION_MINOR_VERSION_SHIFT,
+		     (ctrl_ver & ENA_REGS_CONTROLLER_VERSION_SUBMINOR_VERSION_MASK),
+		     (ctrl_ver & ENA_REGS_CONTROLLER_VERSION_IMPL_ID_MASK) >>
+		     ENA_REGS_CONTROLLER_VERSION_IMPL_ID_SHIFT);
+
+	ctrl_ver_masked =
+		(ctrl_ver & ENA_REGS_CONTROLLER_VERSION_MAJOR_VERSION_MASK) |
+		(ctrl_ver & ENA_REGS_CONTROLLER_VERSION_MINOR_VERSION_MASK) |
+		(ctrl_ver & ENA_REGS_CONTROLLER_VERSION_SUBMINOR_VERSION_MASK);
+
+	/* Validate the ctrl version without the implementation ID */
+	if (ctrl_ver_masked < MIN_ENA_CTRL_VER) {
+		ena_trc_err(ena_dev, "ENA ctrl version is lower than the minimal ctrl version the driver supports\n");
+		return -1;
+	}
+
+	return 0;
+}
+
+static void
+ena_com_free_ena_admin_queue_comp_ctx(struct ena_com_dev *ena_dev,
+				      struct ena_com_admin_queue *admin_queue)
+
+{
+	if (!admin_queue->comp_ctx)
+		return;
+
+	ENA_WAIT_EVENTS_DESTROY(admin_queue);
+	ENA_MEM_FREE(ena_dev->dmadev,
+		     admin_queue->comp_ctx,
+		     (admin_queue->q_depth * sizeof(struct ena_comp_ctx)));
+
+	admin_queue->comp_ctx = NULL;
+}
+
+void ena_com_admin_destroy(struct ena_com_dev *ena_dev)
+{
+	struct ena_com_admin_queue *admin_queue = &ena_dev->admin_queue;
+	struct ena_com_admin_cq *cq = &admin_queue->cq;
+	struct ena_com_admin_sq *sq = &admin_queue->sq;
+	struct ena_com_aenq *aenq = &ena_dev->aenq;
+	u16 size;
+
+	ena_com_free_ena_admin_queue_comp_ctx(ena_dev, admin_queue);
+
+	size = ADMIN_SQ_SIZE(admin_queue->q_depth);
+	if (sq->entries)
+		ENA_MEM_FREE_COHERENT(ena_dev->dmadev, size, sq->entries,
+				      sq->dma_addr, sq->mem_handle);
+	sq->entries = NULL;
+
+	size = ADMIN_CQ_SIZE(admin_queue->q_depth);
+	if (cq->entries)
+		ENA_MEM_FREE_COHERENT(ena_dev->dmadev, size, cq->entries,
+				      cq->dma_addr, cq->mem_handle);
+	cq->entries = NULL;
+
+	size = ADMIN_AENQ_SIZE(aenq->q_depth);
+	if (ena_dev->aenq.entries)
+		ENA_MEM_FREE_COHERENT(ena_dev->dmadev, size, aenq->entries,
+				      aenq->dma_addr, aenq->mem_handle);
+	aenq->entries = NULL;
+	ENA_SPINLOCK_DESTROY(admin_queue->q_lock);
+}
+
+void ena_com_set_admin_polling_mode(struct ena_com_dev *ena_dev, bool polling)
+{
+	u32 mask_value = 0;
+
+	if (polling)
+		mask_value = ENA_REGS_ADMIN_INTR_MASK;
+
+	ENA_REG_WRITE32(ena_dev->bus, mask_value,
+			ena_dev->reg_bar + ENA_REGS_INTR_MASK_OFF);
+	ena_dev->admin_queue.polling = polling;
+}
+
+bool ena_com_get_admin_polling_mode(struct ena_com_dev *ena_dev)
+{
+	return ena_dev->admin_queue.polling;
+}
+
+void ena_com_set_admin_auto_polling_mode(struct ena_com_dev *ena_dev,
+					 bool polling)
+{
+	ena_dev->admin_queue.auto_polling = polling;
+}
+
+int ena_com_mmio_reg_read_request_init(struct ena_com_dev *ena_dev)
+{
+	struct ena_com_mmio_read *mmio_read = &ena_dev->mmio_read;
+
+	ENA_SPINLOCK_INIT(mmio_read->lock);
+	ENA_MEM_ALLOC_COHERENT(ena_dev->dmadev,
+			       sizeof(*mmio_read->read_resp),
+			       mmio_read->read_resp,
+			       mmio_read->read_resp_dma_addr,
+			       mmio_read->read_resp_mem_handle);
+	if (unlikely(!mmio_read->read_resp))
+		goto err;
+
+	ena_com_mmio_reg_read_request_write_dev_addr(ena_dev);
+
+	mmio_read->read_resp->req_id = 0x0;
+	mmio_read->seq_num = 0x0;
+	mmio_read->readless_supported = true;
+
+	return 0;
+
+err:
+		ENA_SPINLOCK_DESTROY(mmio_read->lock);
+		return ENA_COM_NO_MEM;
+}
+
+void ena_com_set_mmio_read_mode(struct ena_com_dev *ena_dev, bool readless_supported)
+{
+	struct ena_com_mmio_read *mmio_read = &ena_dev->mmio_read;
+
+	mmio_read->readless_supported = readless_supported;
+}
+
+void ena_com_mmio_reg_read_request_destroy(struct ena_com_dev *ena_dev)
+{
+	struct ena_com_mmio_read *mmio_read = &ena_dev->mmio_read;
+
+	ENA_REG_WRITE32(ena_dev->bus, 0x0, ena_dev->reg_bar + ENA_REGS_MMIO_RESP_LO_OFF);
+	ENA_REG_WRITE32(ena_dev->bus, 0x0, ena_dev->reg_bar + ENA_REGS_MMIO_RESP_HI_OFF);
+
+	ENA_MEM_FREE_COHERENT(ena_dev->dmadev,
+			      sizeof(*mmio_read->read_resp),
+			      mmio_read->read_resp,
+			      mmio_read->read_resp_dma_addr,
+			      mmio_read->read_resp_mem_handle);
+
+	mmio_read->read_resp = NULL;
+	ENA_SPINLOCK_DESTROY(mmio_read->lock);
+}
+
+void ena_com_mmio_reg_read_request_write_dev_addr(struct ena_com_dev *ena_dev)
+{
+	struct ena_com_mmio_read *mmio_read = &ena_dev->mmio_read;
+	u32 addr_low, addr_high;
+
+	addr_low = ENA_DMA_ADDR_TO_UINT32_LOW(mmio_read->read_resp_dma_addr);
+	addr_high = ENA_DMA_ADDR_TO_UINT32_HIGH(mmio_read->read_resp_dma_addr);
+
+	ENA_REG_WRITE32(ena_dev->bus, addr_low, ena_dev->reg_bar + ENA_REGS_MMIO_RESP_LO_OFF);
+	ENA_REG_WRITE32(ena_dev->bus, addr_high, ena_dev->reg_bar + ENA_REGS_MMIO_RESP_HI_OFF);
+}
+
+int ena_com_admin_init(struct ena_com_dev *ena_dev,
+		       struct ena_aenq_handlers *aenq_handlers)
+{
+	struct ena_com_admin_queue *admin_queue = &ena_dev->admin_queue;
+	u32 aq_caps, acq_caps, dev_sts, addr_low, addr_high;
+	int ret;
+
+	dev_sts = ena_com_reg_bar_read32(ena_dev, ENA_REGS_DEV_STS_OFF);
+
+	if (unlikely(dev_sts == ENA_MMIO_READ_TIMEOUT)) {
+		ena_trc_err(ena_dev, "Reg read timeout occurred\n");
+		return ENA_COM_TIMER_EXPIRED;
+	}
+
+	if (!(dev_sts & ENA_REGS_DEV_STS_READY_MASK)) {
+		ena_trc_err(ena_dev, "Device isn't ready, abort com init\n");
+		return ENA_COM_NO_DEVICE;
+	}
+
+	admin_queue->q_depth = ENA_ADMIN_QUEUE_DEPTH;
+
+	admin_queue->bus = ena_dev->bus;
+	admin_queue->q_dmadev = ena_dev->dmadev;
+	admin_queue->polling = false;
+	admin_queue->curr_cmd_id = 0;
+
+	ATOMIC32_SET(&admin_queue->outstanding_cmds, 0);
+
+	ENA_SPINLOCK_INIT(admin_queue->q_lock);
+
+	ret = ena_com_init_comp_ctxt(admin_queue);
+	if (ret)
+		goto error;
+
+	ret = ena_com_admin_init_sq(admin_queue);
+	if (ret)
+		goto error;
+
+	ret = ena_com_admin_init_cq(admin_queue);
+	if (ret)
+		goto error;
+
+	admin_queue->sq.db_addr = (u32 __iomem *)((uintptr_t)ena_dev->reg_bar +
+		ENA_REGS_AQ_DB_OFF);
+
+	addr_low = ENA_DMA_ADDR_TO_UINT32_LOW(admin_queue->sq.dma_addr);
+	addr_high = ENA_DMA_ADDR_TO_UINT32_HIGH(admin_queue->sq.dma_addr);
+
+	ENA_REG_WRITE32(ena_dev->bus, addr_low, ena_dev->reg_bar + ENA_REGS_AQ_BASE_LO_OFF);
+	ENA_REG_WRITE32(ena_dev->bus, addr_high, ena_dev->reg_bar + ENA_REGS_AQ_BASE_HI_OFF);
+
+	addr_low = ENA_DMA_ADDR_TO_UINT32_LOW(admin_queue->cq.dma_addr);
+	addr_high = ENA_DMA_ADDR_TO_UINT32_HIGH(admin_queue->cq.dma_addr);
+
+	ENA_REG_WRITE32(ena_dev->bus, addr_low, ena_dev->reg_bar + ENA_REGS_ACQ_BASE_LO_OFF);
+	ENA_REG_WRITE32(ena_dev->bus, addr_high, ena_dev->reg_bar + ENA_REGS_ACQ_BASE_HI_OFF);
+
+	aq_caps = 0;
+	aq_caps |= admin_queue->q_depth & ENA_REGS_AQ_CAPS_AQ_DEPTH_MASK;
+	aq_caps |= (sizeof(struct ena_admin_aq_entry) <<
+			ENA_REGS_AQ_CAPS_AQ_ENTRY_SIZE_SHIFT) &
+			ENA_REGS_AQ_CAPS_AQ_ENTRY_SIZE_MASK;
+
+	acq_caps = 0;
+	acq_caps |= admin_queue->q_depth & ENA_REGS_ACQ_CAPS_ACQ_DEPTH_MASK;
+	acq_caps |= (sizeof(struct ena_admin_acq_entry) <<
+		ENA_REGS_ACQ_CAPS_ACQ_ENTRY_SIZE_SHIFT) &
+		ENA_REGS_ACQ_CAPS_ACQ_ENTRY_SIZE_MASK;
+
+	ENA_REG_WRITE32(ena_dev->bus, aq_caps, ena_dev->reg_bar + ENA_REGS_AQ_CAPS_OFF);
+	ENA_REG_WRITE32(ena_dev->bus, acq_caps, ena_dev->reg_bar + ENA_REGS_ACQ_CAPS_OFF);
+	ret = ena_com_admin_init_aenq(ena_dev, aenq_handlers);
+	if (ret)
+		goto error;
+
+	admin_queue->ena_dev = ena_dev;
+	admin_queue->running_state = true;
+
+	return 0;
+error:
+	ena_com_admin_destroy(ena_dev);
+
+	return ret;
+}
+
+int ena_com_create_io_queue(struct ena_com_dev *ena_dev,
+			    struct ena_com_create_io_ctx *ctx)
+{
+	struct ena_com_io_sq *io_sq;
+	struct ena_com_io_cq *io_cq;
+	int ret;
+
+	if (ctx->qid >= ENA_TOTAL_NUM_QUEUES) {
+		ena_trc_err(ena_dev, "Qid (%d) is bigger than max num of queues (%d)\n",
+			    ctx->qid, ENA_TOTAL_NUM_QUEUES);
+		return ENA_COM_INVAL;
+	}
+
+	io_sq = &ena_dev->io_sq_queues[ctx->qid];
+	io_cq = &ena_dev->io_cq_queues[ctx->qid];
+
+	memset(io_sq, 0x0, sizeof(*io_sq));
+	memset(io_cq, 0x0, sizeof(*io_cq));
+
+	/* Init CQ */
+	io_cq->q_depth = ctx->queue_size;
+	io_cq->direction = ctx->direction;
+	io_cq->qid = ctx->qid;
+
+	io_cq->msix_vector = ctx->msix_vector;
+
+	io_sq->q_depth = ctx->queue_size;
+	io_sq->direction = ctx->direction;
+	io_sq->qid = ctx->qid;
+
+	io_sq->mem_queue_type = ctx->mem_queue_type;
+
+	if (ctx->direction == ENA_COM_IO_QUEUE_DIRECTION_TX)
+		/* header length is limited to 8 bits */
+		io_sq->tx_max_header_size =
+			ENA_MIN32(ena_dev->tx_max_header_size, SZ_256);
+
+	ret = ena_com_init_io_sq(ena_dev, ctx, io_sq);
+	if (ret)
+		goto error;
+	ret = ena_com_init_io_cq(ena_dev, ctx, io_cq);
+	if (ret)
+		goto error;
+
+	ret = ena_com_create_io_cq(ena_dev, io_cq);
+	if (ret)
+		goto error;
+
+	ret = ena_com_create_io_sq(ena_dev, io_sq, io_cq->idx);
+	if (ret)
+		goto destroy_io_cq;
+
+	return 0;
+
+destroy_io_cq:
+	ena_com_destroy_io_cq(ena_dev, io_cq);
+error:
+	ena_com_io_queue_free(ena_dev, io_sq, io_cq);
+	return ret;
+}
+
+void ena_com_destroy_io_queue(struct ena_com_dev *ena_dev, u16 qid)
+{
+	struct ena_com_io_sq *io_sq;
+	struct ena_com_io_cq *io_cq;
+
+	if (qid >= ENA_TOTAL_NUM_QUEUES) {
+		ena_trc_err(ena_dev, "Qid (%d) is bigger than max num of queues (%d)\n",
+			    qid, ENA_TOTAL_NUM_QUEUES);
+		return;
+	}
+
+	io_sq = &ena_dev->io_sq_queues[qid];
+	io_cq = &ena_dev->io_cq_queues[qid];
+
+	ena_com_destroy_io_sq(ena_dev, io_sq);
+	ena_com_destroy_io_cq(ena_dev, io_cq);
+
+	ena_com_io_queue_free(ena_dev, io_sq, io_cq);
+}
+
+int ena_com_get_link_params(struct ena_com_dev *ena_dev,
+			    struct ena_admin_get_feat_resp *resp)
+{
+	return ena_com_get_feature(ena_dev, resp, ENA_ADMIN_LINK_CONFIG, 0);
+}
+
+int ena_com_get_dev_attr_feat(struct ena_com_dev *ena_dev,
+			      struct ena_com_dev_get_features_ctx *get_feat_ctx)
+{
+	struct ena_admin_get_feat_resp get_resp;
+	int rc;
+
+	rc = ena_com_get_feature(ena_dev, &get_resp,
+				 ENA_ADMIN_DEVICE_ATTRIBUTES, 0);
+	if (rc)
+		return rc;
+
+	memcpy(&get_feat_ctx->dev_attr, &get_resp.u.dev_attr,
+	       sizeof(get_resp.u.dev_attr));
+
+	ena_dev->supported_features = get_resp.u.dev_attr.supported_features;
+
+	if (ena_dev->supported_features & BIT(ENA_ADMIN_MAX_QUEUES_EXT)) {
+		rc = ena_com_get_feature(ena_dev, &get_resp,
+					 ENA_ADMIN_MAX_QUEUES_EXT,
+					 ENA_FEATURE_MAX_QUEUE_EXT_VER);
+		if (rc)
+			return rc;
+
+		if (get_resp.u.max_queue_ext.version != ENA_FEATURE_MAX_QUEUE_EXT_VER)
+			return -EINVAL;
+
+		memcpy(&get_feat_ctx->max_queue_ext, &get_resp.u.max_queue_ext,
+		       sizeof(get_resp.u.max_queue_ext));
+		ena_dev->tx_max_header_size =
+			get_resp.u.max_queue_ext.max_queue_ext.max_tx_header_size;
+	} else {
+		rc = ena_com_get_feature(ena_dev, &get_resp,
+					 ENA_ADMIN_MAX_QUEUES_NUM, 0);
+		memcpy(&get_feat_ctx->max_queues, &get_resp.u.max_queue,
+		       sizeof(get_resp.u.max_queue));
+		ena_dev->tx_max_header_size =
+			get_resp.u.max_queue.max_header_size;
+
+		if (rc)
+			return rc;
+	}
+
+	rc = ena_com_get_feature(ena_dev, &get_resp,
+				 ENA_ADMIN_AENQ_CONFIG, 0);
+	if (rc)
+		return rc;
+
+	memcpy(&get_feat_ctx->aenq, &get_resp.u.aenq,
+	       sizeof(get_resp.u.aenq));
+
+	rc = ena_com_get_feature(ena_dev, &get_resp,
+				 ENA_ADMIN_STATELESS_OFFLOAD_CONFIG, 0);
+	if (rc)
+		return rc;
+
+	memcpy(&get_feat_ctx->offload, &get_resp.u.offload,
+	       sizeof(get_resp.u.offload));
+
+	/* Driver hints isn't mandatory admin command. So in case the
+	 * command isn't supported set driver hints to 0
+	 */
+	rc = ena_com_get_feature(ena_dev, &get_resp, ENA_ADMIN_HW_HINTS, 0);
+
+	if (!rc)
+		memcpy(&get_feat_ctx->hw_hints, &get_resp.u.hw_hints,
+		       sizeof(get_resp.u.hw_hints));
+	else if (rc == ENA_COM_UNSUPPORTED)
+		memset(&get_feat_ctx->hw_hints, 0x0, sizeof(get_feat_ctx->hw_hints));
+	else
+		return rc;
+
+	rc = ena_com_get_feature(ena_dev, &get_resp, ENA_ADMIN_LLQ, 0);
+	if (!rc)
+		memcpy(&get_feat_ctx->llq, &get_resp.u.llq,
+		       sizeof(get_resp.u.llq));
+	else if (rc == ENA_COM_UNSUPPORTED)
+		memset(&get_feat_ctx->llq, 0x0, sizeof(get_feat_ctx->llq));
+	else
+		return rc;
+
+	return 0;
+}
+
+void ena_com_admin_q_comp_intr_handler(struct ena_com_dev *ena_dev)
+{
+	ena_com_handle_admin_completion(&ena_dev->admin_queue);
+}
+
+/* ena_handle_specific_aenq_event:
+ * return the handler that is relevant to the specific event group
+ */
+static ena_aenq_handler ena_com_get_specific_aenq_cb(struct ena_com_dev *ena_dev,
+						     u16 group)
+{
+	struct ena_aenq_handlers *aenq_handlers = ena_dev->aenq.aenq_handlers;
+
+	if ((group < ENA_MAX_HANDLERS) && aenq_handlers->handlers[group])
+		return aenq_handlers->handlers[group];
+
+	return aenq_handlers->unimplemented_handler;
+}
+
+/* ena_aenq_intr_handler:
+ * handles the aenq incoming events.
+ * pop events from the queue and apply the specific handler
+ */
+void ena_com_aenq_intr_handler(struct ena_com_dev *ena_dev, void *data)
+{
+	struct ena_admin_aenq_entry *aenq_e;
+	struct ena_admin_aenq_common_desc *aenq_common;
+	struct ena_com_aenq *aenq  = &ena_dev->aenq;
+	u64 timestamp;
+	ena_aenq_handler handler_cb;
+	u16 masked_head, processed = 0;
+	u8 phase;
+
+	masked_head = aenq->head & (aenq->q_depth - 1);
+	phase = aenq->phase;
+	aenq_e = &aenq->entries[masked_head]; /* Get first entry */
+	aenq_common = &aenq_e->aenq_common_desc;
+
+	/* Go over all the events */
+	while ((READ_ONCE8(aenq_common->flags) &
+		ENA_ADMIN_AENQ_COMMON_DESC_PHASE_MASK) == phase) {
+		/* Make sure the phase bit (ownership) is as expected before
+		 * reading the rest of the descriptor.
+		 */
+		dma_rmb();
+
+		timestamp = (u64)aenq_common->timestamp_low |
+			((u64)aenq_common->timestamp_high << 32);
+
+		ena_trc_dbg(ena_dev, "AENQ! Group[%x] Syndrome[%x] timestamp: [%" ENA_PRIu64 "s]\n",
+			    aenq_common->group,
+			    aenq_common->syndrome,
+			    timestamp);
+
+		/* Handle specific event*/
+		handler_cb = ena_com_get_specific_aenq_cb(ena_dev,
+							  aenq_common->group);
+		handler_cb(data, aenq_e); /* call the actual event handler*/
+
+		/* Get next event entry */
+		masked_head++;
+		processed++;
+
+		if (unlikely(masked_head == aenq->q_depth)) {
+			masked_head = 0;
+			phase = !phase;
+		}
+		aenq_e = &aenq->entries[masked_head];
+		aenq_common = &aenq_e->aenq_common_desc;
+	}
+
+	aenq->head += processed;
+	aenq->phase = phase;
+
+	/* Don't update aenq doorbell if there weren't any processed events */
+	if (!processed)
+		return;
+
+	/* write the aenq doorbell after all AENQ descriptors were read */
+	mb();
+	ENA_REG_WRITE32_RELAXED(ena_dev->bus, (u32)aenq->head,
+				ena_dev->reg_bar + ENA_REGS_AENQ_HEAD_DB_OFF);
+	mmiowb();
+}
+#ifdef ENA_EXTENDED_STATS
+/*
+ * Sets the function Idx and Queue Idx to be used for
+ * get full statistics feature
+ *
+ */
+int ena_com_extended_stats_set_func_queue(struct ena_com_dev *ena_dev,
+					  u32 func_queue)
+{
+
+	/* Function & Queue is acquired from user in the following format :
+	 * Bottom Half word:	funct
+	 * Top Half Word:	queue
+	 */
+	ena_dev->stats_func = ENA_EXTENDED_STAT_GET_FUNCT(func_queue);
+	ena_dev->stats_queue = ENA_EXTENDED_STAT_GET_QUEUE(func_queue);
+
+	return 0;
+}
+
+#endif /* ENA_EXTENDED_STATS */
+
+int ena_com_dev_reset(struct ena_com_dev *ena_dev,
+		      enum ena_regs_reset_reason_types reset_reason)
+{
+	u32 stat, timeout, cap, reset_val;
+	int rc;
+
+	stat = ena_com_reg_bar_read32(ena_dev, ENA_REGS_DEV_STS_OFF);
+	cap = ena_com_reg_bar_read32(ena_dev, ENA_REGS_CAPS_OFF);
+
+	if (unlikely((stat == ENA_MMIO_READ_TIMEOUT) ||
+		     (cap == ENA_MMIO_READ_TIMEOUT))) {
+		ena_trc_err(ena_dev, "Reg read32 timeout occurred\n");
+		return ENA_COM_TIMER_EXPIRED;
+	}
+
+	if ((stat & ENA_REGS_DEV_STS_READY_MASK) == 0) {
+		ena_trc_err(ena_dev, "Device isn't ready, can't reset device\n");
+		return ENA_COM_INVAL;
+	}
+
+	timeout = (cap & ENA_REGS_CAPS_RESET_TIMEOUT_MASK) >>
+			ENA_REGS_CAPS_RESET_TIMEOUT_SHIFT;
+	if (timeout == 0) {
+		ena_trc_err(ena_dev, "Invalid timeout value\n");
+		return ENA_COM_INVAL;
+	}
+
+	/* start reset */
+	reset_val = ENA_REGS_DEV_CTL_DEV_RESET_MASK;
+	reset_val |= (reset_reason << ENA_REGS_DEV_CTL_RESET_REASON_SHIFT) &
+			ENA_REGS_DEV_CTL_RESET_REASON_MASK;
+	ENA_REG_WRITE32(ena_dev->bus, reset_val, ena_dev->reg_bar + ENA_REGS_DEV_CTL_OFF);
+
+	/* Write again the MMIO read request address */
+	ena_com_mmio_reg_read_request_write_dev_addr(ena_dev);
+
+	rc = wait_for_reset_state(ena_dev, timeout,
+				  ENA_REGS_DEV_STS_RESET_IN_PROGRESS_MASK);
+	if (rc != 0) {
+		ena_trc_err(ena_dev, "Reset indication didn't turn on\n");
+		return rc;
+	}
+
+	/* reset done */
+	ENA_REG_WRITE32(ena_dev->bus, 0, ena_dev->reg_bar + ENA_REGS_DEV_CTL_OFF);
+	rc = wait_for_reset_state(ena_dev, timeout, 0);
+	if (rc != 0) {
+		ena_trc_err(ena_dev, "Reset indication didn't turn off\n");
+		return rc;
+	}
+
+	timeout = (cap & ENA_REGS_CAPS_ADMIN_CMD_TO_MASK) >>
+		ENA_REGS_CAPS_ADMIN_CMD_TO_SHIFT;
+	if (timeout)
+		/* the resolution of timeout reg is 100ms */
+		ena_dev->admin_queue.completion_timeout = timeout * 100000;
+	else
+		ena_dev->admin_queue.completion_timeout = ADMIN_CMD_TIMEOUT_US;
+
+	return 0;
+}
+
+static int ena_get_dev_stats(struct ena_com_dev *ena_dev,
+			     struct ena_com_stats_ctx *ctx,
+			     enum ena_admin_get_stats_type type)
+{
+	struct ena_admin_aq_get_stats_cmd *get_cmd = &ctx->get_cmd;
+	struct ena_admin_acq_get_stats_resp *get_resp = &ctx->get_resp;
+	struct ena_com_admin_queue *admin_queue;
+	int ret;
+
+	admin_queue = &ena_dev->admin_queue;
+
+	get_cmd->aq_common_descriptor.opcode = ENA_ADMIN_GET_STATS;
+	get_cmd->aq_common_descriptor.flags = 0;
+	get_cmd->type = type;
+
+	ret =  ena_com_execute_admin_command(admin_queue,
+					     (struct ena_admin_aq_entry *)get_cmd,
+					     sizeof(*get_cmd),
+					     (struct ena_admin_acq_entry *)get_resp,
+					     sizeof(*get_resp));
+
+	if (unlikely(ret))
+		ena_trc_err(ena_dev, "Failed to get stats. error: %d\n", ret);
+
+	return ret;
+}
+
+int ena_com_get_eni_stats(struct ena_com_dev *ena_dev,
+			  struct ena_admin_eni_stats *stats)
+{
+	struct ena_com_stats_ctx ctx;
+	int ret;
+
+	memset(&ctx, 0x0, sizeof(ctx));
+	ret = ena_get_dev_stats(ena_dev, &ctx, ENA_ADMIN_GET_STATS_TYPE_ENI);
+	if (likely(ret == 0))
+		memcpy(stats, &ctx.get_resp.u.eni_stats,
+		       sizeof(ctx.get_resp.u.eni_stats));
+
+	return ret;
+}
+
+int ena_com_get_dev_basic_stats(struct ena_com_dev *ena_dev,
+				struct ena_admin_basic_stats *stats)
+{
+	struct ena_com_stats_ctx ctx;
+	int ret;
+
+	memset(&ctx, 0x0, sizeof(ctx));
+	ret = ena_get_dev_stats(ena_dev, &ctx, ENA_ADMIN_GET_STATS_TYPE_BASIC);
+	if (likely(ret == 0))
+		memcpy(stats, &ctx.get_resp.u.basic_stats,
+		       sizeof(ctx.get_resp.u.basic_stats));
+
+	return ret;
+}
+#ifdef ENA_EXTENDED_STATS
+
+int ena_com_get_dev_extended_stats(struct ena_com_dev *ena_dev, char *buff,
+				   u32 len)
+{
+	struct ena_com_stats_ctx ctx;
+	struct ena_admin_aq_get_stats_cmd *get_cmd = &ctx.get_cmd;
+	ena_mem_handle_t mem_handle;
+	void *virt_addr;
+	dma_addr_t phys_addr;
+	int ret;
+
+	ENA_MEM_ALLOC_COHERENT(ena_dev->dmadev, len,
+			       virt_addr, phys_addr, mem_handle);
+	if (!virt_addr) {
+		ret = ENA_COM_NO_MEM;
+		goto done;
+	}
+	memset(&ctx, 0x0, sizeof(ctx));
+	ret = ena_com_mem_addr_set(ena_dev,
+				   &get_cmd->u.control_buffer.address,
+				   phys_addr);
+	if (unlikely(ret)) {
+		ena_trc_err(ena_dev, "Memory address set failed\n");
+		goto free_ext_stats_mem;
+	}
+	get_cmd->u.control_buffer.length = len;
+
+	get_cmd->device_id = ena_dev->stats_func;
+	get_cmd->queue_idx = ena_dev->stats_queue;
+
+	ret = ena_get_dev_stats(ena_dev, &ctx,
+				ENA_ADMIN_GET_STATS_TYPE_EXTENDED);
+	if (ret < 0)
+		goto free_ext_stats_mem;
+
+	ret = snprintf(buff, len, "%s", (char *)virt_addr);
+
+free_ext_stats_mem:
+	ENA_MEM_FREE_COHERENT(ena_dev->dmadev, len, virt_addr, phys_addr,
+			      mem_handle);
+done:
+	return ret;
+}
+#endif
+
+int ena_com_set_dev_mtu(struct ena_com_dev *ena_dev, int mtu)
+{
+	struct ena_com_admin_queue *admin_queue;
+	struct ena_admin_set_feat_cmd cmd;
+	struct ena_admin_set_feat_resp resp;
+	int ret;
+
+	if (!ena_com_check_supported_feature_id(ena_dev, ENA_ADMIN_MTU)) {
+		ena_trc_dbg(ena_dev, "Feature %d isn't supported\n", ENA_ADMIN_MTU);
+		return ENA_COM_UNSUPPORTED;
+	}
+
+	memset(&cmd, 0x0, sizeof(cmd));
+	admin_queue = &ena_dev->admin_queue;
+
+	cmd.aq_common_descriptor.opcode = ENA_ADMIN_SET_FEATURE;
+	cmd.aq_common_descriptor.flags = 0;
+	cmd.feat_common.feature_id = ENA_ADMIN_MTU;
+	cmd.u.mtu.mtu = (u32)mtu;
+
+	ret = ena_com_execute_admin_command(admin_queue,
+					    (struct ena_admin_aq_entry *)&cmd,
+					    sizeof(cmd),
+					    (struct ena_admin_acq_entry *)&resp,
+					    sizeof(resp));
+
+	if (unlikely(ret))
+		ena_trc_err(ena_dev, "Failed to set mtu %d. error: %d\n", mtu, ret);
+
+	return ret;
+}
+
+int ena_com_get_offload_settings(struct ena_com_dev *ena_dev,
+				 struct ena_admin_feature_offload_desc *offload)
+{
+	int ret;
+	struct ena_admin_get_feat_resp resp;
+
+	ret = ena_com_get_feature(ena_dev, &resp,
+				  ENA_ADMIN_STATELESS_OFFLOAD_CONFIG, 0);
+	if (unlikely(ret)) {
+		ena_trc_err(ena_dev, "Failed to get offload capabilities %d\n", ret);
+		return ret;
+	}
+
+	memcpy(offload, &resp.u.offload, sizeof(resp.u.offload));
+
+	return 0;
+}
+
+int ena_com_set_hash_function(struct ena_com_dev *ena_dev)
+{
+	struct ena_com_admin_queue *admin_queue = &ena_dev->admin_queue;
+	struct ena_rss *rss = &ena_dev->rss;
+	struct ena_admin_set_feat_cmd cmd;
+	struct ena_admin_set_feat_resp resp;
+	struct ena_admin_get_feat_resp get_resp;
+	int ret;
+
+	if (!ena_com_check_supported_feature_id(ena_dev,
+						ENA_ADMIN_RSS_HASH_FUNCTION)) {
+		ena_trc_dbg(ena_dev, "Feature %d isn't supported\n",
+			    ENA_ADMIN_RSS_HASH_FUNCTION);
+		return ENA_COM_UNSUPPORTED;
+	}
+
+	/* Validate hash function is supported */
+	ret = ena_com_get_feature(ena_dev, &get_resp,
+				  ENA_ADMIN_RSS_HASH_FUNCTION, 0);
+	if (unlikely(ret))
+		return ret;
+
+	if (!(get_resp.u.flow_hash_func.supported_func & BIT(rss->hash_func))) {
+		ena_trc_err(ena_dev, "Func hash %d isn't supported by device, abort\n",
+			    rss->hash_func);
+		return ENA_COM_UNSUPPORTED;
+	}
+
+	memset(&cmd, 0x0, sizeof(cmd));
+
+	cmd.aq_common_descriptor.opcode = ENA_ADMIN_SET_FEATURE;
+	cmd.aq_common_descriptor.flags =
+		ENA_ADMIN_AQ_COMMON_DESC_CTRL_DATA_INDIRECT_MASK;
+	cmd.feat_common.feature_id = ENA_ADMIN_RSS_HASH_FUNCTION;
+	cmd.u.flow_hash_func.init_val = rss->hash_init_val;
+	cmd.u.flow_hash_func.selected_func = 1 << rss->hash_func;
+
+	ret = ena_com_mem_addr_set(ena_dev,
+				   &cmd.control_buffer.address,
+				   rss->hash_key_dma_addr);
+	if (unlikely(ret)) {
+		ena_trc_err(ena_dev, "Memory address set failed\n");
+		return ret;
+	}
+
+	cmd.control_buffer.length = sizeof(*rss->hash_key);
+
+	ret = ena_com_execute_admin_command(admin_queue,
+					    (struct ena_admin_aq_entry *)&cmd,
+					    sizeof(cmd),
+					    (struct ena_admin_acq_entry *)&resp,
+					    sizeof(resp));
+	if (unlikely(ret)) {
+		ena_trc_err(ena_dev, "Failed to set hash function %d. error: %d\n",
+			    rss->hash_func, ret);
+		return ENA_COM_INVAL;
+	}
+
+	return 0;
+}
+
+int ena_com_fill_hash_function(struct ena_com_dev *ena_dev,
+			       enum ena_admin_hash_functions func,
+			       const u8 *key, u16 key_len, u32 init_val)
+{
+	struct ena_admin_feature_rss_flow_hash_control *hash_key;
+	struct ena_admin_get_feat_resp get_resp;
+	enum ena_admin_hash_functions old_func;
+	struct ena_rss *rss = &ena_dev->rss;
+	int rc;
+
+	hash_key = rss->hash_key;
+
+	/* Make sure size is a mult of DWs */
+	if (unlikely(key_len & 0x3))
+		return ENA_COM_INVAL;
+
+	rc = ena_com_get_feature_ex(ena_dev, &get_resp,
+				    ENA_ADMIN_RSS_HASH_FUNCTION,
+				    rss->hash_key_dma_addr,
+				    sizeof(*rss->hash_key), 0);
+	if (unlikely(rc))
+		return rc;
+
+	if (!(BIT(func) & get_resp.u.flow_hash_func.supported_func)) {
+		ena_trc_err(ena_dev, "Flow hash function %d isn't supported\n", func);
+		return ENA_COM_UNSUPPORTED;
+	}
+
+	switch (func) {
+	case ENA_ADMIN_TOEPLITZ:
+		if (key) {
+			if (key_len != sizeof(hash_key->key)) {
+				ena_trc_err(ena_dev, "key len (%hu) doesn't equal the supported size (%zu)\n",
+					     key_len, sizeof(hash_key->key));
+				return ENA_COM_INVAL;
+			}
+			memcpy(hash_key->key, key, key_len);
+			rss->hash_init_val = init_val;
+			hash_key->key_parts = key_len / sizeof(hash_key->key[0]);
+		}
+		break;
+	case ENA_ADMIN_CRC32:
+		rss->hash_init_val = init_val;
+		break;
+	default:
+		ena_trc_err(ena_dev, "Invalid hash function (%d)\n", func);
+		return ENA_COM_INVAL;
+	}
+
+	old_func = rss->hash_func;
+	rss->hash_func = func;
+	rc = ena_com_set_hash_function(ena_dev);
+
+	/* Restore the old function */
+	if (unlikely(rc))
+		rss->hash_func = old_func;
+
+	return rc;
+}
+
+int ena_com_get_hash_function(struct ena_com_dev *ena_dev,
+			      enum ena_admin_hash_functions *func)
+{
+	struct ena_rss *rss = &ena_dev->rss;
+	struct ena_admin_get_feat_resp get_resp;
+	int rc;
+
+	if (unlikely(!func))
+		return ENA_COM_INVAL;
+
+	rc = ena_com_get_feature_ex(ena_dev, &get_resp,
+				    ENA_ADMIN_RSS_HASH_FUNCTION,
+				    rss->hash_key_dma_addr,
+				    sizeof(*rss->hash_key), 0);
+	if (unlikely(rc))
+		return rc;
+
+	/* ENA_FFS() returns 1 in case the lsb is set */
+	rss->hash_func = ENA_FFS(get_resp.u.flow_hash_func.selected_func);
+	if (rss->hash_func)
+		rss->hash_func--;
+
+	*func = rss->hash_func;
+
+	return 0;
+}
+
+int ena_com_get_hash_key(struct ena_com_dev *ena_dev, u8 *key)
+{
+	struct ena_admin_feature_rss_flow_hash_control *hash_key =
+		ena_dev->rss.hash_key;
+
+	if (key)
+		memcpy(key, hash_key->key,
+		       (size_t)(hash_key->key_parts) * sizeof(hash_key->key[0]));
+
+	return 0;
+}
+
+int ena_com_get_hash_ctrl(struct ena_com_dev *ena_dev,
+			  enum ena_admin_flow_hash_proto proto,
+			  u16 *fields)
+{
+	struct ena_rss *rss = &ena_dev->rss;
+	struct ena_admin_get_feat_resp get_resp;
+	int rc;
+
+	rc = ena_com_get_feature_ex(ena_dev, &get_resp,
+				    ENA_ADMIN_RSS_HASH_INPUT,
+				    rss->hash_ctrl_dma_addr,
+				    sizeof(*rss->hash_ctrl), 0);
+	if (unlikely(rc))
+		return rc;
+
+	if (fields)
+		*fields = rss->hash_ctrl->selected_fields[proto].fields;
+
+	return 0;
+}
+
+int ena_com_set_hash_ctrl(struct ena_com_dev *ena_dev)
+{
+	struct ena_com_admin_queue *admin_queue = &ena_dev->admin_queue;
+	struct ena_rss *rss = &ena_dev->rss;
+	struct ena_admin_feature_rss_hash_control *hash_ctrl = rss->hash_ctrl;
+	struct ena_admin_set_feat_cmd cmd;
+	struct ena_admin_set_feat_resp resp;
+	int ret;
+
+	if (!ena_com_check_supported_feature_id(ena_dev,
+						ENA_ADMIN_RSS_HASH_INPUT)) {
+		ena_trc_dbg(ena_dev, "Feature %d isn't supported\n",
+			    ENA_ADMIN_RSS_HASH_INPUT);
+		return ENA_COM_UNSUPPORTED;
+	}
+
+	memset(&cmd, 0x0, sizeof(cmd));
+
+	cmd.aq_common_descriptor.opcode = ENA_ADMIN_SET_FEATURE;
+	cmd.aq_common_descriptor.flags =
+		ENA_ADMIN_AQ_COMMON_DESC_CTRL_DATA_INDIRECT_MASK;
+	cmd.feat_common.feature_id = ENA_ADMIN_RSS_HASH_INPUT;
+	cmd.u.flow_hash_input.enabled_input_sort =
+		ENA_ADMIN_FEATURE_RSS_FLOW_HASH_INPUT_L3_SORT_MASK |
+		ENA_ADMIN_FEATURE_RSS_FLOW_HASH_INPUT_L4_SORT_MASK;
+
+	ret = ena_com_mem_addr_set(ena_dev,
+				   &cmd.control_buffer.address,
+				   rss->hash_ctrl_dma_addr);
+	if (unlikely(ret)) {
+		ena_trc_err(ena_dev, "Memory address set failed\n");
+		return ret;
+	}
+	cmd.control_buffer.length = sizeof(*hash_ctrl);
+
+	ret = ena_com_execute_admin_command(admin_queue,
+					    (struct ena_admin_aq_entry *)&cmd,
+					    sizeof(cmd),
+					    (struct ena_admin_acq_entry *)&resp,
+					    sizeof(resp));
+	if (unlikely(ret))
+		ena_trc_err(ena_dev, "Failed to set hash input. error: %d\n", ret);
+
+	return ret;
+}
+
+int ena_com_set_default_hash_ctrl(struct ena_com_dev *ena_dev)
+{
+	struct ena_rss *rss = &ena_dev->rss;
+	struct ena_admin_feature_rss_hash_control *hash_ctrl =
+		rss->hash_ctrl;
+	u16 available_fields = 0;
+	int rc, i;
+
+	/* Get the supported hash input */
+	rc = ena_com_get_hash_ctrl(ena_dev, 0, NULL);
+	if (unlikely(rc))
+		return rc;
+
+	hash_ctrl->selected_fields[ENA_ADMIN_RSS_TCP4].fields =
+		ENA_ADMIN_RSS_L3_SA | ENA_ADMIN_RSS_L3_DA |
+		ENA_ADMIN_RSS_L4_DP | ENA_ADMIN_RSS_L4_SP;
+
+	hash_ctrl->selected_fields[ENA_ADMIN_RSS_UDP4].fields =
+		ENA_ADMIN_RSS_L3_SA | ENA_ADMIN_RSS_L3_DA |
+		ENA_ADMIN_RSS_L4_DP | ENA_ADMIN_RSS_L4_SP;
+
+	hash_ctrl->selected_fields[ENA_ADMIN_RSS_TCP6].fields =
+		ENA_ADMIN_RSS_L3_SA | ENA_ADMIN_RSS_L3_DA |
+		ENA_ADMIN_RSS_L4_DP | ENA_ADMIN_RSS_L4_SP;
+
+	hash_ctrl->selected_fields[ENA_ADMIN_RSS_UDP6].fields =
+		ENA_ADMIN_RSS_L3_SA | ENA_ADMIN_RSS_L3_DA |
+		ENA_ADMIN_RSS_L4_DP | ENA_ADMIN_RSS_L4_SP;
+
+	hash_ctrl->selected_fields[ENA_ADMIN_RSS_IP4].fields =
+		ENA_ADMIN_RSS_L3_SA | ENA_ADMIN_RSS_L3_DA;
+
+	hash_ctrl->selected_fields[ENA_ADMIN_RSS_IP6].fields =
+		ENA_ADMIN_RSS_L3_SA | ENA_ADMIN_RSS_L3_DA;
+
+	hash_ctrl->selected_fields[ENA_ADMIN_RSS_IP4_FRAG].fields =
+		ENA_ADMIN_RSS_L3_SA | ENA_ADMIN_RSS_L3_DA;
+
+	hash_ctrl->selected_fields[ENA_ADMIN_RSS_NOT_IP].fields =
+		ENA_ADMIN_RSS_L2_DA | ENA_ADMIN_RSS_L2_SA;
+
+	for (i = 0; i < ENA_ADMIN_RSS_PROTO_NUM; i++) {
+		available_fields = hash_ctrl->selected_fields[i].fields &
+				hash_ctrl->supported_fields[i].fields;
+		if (available_fields != hash_ctrl->selected_fields[i].fields) {
+			ena_trc_err(ena_dev, "Hash control doesn't support all the desire configuration. proto %x supported %x selected %x\n",
+				    i, hash_ctrl->supported_fields[i].fields,
+				    hash_ctrl->selected_fields[i].fields);
+			return ENA_COM_UNSUPPORTED;
+		}
+	}
+
+	rc = ena_com_set_hash_ctrl(ena_dev);
+
+	/* In case of failure, restore the old hash ctrl */
+	if (unlikely(rc))
+		ena_com_get_hash_ctrl(ena_dev, 0, NULL);
+
+	return rc;
+}
+
+int ena_com_fill_hash_ctrl(struct ena_com_dev *ena_dev,
+			   enum ena_admin_flow_hash_proto proto,
+			   u16 hash_fields)
+{
+	struct ena_rss *rss = &ena_dev->rss;
+	struct ena_admin_feature_rss_hash_control *hash_ctrl = rss->hash_ctrl;
+	u16 supported_fields;
+	int rc;
+
+	if (proto >= ENA_ADMIN_RSS_PROTO_NUM) {
+		ena_trc_err(ena_dev, "Invalid proto num (%u)\n", proto);
+		return ENA_COM_INVAL;
+	}
+
+	/* Get the ctrl table */
+	rc = ena_com_get_hash_ctrl(ena_dev, proto, NULL);
+	if (unlikely(rc))
+		return rc;
+
+	/* Make sure all the fields are supported */
+	supported_fields = hash_ctrl->supported_fields[proto].fields;
+	if ((hash_fields & supported_fields) != hash_fields) {
+		ena_trc_err(ena_dev, "Proto %d doesn't support the required fields %x. supports only: %x\n",
+			    proto, hash_fields, supported_fields);
+	}
+
+	hash_ctrl->selected_fields[proto].fields = hash_fields;
+
+	rc = ena_com_set_hash_ctrl(ena_dev);
+
+	/* In case of failure, restore the old hash ctrl */
+	if (unlikely(rc))
+		ena_com_get_hash_ctrl(ena_dev, 0, NULL);
+
+	return 0;
+}
+
+int ena_com_indirect_table_fill_entry(struct ena_com_dev *ena_dev,
+				      u16 entry_idx, u16 entry_value)
+{
+	struct ena_rss *rss = &ena_dev->rss;
+
+	if (unlikely(entry_idx >= (1 << rss->tbl_log_size)))
+		return ENA_COM_INVAL;
+
+	if (unlikely((entry_value > ENA_TOTAL_NUM_QUEUES)))
+		return ENA_COM_INVAL;
+
+	rss->host_rss_ind_tbl[entry_idx] = entry_value;
+
+	return 0;
+}
+
+int ena_com_indirect_table_set(struct ena_com_dev *ena_dev)
+{
+	struct ena_com_admin_queue *admin_queue = &ena_dev->admin_queue;
+	struct ena_rss *rss = &ena_dev->rss;
+	struct ena_admin_set_feat_cmd cmd;
+	struct ena_admin_set_feat_resp resp;
+	int ret;
+
+	if (!ena_com_check_supported_feature_id(ena_dev,
+						ENA_ADMIN_RSS_INDIRECTION_TABLE_CONFIG)) {
+		ena_trc_dbg(ena_dev, "Feature %d isn't supported\n",
+			    ENA_ADMIN_RSS_INDIRECTION_TABLE_CONFIG);
+		return ENA_COM_UNSUPPORTED;
+	}
+
+	ret = ena_com_ind_tbl_convert_to_device(ena_dev);
+	if (ret) {
+		ena_trc_err(ena_dev, "Failed to convert host indirection table to device table\n");
+		return ret;
+	}
+
+	memset(&cmd, 0x0, sizeof(cmd));
+
+	cmd.aq_common_descriptor.opcode = ENA_ADMIN_SET_FEATURE;
+	cmd.aq_common_descriptor.flags =
+		ENA_ADMIN_AQ_COMMON_DESC_CTRL_DATA_INDIRECT_MASK;
+	cmd.feat_common.feature_id = ENA_ADMIN_RSS_INDIRECTION_TABLE_CONFIG;
+	cmd.u.ind_table.size = rss->tbl_log_size;
+	cmd.u.ind_table.inline_index = 0xFFFFFFFF;
+
+	ret = ena_com_mem_addr_set(ena_dev,
+				   &cmd.control_buffer.address,
+				   rss->rss_ind_tbl_dma_addr);
+	if (unlikely(ret)) {
+		ena_trc_err(ena_dev, "Memory address set failed\n");
+		return ret;
+	}
+
+	cmd.control_buffer.length = (u32)(1ULL << rss->tbl_log_size) *
+		sizeof(struct ena_admin_rss_ind_table_entry);
+
+	ret = ena_com_execute_admin_command(admin_queue,
+					    (struct ena_admin_aq_entry *)&cmd,
+					    sizeof(cmd),
+					    (struct ena_admin_acq_entry *)&resp,
+					    sizeof(resp));
+
+	if (unlikely(ret))
+		ena_trc_err(ena_dev, "Failed to set indirect table. error: %d\n", ret);
+
+	return ret;
+}
+
+int ena_com_indirect_table_get(struct ena_com_dev *ena_dev, u32 *ind_tbl)
+{
+	struct ena_rss *rss = &ena_dev->rss;
+	struct ena_admin_get_feat_resp get_resp;
+	u32 tbl_size;
+	int i, rc;
+
+	tbl_size = (u32)(1ULL << rss->tbl_log_size) *
+		sizeof(struct ena_admin_rss_ind_table_entry);
+
+	rc = ena_com_get_feature_ex(ena_dev, &get_resp,
+				    ENA_ADMIN_RSS_INDIRECTION_TABLE_CONFIG,
+				    rss->rss_ind_tbl_dma_addr,
+				    tbl_size, 0);
+	if (unlikely(rc))
+		return rc;
+
+	if (!ind_tbl)
+		return 0;
+
+	for (i = 0; i < (1 << rss->tbl_log_size); i++)
+		ind_tbl[i] = rss->host_rss_ind_tbl[i];
+
+	return 0;
+}
+
+int ena_com_rss_init(struct ena_com_dev *ena_dev, u16 indr_tbl_log_size)
+{
+	int rc;
+
+	memset(&ena_dev->rss, 0x0, sizeof(ena_dev->rss));
+
+	rc = ena_com_indirect_table_allocate(ena_dev, indr_tbl_log_size);
+	if (unlikely(rc))
+		goto err_indr_tbl;
+
+	/* The following function might return unsupported in case the
+	 * device doesn't support setting the key / hash function. We can safely
+	 * ignore this error and have indirection table support only.
+	 */
+	rc = ena_com_hash_key_allocate(ena_dev);
+	if (likely(!rc))
+		ena_com_hash_key_fill_default_key(ena_dev);
+	else if (rc != ENA_COM_UNSUPPORTED)
+		goto err_hash_key;
+
+	rc = ena_com_hash_ctrl_init(ena_dev);
+	if (unlikely(rc))
+		goto err_hash_ctrl;
+
+	return 0;
+
+err_hash_ctrl:
+	ena_com_hash_key_destroy(ena_dev);
+err_hash_key:
+	ena_com_indirect_table_destroy(ena_dev);
+err_indr_tbl:
+
+	return rc;
+}
+
+void ena_com_rss_destroy(struct ena_com_dev *ena_dev)
+{
+	ena_com_indirect_table_destroy(ena_dev);
+	ena_com_hash_key_destroy(ena_dev);
+	ena_com_hash_ctrl_destroy(ena_dev);
+
+	memset(&ena_dev->rss, 0x0, sizeof(ena_dev->rss));
+}
+
+int ena_com_allocate_host_info(struct ena_com_dev *ena_dev)
+{
+	struct ena_host_attribute *host_attr = &ena_dev->host_attr;
+
+	ENA_MEM_ALLOC_COHERENT(ena_dev->dmadev,
+			       SZ_4K,
+			       host_attr->host_info,
+			       host_attr->host_info_dma_addr,
+			       host_attr->host_info_dma_handle);
+	if (unlikely(!host_attr->host_info))
+		return ENA_COM_NO_MEM;
+
+	host_attr->host_info->ena_spec_version = ((ENA_COMMON_SPEC_VERSION_MAJOR <<
+		ENA_REGS_VERSION_MAJOR_VERSION_SHIFT) |
+		(ENA_COMMON_SPEC_VERSION_MINOR));
+
+	return 0;
+}
+
+int ena_com_allocate_debug_area(struct ena_com_dev *ena_dev,
+				u32 debug_area_size)
+{
+	struct ena_host_attribute *host_attr = &ena_dev->host_attr;
+
+	ENA_MEM_ALLOC_COHERENT(ena_dev->dmadev,
+			       debug_area_size,
+			       host_attr->debug_area_virt_addr,
+			       host_attr->debug_area_dma_addr,
+			       host_attr->debug_area_dma_handle);
+	if (unlikely(!host_attr->debug_area_virt_addr)) {
+		host_attr->debug_area_size = 0;
+		return ENA_COM_NO_MEM;
+	}
+
+	host_attr->debug_area_size = debug_area_size;
+
+	return 0;
+}
+
+void ena_com_delete_host_info(struct ena_com_dev *ena_dev)
+{
+	struct ena_host_attribute *host_attr = &ena_dev->host_attr;
+
+	if (host_attr->host_info) {
+		ENA_MEM_FREE_COHERENT(ena_dev->dmadev,
+				      SZ_4K,
+				      host_attr->host_info,
+				      host_attr->host_info_dma_addr,
+				      host_attr->host_info_dma_handle);
+		host_attr->host_info = NULL;
+	}
+}
+
+void ena_com_delete_debug_area(struct ena_com_dev *ena_dev)
+{
+	struct ena_host_attribute *host_attr = &ena_dev->host_attr;
+
+	if (host_attr->debug_area_virt_addr) {
+		ENA_MEM_FREE_COHERENT(ena_dev->dmadev,
+				      host_attr->debug_area_size,
+				      host_attr->debug_area_virt_addr,
+				      host_attr->debug_area_dma_addr,
+				      host_attr->debug_area_dma_handle);
+		host_attr->debug_area_virt_addr = NULL;
+	}
+}
+
+int ena_com_set_host_attributes(struct ena_com_dev *ena_dev)
+{
+	struct ena_host_attribute *host_attr = &ena_dev->host_attr;
+	struct ena_com_admin_queue *admin_queue;
+	struct ena_admin_set_feat_cmd cmd;
+	struct ena_admin_set_feat_resp resp;
+
+	int ret;
+
+	/* Host attribute config is called before ena_com_get_dev_attr_feat
+	 * so ena_com can't check if the feature is supported.
+	 */
+
+	memset(&cmd, 0x0, sizeof(cmd));
+	admin_queue = &ena_dev->admin_queue;
+
+	cmd.aq_common_descriptor.opcode = ENA_ADMIN_SET_FEATURE;
+	cmd.feat_common.feature_id = ENA_ADMIN_HOST_ATTR_CONFIG;
+
+	ret = ena_com_mem_addr_set(ena_dev,
+				   &cmd.u.host_attr.debug_ba,
+				   host_attr->debug_area_dma_addr);
+	if (unlikely(ret)) {
+		ena_trc_err(ena_dev, "Memory address set failed\n");
+		return ret;
+	}
+
+	ret = ena_com_mem_addr_set(ena_dev,
+				   &cmd.u.host_attr.os_info_ba,
+				   host_attr->host_info_dma_addr);
+	if (unlikely(ret)) {
+		ena_trc_err(ena_dev, "Memory address set failed\n");
+		return ret;
+	}
+
+	cmd.u.host_attr.debug_area_size = host_attr->debug_area_size;
+
+	ret = ena_com_execute_admin_command(admin_queue,
+					    (struct ena_admin_aq_entry *)&cmd,
+					    sizeof(cmd),
+					    (struct ena_admin_acq_entry *)&resp,
+					    sizeof(resp));
+
+	if (unlikely(ret))
+		ena_trc_err(ena_dev, "Failed to set host attributes: %d\n", ret);
+
+	return ret;
+}
+
+/* Interrupt moderation */
+bool ena_com_interrupt_moderation_supported(struct ena_com_dev *ena_dev)
+{
+	return ena_com_check_supported_feature_id(ena_dev,
+						  ENA_ADMIN_INTERRUPT_MODERATION);
+}
+
+static int ena_com_update_nonadaptive_moderation_interval(struct ena_com_dev *ena_dev,
+							  u32 coalesce_usecs,
+							  u32 intr_delay_resolution,
+							  u32 *intr_moder_interval)
+{
+	if (!intr_delay_resolution) {
+		ena_trc_err(ena_dev, "Illegal interrupt delay granularity value\n");
+		return ENA_COM_FAULT;
+	}
+
+	*intr_moder_interval = coalesce_usecs / intr_delay_resolution;
+
+	return 0;
+}
+
+int ena_com_update_nonadaptive_moderation_interval_tx(struct ena_com_dev *ena_dev,
+						      u32 tx_coalesce_usecs)
+{
+	return ena_com_update_nonadaptive_moderation_interval(ena_dev,
+							      tx_coalesce_usecs,
+							      ena_dev->intr_delay_resolution,
+							      &ena_dev->intr_moder_tx_interval);
+}
+
+int ena_com_update_nonadaptive_moderation_interval_rx(struct ena_com_dev *ena_dev,
+						      u32 rx_coalesce_usecs)
+{
+	return ena_com_update_nonadaptive_moderation_interval(ena_dev,
+							      rx_coalesce_usecs,
+							      ena_dev->intr_delay_resolution,
+							      &ena_dev->intr_moder_rx_interval);
+}
+
+int ena_com_init_interrupt_moderation(struct ena_com_dev *ena_dev)
+{
+	struct ena_admin_get_feat_resp get_resp;
+	u16 delay_resolution;
+	int rc;
+
+	rc = ena_com_get_feature(ena_dev, &get_resp,
+				 ENA_ADMIN_INTERRUPT_MODERATION, 0);
+
+	if (rc) {
+		if (rc == ENA_COM_UNSUPPORTED) {
+			ena_trc_dbg(ena_dev, "Feature %d isn't supported\n",
+				    ENA_ADMIN_INTERRUPT_MODERATION);
+			rc = 0;
+		} else {
+			ena_trc_err(ena_dev,
+				    "Failed to get interrupt moderation admin cmd. rc: %d\n", rc);
+		}
+
+		/* no moderation supported, disable adaptive support */
+		ena_com_disable_adaptive_moderation(ena_dev);
+		return rc;
+	}
+
+	/* if moderation is supported by device we set adaptive moderation */
+	delay_resolution = get_resp.u.intr_moderation.intr_delay_resolution;
+	ena_com_update_intr_delay_resolution(ena_dev, delay_resolution);
+
+	/* Disable adaptive moderation by default - can be enabled later */
+	ena_com_disable_adaptive_moderation(ena_dev);
+
+	return 0;
+}
+
+unsigned int ena_com_get_nonadaptive_moderation_interval_tx(struct ena_com_dev *ena_dev)
+{
+	return ena_dev->intr_moder_tx_interval;
+}
+
+unsigned int ena_com_get_nonadaptive_moderation_interval_rx(struct ena_com_dev *ena_dev)
+{
+	return ena_dev->intr_moder_rx_interval;
+}
+
+int ena_com_config_dev_mode(struct ena_com_dev *ena_dev,
+			    struct ena_admin_feature_llq_desc *llq_features,
+			    struct ena_llq_configurations *llq_default_cfg)
+{
+	struct ena_com_llq_info *llq_info = &ena_dev->llq_info;
+	int rc;
+
+	if (!llq_features->max_llq_num) {
+		ena_dev->tx_mem_queue_type = ENA_ADMIN_PLACEMENT_POLICY_HOST;
+		return 0;
+	}
+
+	rc = ena_com_config_llq_info(ena_dev, llq_features, llq_default_cfg);
+	if (rc)
+		return rc;
+
+	ena_dev->tx_max_header_size = llq_info->desc_list_entry_size -
+		(llq_info->descs_num_before_header * sizeof(struct ena_eth_io_tx_desc));
+
+	if (unlikely(ena_dev->tx_max_header_size == 0)) {
+		ena_trc_err(ena_dev, "The size of the LLQ entry is smaller than needed\n");
+		return -EINVAL;
+	}
+
+	ena_dev->tx_mem_queue_type = ENA_ADMIN_PLACEMENT_POLICY_DEV;
+
+	return 0;
+}

--- a/kernel/macOS/ena/ena_com/ena_com.h
+++ b/kernel/macOS/ena/ena_com/ena_com.h
@@ -1,0 +1,1029 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef ENA_COM
+#define ENA_COM
+
+#include "ena_plat.h"
+
+#define ENA_MAX_NUM_IO_QUEUES 128U
+/* We need to queues for each IO (on for Tx and one for Rx) */
+#define ENA_TOTAL_NUM_QUEUES (2 * (ENA_MAX_NUM_IO_QUEUES))
+
+#define ENA_MAX_HANDLERS 256
+
+#define ENA_MAX_PHYS_ADDR_SIZE_BITS 48
+
+/* Unit in usec */
+#define ENA_REG_READ_TIMEOUT 200000
+
+#define ADMIN_SQ_SIZE(depth)	((depth) * sizeof(struct ena_admin_aq_entry))
+#define ADMIN_CQ_SIZE(depth)	((depth) * sizeof(struct ena_admin_acq_entry))
+#define ADMIN_AENQ_SIZE(depth)	((depth) * sizeof(struct ena_admin_aenq_entry))
+
+/*****************************************************************************/
+/*****************************************************************************/
+/* ENA adaptive interrupt moderation settings */
+
+#define ENA_INTR_INITIAL_TX_INTERVAL_USECS ENA_INTR_INITIAL_TX_INTERVAL_USECS_PLAT
+#define ENA_INTR_INITIAL_RX_INTERVAL_USECS 0
+#define ENA_DEFAULT_INTR_DELAY_RESOLUTION 1
+
+#define ENA_HASH_KEY_SIZE 40
+
+#define ENA_HW_HINTS_NO_TIMEOUT	0xFFFF
+
+#define ENA_FEATURE_MAX_QUEUE_EXT_VER 1
+
+struct ena_llq_configurations {
+	enum ena_admin_llq_header_location llq_header_location;
+	enum ena_admin_llq_ring_entry_size llq_ring_entry_size;
+	enum ena_admin_llq_stride_ctrl  llq_stride_ctrl;
+	enum ena_admin_llq_num_descs_before_header llq_num_decs_before_header;
+	u16 llq_ring_entry_size_value;
+};
+
+enum queue_direction {
+	ENA_COM_IO_QUEUE_DIRECTION_TX,
+	ENA_COM_IO_QUEUE_DIRECTION_RX
+};
+
+struct ena_com_buf {
+	dma_addr_t paddr; /**< Buffer physical address */
+	u16 len; /**< Buffer length in bytes */
+};
+
+struct ena_com_rx_buf_info {
+	u16 len;
+	u16 req_id;
+};
+
+struct ena_com_io_desc_addr {
+	u8 __iomem *pbuf_dev_addr; /* LLQ address */
+	u8 *virt_addr;
+	dma_addr_t phys_addr;
+	ena_mem_handle_t mem_handle;
+};
+
+struct ena_com_tx_meta {
+	u16 mss;
+	u16 l3_hdr_len;
+	u16 l3_hdr_offset;
+	u16 l4_hdr_len; /* In words */
+};
+
+struct ena_com_llq_info {
+	u16 header_location_ctrl;
+	u16 desc_stride_ctrl;
+	u16 desc_list_entry_size_ctrl;
+	u16 desc_list_entry_size;
+	u16 descs_num_before_header;
+	u16 descs_per_entry;
+	u16 max_entries_in_tx_burst;
+	bool disable_meta_caching;
+};
+
+struct ena_com_io_cq {
+	struct ena_com_io_desc_addr cdesc_addr;
+	void *bus;
+
+	/* Interrupt unmask register */
+	u32 __iomem *unmask_reg;
+
+	/* The completion queue head doorbell register */
+	u32 __iomem *cq_head_db_reg;
+
+	/* numa configuration register (for TPH) */
+	u32 __iomem *numa_node_cfg_reg;
+
+	/* The value to write to the above register to unmask
+	 * the interrupt of this queue
+	 */
+	u32 msix_vector;
+
+	enum queue_direction direction;
+
+	/* holds the number of cdesc of the current packet */
+	u16 cur_rx_pkt_cdesc_count;
+	/* save the firt cdesc idx of the current packet */
+	u16 cur_rx_pkt_cdesc_start_idx;
+
+	u16 q_depth;
+	/* Caller qid */
+	u16 qid;
+
+	/* Device queue index */
+	u16 idx;
+	u16 head;
+	u16 last_head_update;
+	u8 phase;
+	u8 cdesc_entry_size_in_bytes;
+
+} ____cacheline_aligned;
+
+struct ena_com_io_bounce_buffer_control {
+	u8 *base_buffer;
+	u16 next_to_use;
+	u16 buffer_size;
+	u16 buffers_num;  /* Must be a power of 2 */
+};
+
+/* This struct is to keep tracking the current location of the next llq entry */
+struct ena_com_llq_pkt_ctrl {
+	u8 *curr_bounce_buf;
+	u16 idx;
+	u16 descs_left_in_line;
+};
+
+struct ena_com_io_sq {
+	struct ena_com_io_desc_addr desc_addr;
+	void *bus;
+
+	u32 __iomem *db_addr;
+	u8 __iomem *header_addr;
+
+	enum queue_direction direction;
+	enum ena_admin_placement_policy_type mem_queue_type;
+
+	bool disable_meta_caching;
+
+	u32 msix_vector;
+	struct ena_com_tx_meta cached_tx_meta;
+	struct ena_com_llq_info llq_info;
+	struct ena_com_llq_pkt_ctrl llq_buf_ctrl;
+	struct ena_com_io_bounce_buffer_control bounce_buf_ctrl;
+
+	u16 q_depth;
+	u16 qid;
+
+	u16 idx;
+	u16 tail;
+	u16 next_to_comp;
+	u16 llq_last_copy_tail;
+	u32 tx_max_header_size;
+	u8 phase;
+	u8 desc_entry_size;
+	u8 dma_addr_bits;
+	u16 entries_in_tx_burst_left;
+} ____cacheline_aligned;
+
+struct ena_com_admin_cq {
+	struct ena_admin_acq_entry *entries;
+	ena_mem_handle_t mem_handle;
+	dma_addr_t dma_addr;
+
+	u16 head;
+	u8 phase;
+};
+
+struct ena_com_admin_sq {
+	struct ena_admin_aq_entry *entries;
+	ena_mem_handle_t mem_handle;
+	dma_addr_t dma_addr;
+
+	u32 __iomem *db_addr;
+
+	u16 head;
+	u16 tail;
+	u8 phase;
+
+};
+
+struct ena_com_stats_admin {
+	u64 aborted_cmd;
+	u64 submitted_cmd;
+	u64 completed_cmd;
+	u64 out_of_space;
+	u64 no_completion;
+};
+
+struct ena_com_admin_queue {
+	void *q_dmadev;
+	void *bus;
+	struct ena_com_dev *ena_dev;
+	ena_spinlock_t q_lock; /* spinlock for the admin queue */
+
+	struct ena_comp_ctx *comp_ctx;
+	u32 completion_timeout;
+	u16 q_depth;
+	struct ena_com_admin_cq cq;
+	struct ena_com_admin_sq sq;
+
+	/* Indicate if the admin queue should poll for completion */
+	bool polling;
+
+	/* Define if fallback to polling mode should occur */
+	bool auto_polling;
+
+	u16 curr_cmd_id;
+
+	/* Indicate that the ena was initialized and can
+	 * process new admin commands
+	 */
+	bool running_state;
+
+	/* Count the number of outstanding admin commands */
+	ena_atomic32_t outstanding_cmds;
+
+	struct ena_com_stats_admin stats;
+};
+
+struct ena_aenq_handlers;
+
+struct ena_com_aenq {
+	u16 head;
+	u8 phase;
+	struct ena_admin_aenq_entry *entries;
+	dma_addr_t dma_addr;
+	ena_mem_handle_t mem_handle;
+	u16 q_depth;
+	struct ena_aenq_handlers *aenq_handlers;
+};
+
+struct ena_com_mmio_read {
+	struct ena_admin_ena_mmio_req_read_less_resp *read_resp;
+	dma_addr_t read_resp_dma_addr;
+	ena_mem_handle_t read_resp_mem_handle;
+	u32 reg_read_to; /* in us */
+	u16 seq_num;
+	bool readless_supported;
+	/* spin lock to ensure a single outstanding read */
+	ena_spinlock_t lock;
+};
+
+struct ena_rss {
+	/* Indirect table */
+	u16 *host_rss_ind_tbl;
+	struct ena_admin_rss_ind_table_entry *rss_ind_tbl;
+	dma_addr_t rss_ind_tbl_dma_addr;
+	ena_mem_handle_t rss_ind_tbl_mem_handle;
+	u16 tbl_log_size;
+
+	/* Hash key */
+	enum ena_admin_hash_functions hash_func;
+	struct ena_admin_feature_rss_flow_hash_control *hash_key;
+	dma_addr_t hash_key_dma_addr;
+	ena_mem_handle_t hash_key_mem_handle;
+	u32 hash_init_val;
+
+	/* Flow Control */
+	struct ena_admin_feature_rss_hash_control *hash_ctrl;
+	dma_addr_t hash_ctrl_dma_addr;
+	ena_mem_handle_t hash_ctrl_mem_handle;
+
+};
+
+struct ena_host_attribute {
+	/* Debug area */
+	u8 *debug_area_virt_addr;
+	dma_addr_t debug_area_dma_addr;
+	ena_mem_handle_t debug_area_dma_handle;
+	u32 debug_area_size;
+
+	/* Host information */
+	struct ena_admin_host_info *host_info;
+	dma_addr_t host_info_dma_addr;
+	ena_mem_handle_t host_info_dma_handle;
+};
+
+/* Each ena_dev is a PCI function. */
+struct ena_com_dev {
+	struct ena_com_admin_queue admin_queue;
+	struct ena_com_aenq aenq;
+	struct ena_com_io_cq io_cq_queues[ENA_TOTAL_NUM_QUEUES];
+	struct ena_com_io_sq io_sq_queues[ENA_TOTAL_NUM_QUEUES];
+	u8 __iomem *reg_bar;
+	void __iomem *mem_bar;
+	void *dmadev;
+	void *bus;
+
+	enum ena_admin_placement_policy_type tx_mem_queue_type;
+	u32 tx_max_header_size;
+	u16 stats_func; /* Selected function for extended statistic dump */
+	u16 stats_queue; /* Selected queue for extended statistic dump */
+
+	struct ena_com_mmio_read mmio_read;
+
+	struct ena_rss rss;
+	u32 supported_features;
+	u32 dma_addr_bits;
+
+	struct ena_host_attribute host_attr;
+	bool adaptive_coalescing;
+	u16 intr_delay_resolution;
+
+	/* interrupt moderation intervals are in usec divided by
+	 * intr_delay_resolution, which is supplied by the device.
+	 */
+	u32 intr_moder_tx_interval;
+	u32 intr_moder_rx_interval;
+
+	struct ena_intr_moder_entry *intr_moder_tbl;
+
+	struct ena_com_llq_info llq_info;
+
+	u32 ena_min_poll_delay_us;
+};
+
+struct ena_com_dev_get_features_ctx {
+	struct ena_admin_queue_feature_desc max_queues;
+	struct ena_admin_queue_ext_feature_desc max_queue_ext;
+	struct ena_admin_device_attr_feature_desc dev_attr;
+	struct ena_admin_feature_aenq_desc aenq;
+	struct ena_admin_feature_offload_desc offload;
+	struct ena_admin_ena_hw_hints hw_hints;
+	struct ena_admin_feature_llq_desc llq;
+};
+
+struct ena_com_create_io_ctx {
+	enum ena_admin_placement_policy_type mem_queue_type;
+	enum queue_direction direction;
+	int numa_node;
+	u32 msix_vector;
+	u16 queue_size;
+	u16 qid;
+};
+
+typedef void (*ena_aenq_handler)(void *data,
+	struct ena_admin_aenq_entry *aenq_e);
+
+/* Holds aenq handlers. Indexed by AENQ event group */
+struct ena_aenq_handlers {
+	ena_aenq_handler handlers[ENA_MAX_HANDLERS];
+	ena_aenq_handler unimplemented_handler;
+};
+
+/*****************************************************************************/
+/*****************************************************************************/
+#if defined(__cplusplus)
+extern "C" {
+#endif
+
+/* ena_com_mmio_reg_read_request_init - Init the mmio reg read mechanism
+ * @ena_dev: ENA communication layer struct
+ *
+ * Initialize the register read mechanism.
+ *
+ * @note: This method must be the first stage in the initialization sequence.
+ *
+ * @return - 0 on success, negative value on failure.
+ */
+int ena_com_mmio_reg_read_request_init(struct ena_com_dev *ena_dev);
+
+/* ena_com_set_mmio_read_mode - Enable/disable the indirect mmio reg read mechanism
+ * @ena_dev: ENA communication layer struct
+ * @readless_supported: readless mode (enable/disable)
+ */
+void ena_com_set_mmio_read_mode(struct ena_com_dev *ena_dev,
+				bool readless_supported);
+
+/* ena_com_mmio_reg_read_request_write_dev_addr - Write the mmio reg read return
+ * value physical address.
+ * @ena_dev: ENA communication layer struct
+ */
+void ena_com_mmio_reg_read_request_write_dev_addr(struct ena_com_dev *ena_dev);
+
+/* ena_com_mmio_reg_read_request_destroy - Destroy the mmio reg read mechanism
+ * @ena_dev: ENA communication layer struct
+ */
+void ena_com_mmio_reg_read_request_destroy(struct ena_com_dev *ena_dev);
+
+/* ena_com_admin_init - Init the admin and the async queues
+ * @ena_dev: ENA communication layer struct
+ * @aenq_handlers: Those handlers to be called upon event.
+ *
+ * Initialize the admin submission and completion queues.
+ * Initialize the asynchronous events notification queues.
+ *
+ * @return - 0 on success, negative value on failure.
+ */
+int ena_com_admin_init(struct ena_com_dev *ena_dev,
+		       struct ena_aenq_handlers *aenq_handlers);
+
+/* ena_com_admin_destroy - Destroy the admin and the async events queues.
+ * @ena_dev: ENA communication layer struct
+ *
+ * @note: Before calling this method, the caller must validate that the device
+ * won't send any additional admin completions/aenq.
+ * To achieve that, a FLR is recommended.
+ */
+void ena_com_admin_destroy(struct ena_com_dev *ena_dev);
+
+/* ena_com_dev_reset - Perform device FLR to the device.
+ * @ena_dev: ENA communication layer struct
+ * @reset_reason: Specify what is the trigger for the reset in case of an error.
+ *
+ * @return - 0 on success, negative value on failure.
+ */
+int ena_com_dev_reset(struct ena_com_dev *ena_dev,
+		      enum ena_regs_reset_reason_types reset_reason);
+
+/* ena_com_create_io_queue - Create io queue.
+ * @ena_dev: ENA communication layer struct
+ * @ctx - create context structure
+ *
+ * Create the submission and the completion queues.
+ *
+ * @return - 0 on success, negative value on failure.
+ */
+int ena_com_create_io_queue(struct ena_com_dev *ena_dev,
+			    struct ena_com_create_io_ctx *ctx);
+
+/* ena_com_destroy_io_queue - Destroy IO queue with the queue id - qid.
+ * @ena_dev: ENA communication layer struct
+ * @qid - the caller virtual queue id.
+ */
+void ena_com_destroy_io_queue(struct ena_com_dev *ena_dev, u16 qid);
+
+/* ena_com_get_io_handlers - Return the io queue handlers
+ * @ena_dev: ENA communication layer struct
+ * @qid - the caller virtual queue id.
+ * @io_sq - IO submission queue handler
+ * @io_cq - IO completion queue handler.
+ *
+ * @return - 0 on success, negative value on failure.
+ */
+int ena_com_get_io_handlers(struct ena_com_dev *ena_dev, u16 qid,
+			    struct ena_com_io_sq **io_sq,
+			    struct ena_com_io_cq **io_cq);
+
+/* ena_com_admin_aenq_enable - ENAble asynchronous event notifications
+ * @ena_dev: ENA communication layer struct
+ *
+ * After this method, aenq event can be received via AENQ.
+ */
+void ena_com_admin_aenq_enable(struct ena_com_dev *ena_dev);
+
+/* ena_com_set_admin_running_state - Set the state of the admin queue
+ * @ena_dev: ENA communication layer struct
+ *
+ * Change the state of the admin queue (enable/disable)
+ */
+void ena_com_set_admin_running_state(struct ena_com_dev *ena_dev, bool state);
+
+/* ena_com_get_admin_running_state - Get the admin queue state
+ * @ena_dev: ENA communication layer struct
+ *
+ * Retrieve the state of the admin queue (enable/disable)
+ *
+ * @return - current polling mode (enable/disable)
+ */
+bool ena_com_get_admin_running_state(struct ena_com_dev *ena_dev);
+
+/* ena_com_set_admin_polling_mode - Set the admin completion queue polling mode
+ * @ena_dev: ENA communication layer struct
+ * @polling: ENAble/Disable polling mode
+ *
+ * Set the admin completion mode.
+ */
+void ena_com_set_admin_polling_mode(struct ena_com_dev *ena_dev, bool polling);
+
+/* ena_com_get_admin_polling_mode - Get the admin completion queue polling mode
+ * @ena_dev: ENA communication layer struct
+ *
+ * Get the admin completion mode.
+ * If polling mode is on, ena_com_execute_admin_command will perform a
+ * polling on the admin completion queue for the commands completion,
+ * otherwise it will wait on wait event.
+ *
+ * @return state
+ */
+bool ena_com_get_admin_polling_mode(struct ena_com_dev *ena_dev);
+
+/* ena_com_set_admin_auto_polling_mode - Enable autoswitch to polling mode
+ * @ena_dev: ENA communication layer struct
+ * @polling: Enable/Disable polling mode
+ *
+ * Set the autopolling mode.
+ * If autopolling is on:
+ * In case of missing interrupt when data is available switch to polling.
+ */
+void ena_com_set_admin_auto_polling_mode(struct ena_com_dev *ena_dev,
+					 bool polling);
+
+/* ena_com_admin_q_comp_intr_handler - admin queue interrupt handler
+ * @ena_dev: ENA communication layer struct
+ *
+ * This method goes over the admin completion queue and wakes up all the pending
+ * threads that wait on the commands wait event.
+ *
+ * @note: Should be called after MSI-X interrupt.
+ */
+void ena_com_admin_q_comp_intr_handler(struct ena_com_dev *ena_dev);
+
+/* ena_com_aenq_intr_handler - AENQ interrupt handler
+ * @ena_dev: ENA communication layer struct
+ *
+ * This method goes over the async event notification queue and calls the proper
+ * aenq handler.
+ */
+void ena_com_aenq_intr_handler(struct ena_com_dev *ena_dev, void *data);
+
+/* ena_com_abort_admin_commands - Abort all the outstanding admin commands.
+ * @ena_dev: ENA communication layer struct
+ *
+ * This method aborts all the outstanding admin commands.
+ * The caller should then call ena_com_wait_for_abort_completion to make sure
+ * all the commands were completed.
+ */
+void ena_com_abort_admin_commands(struct ena_com_dev *ena_dev);
+
+/* ena_com_wait_for_abort_completion - Wait for admin commands abort.
+ * @ena_dev: ENA communication layer struct
+ *
+ * This method waits until all the outstanding admin commands are completed.
+ */
+void ena_com_wait_for_abort_completion(struct ena_com_dev *ena_dev);
+
+/* ena_com_validate_version - Validate the device parameters
+ * @ena_dev: ENA communication layer struct
+ *
+ * This method verifies the device parameters are the same as the saved
+ * parameters in ena_dev.
+ * This method is useful after device reset, to validate the device mac address
+ * and the device offloads are the same as before the reset.
+ *
+ * @return - 0 on success negative value otherwise.
+ */
+int ena_com_validate_version(struct ena_com_dev *ena_dev);
+
+/* ena_com_get_link_params - Retrieve physical link parameters.
+ * @ena_dev: ENA communication layer struct
+ * @resp: Link parameters
+ *
+ * Retrieve the physical link parameters,
+ * like speed, auto-negotiation and full duplex support.
+ *
+ * @return - 0 on Success negative value otherwise.
+ */
+int ena_com_get_link_params(struct ena_com_dev *ena_dev,
+			    struct ena_admin_get_feat_resp *resp);
+
+/* ena_com_get_dma_width - Retrieve physical dma address width the device
+ * supports.
+ * @ena_dev: ENA communication layer struct
+ *
+ * Retrieve the maximum physical address bits the device can handle.
+ *
+ * @return: > 0 on Success and negative value otherwise.
+ */
+int ena_com_get_dma_width(struct ena_com_dev *ena_dev);
+
+/* ena_com_set_aenq_config - Set aenq groups configurations
+ * @ena_dev: ENA communication layer struct
+ * @groups flag: bit fields flags of enum ena_admin_aenq_group.
+ *
+ * Configure which aenq event group the driver would like to receive.
+ *
+ * @return: 0 on Success and negative value otherwise.
+ */
+int ena_com_set_aenq_config(struct ena_com_dev *ena_dev, u32 groups_flag);
+
+/* ena_com_get_dev_attr_feat - Get device features
+ * @ena_dev: ENA communication layer struct
+ * @get_feat_ctx: returned context that contain the get features.
+ *
+ * @return: 0 on Success and negative value otherwise.
+ */
+int ena_com_get_dev_attr_feat(struct ena_com_dev *ena_dev,
+			      struct ena_com_dev_get_features_ctx *get_feat_ctx);
+
+/* ena_com_get_dev_basic_stats - Get device basic statistics
+ * @ena_dev: ENA communication layer struct
+ * @stats: stats return value
+ *
+ * @return: 0 on Success and negative value otherwise.
+ */
+int ena_com_get_dev_basic_stats(struct ena_com_dev *ena_dev,
+				struct ena_admin_basic_stats *stats);
+
+/* ena_com_get_eni_stats - Get extended network interface statistics
+ * @ena_dev: ENA communication layer struct
+ * @stats: stats return value
+ *
+ * @return: 0 on Success and negative value otherwise.
+ */
+int ena_com_get_eni_stats(struct ena_com_dev *ena_dev,
+			  struct ena_admin_eni_stats *stats);
+
+/* ena_com_set_dev_mtu - Configure the device mtu.
+ * @ena_dev: ENA communication layer struct
+ * @mtu: mtu value
+ *
+ * @return: 0 on Success and negative value otherwise.
+ */
+int ena_com_set_dev_mtu(struct ena_com_dev *ena_dev, int mtu);
+
+/* ena_com_get_offload_settings - Retrieve the device offloads capabilities
+ * @ena_dev: ENA communication layer struct
+ * @offlad: offload return value
+ *
+ * @return: 0 on Success and negative value otherwise.
+ */
+int ena_com_get_offload_settings(struct ena_com_dev *ena_dev,
+				 struct ena_admin_feature_offload_desc *offload);
+
+/* ena_com_rss_init - Init RSS
+ * @ena_dev: ENA communication layer struct
+ * @log_size: indirection log size
+ *
+ * Allocate RSS/RFS resources.
+ * The caller then can configure rss using ena_com_set_hash_function,
+ * ena_com_set_hash_ctrl and ena_com_indirect_table_set.
+ *
+ * @return: 0 on Success and negative value otherwise.
+ */
+int ena_com_rss_init(struct ena_com_dev *ena_dev, u16 log_size);
+
+/* ena_com_rss_destroy - Destroy rss
+ * @ena_dev: ENA communication layer struct
+ *
+ * Free all the RSS/RFS resources.
+ */
+void ena_com_rss_destroy(struct ena_com_dev *ena_dev);
+
+/* ena_com_get_current_hash_function - Get RSS hash function
+ * @ena_dev: ENA communication layer struct
+ *
+ * Return the current hash function.
+ * @return: 0 or one of the ena_admin_hash_functions values.
+ */
+int ena_com_get_current_hash_function(struct ena_com_dev *ena_dev);
+
+/* ena_com_fill_hash_function - Fill RSS hash function
+ * @ena_dev: ENA communication layer struct
+ * @func: The hash function (Toeplitz or crc)
+ * @key: Hash key (for toeplitz hash)
+ * @key_len: key length (max length 10 DW)
+ * @init_val: initial value for the hash function
+ *
+ * Fill the ena_dev resources with the desire hash function, hash key, key_len
+ * and key initial value (if needed by the hash function).
+ * To flush the key into the device the caller should call
+ * ena_com_set_hash_function.
+ *
+ * @return: 0 on Success and negative value otherwise.
+ */
+int ena_com_fill_hash_function(struct ena_com_dev *ena_dev,
+			       enum ena_admin_hash_functions func,
+			       const u8 *key, u16 key_len, u32 init_val);
+
+/* ena_com_set_hash_function - Flush the hash function and it dependencies to
+ * the device.
+ * @ena_dev: ENA communication layer struct
+ *
+ * Flush the hash function and it dependencies (key, key length and
+ * initial value) if needed.
+ *
+ * @note: Prior to this method the caller should call ena_com_fill_hash_function
+ *
+ * @return: 0 on Success and negative value otherwise.
+ */
+int ena_com_set_hash_function(struct ena_com_dev *ena_dev);
+
+/* ena_com_get_hash_function - Retrieve the hash function from the device.
+ * @ena_dev: ENA communication layer struct
+ * @func: hash function
+ *
+ * Retrieve the hash function from the device.
+ *
+ * @note: If the caller called ena_com_fill_hash_function but didn't flush
+ * it to the device, the new configuration will be lost.
+ *
+ * @return: 0 on Success and negative value otherwise.
+ */
+int ena_com_get_hash_function(struct ena_com_dev *ena_dev,
+			      enum ena_admin_hash_functions *func);
+
+/* ena_com_get_hash_key - Retrieve the hash key
+ * @ena_dev: ENA communication layer struct
+ * @key: hash key
+ *
+ * Retrieve the hash key.
+ *
+ * @note: If the caller called ena_com_fill_hash_key but didn't flush
+ * it to the device, the new configuration will be lost.
+ *
+ * @return: 0 on Success and negative value otherwise.
+ */
+int ena_com_get_hash_key(struct ena_com_dev *ena_dev, u8 *key);
+/* ena_com_fill_hash_ctrl - Fill RSS hash control
+ * @ena_dev: ENA communication layer struct.
+ * @proto: The protocol to configure.
+ * @hash_fields: bit mask of ena_admin_flow_hash_fields
+ *
+ * Fill the ena_dev resources with the desire hash control (the ethernet
+ * fields that take part of the hash) for a specific protocol.
+ * To flush the hash control to the device, the caller should call
+ * ena_com_set_hash_ctrl.
+ *
+ * @return: 0 on Success and negative value otherwise.
+ */
+int ena_com_fill_hash_ctrl(struct ena_com_dev *ena_dev,
+			   enum ena_admin_flow_hash_proto proto,
+			   u16 hash_fields);
+
+/* ena_com_set_hash_ctrl - Flush the hash control resources to the device.
+ * @ena_dev: ENA communication layer struct
+ *
+ * Flush the hash control (the ethernet fields that take part of the hash)
+ *
+ * @note: Prior to this method the caller should call ena_com_fill_hash_ctrl.
+ *
+ * @return: 0 on Success and negative value otherwise.
+ */
+int ena_com_set_hash_ctrl(struct ena_com_dev *ena_dev);
+
+/* ena_com_get_hash_ctrl - Retrieve the hash control from the device.
+ * @ena_dev: ENA communication layer struct
+ * @proto: The protocol to retrieve.
+ * @fields: bit mask of ena_admin_flow_hash_fields.
+ *
+ * Retrieve the hash control from the device.
+ *
+ * @note: If the caller called ena_com_fill_hash_ctrl but didn't flush
+ * it to the device, the new configuration will be lost.
+ *
+ * @return: 0 on Success and negative value otherwise.
+ */
+int ena_com_get_hash_ctrl(struct ena_com_dev *ena_dev,
+			  enum ena_admin_flow_hash_proto proto,
+			  u16 *fields);
+
+/* ena_com_set_default_hash_ctrl - Set the hash control to a default
+ * configuration.
+ * @ena_dev: ENA communication layer struct
+ *
+ * Fill the ena_dev resources with the default hash control configuration.
+ * To flush the hash control to the device, the caller should call
+ * ena_com_set_hash_ctrl.
+ *
+ * @return: 0 on Success and negative value otherwise.
+ */
+int ena_com_set_default_hash_ctrl(struct ena_com_dev *ena_dev);
+
+/* ena_com_indirect_table_fill_entry - Fill a single entry in the RSS
+ * indirection table
+ * @ena_dev: ENA communication layer struct.
+ * @entry_idx - indirection table entry.
+ * @entry_value - redirection value
+ *
+ * Fill a single entry of the RSS indirection table in the ena_dev resources.
+ * To flush the indirection table to the device, the called should call
+ * ena_com_indirect_table_set.
+ *
+ * @return: 0 on Success and negative value otherwise.
+ */
+int ena_com_indirect_table_fill_entry(struct ena_com_dev *ena_dev,
+				      u16 entry_idx, u16 entry_value);
+
+/* ena_com_indirect_table_set - Flush the indirection table to the device.
+ * @ena_dev: ENA communication layer struct
+ *
+ * Flush the indirection hash control to the device.
+ * Prior to this method the caller should call ena_com_indirect_table_fill_entry
+ *
+ * @return: 0 on Success and negative value otherwise.
+ */
+int ena_com_indirect_table_set(struct ena_com_dev *ena_dev);
+
+/* ena_com_indirect_table_get - Retrieve the indirection table from the device.
+ * @ena_dev: ENA communication layer struct
+ * @ind_tbl: indirection table
+ *
+ * Retrieve the RSS indirection table from the device.
+ *
+ * @note: If the caller called ena_com_indirect_table_fill_entry but didn't flush
+ * it to the device, the new configuration will be lost.
+ *
+ * @return: 0 on Success and negative value otherwise.
+ */
+int ena_com_indirect_table_get(struct ena_com_dev *ena_dev, u32 *ind_tbl);
+
+/* ena_com_allocate_host_info - Allocate host info resources.
+ * @ena_dev: ENA communication layer struct
+ *
+ * @return: 0 on Success and negative value otherwise.
+ */
+int ena_com_allocate_host_info(struct ena_com_dev *ena_dev);
+
+/* ena_com_allocate_debug_area - Allocate debug area.
+ * @ena_dev: ENA communication layer struct
+ * @debug_area_size - debug area size.
+ *
+ * @return: 0 on Success and negative value otherwise.
+ */
+int ena_com_allocate_debug_area(struct ena_com_dev *ena_dev,
+				u32 debug_area_size);
+
+/* ena_com_delete_debug_area - Free the debug area resources.
+ * @ena_dev: ENA communication layer struct
+ *
+ * Free the allocated debug area.
+ */
+void ena_com_delete_debug_area(struct ena_com_dev *ena_dev);
+
+/* ena_com_delete_host_info - Free the host info resources.
+ * @ena_dev: ENA communication layer struct
+ *
+ * Free the allocated host info.
+ */
+void ena_com_delete_host_info(struct ena_com_dev *ena_dev);
+
+/* ena_com_set_host_attributes - Update the device with the host
+ * attributes (debug area and host info) base address.
+ * @ena_dev: ENA communication layer struct
+ *
+ * @return: 0 on Success and negative value otherwise.
+ */
+int ena_com_set_host_attributes(struct ena_com_dev *ena_dev);
+
+/* ena_com_create_io_cq - Create io completion queue.
+ * @ena_dev: ENA communication layer struct
+ * @io_cq - io completion queue handler
+
+ * Create IO completion queue.
+ *
+ * @return - 0 on success, negative value on failure.
+ */
+int ena_com_create_io_cq(struct ena_com_dev *ena_dev,
+			 struct ena_com_io_cq *io_cq);
+
+/* ena_com_destroy_io_cq - Destroy io completion queue.
+ * @ena_dev: ENA communication layer struct
+ * @io_cq - io completion queue handler
+
+ * Destroy IO completion queue.
+ *
+ * @return - 0 on success, negative value on failure.
+ */
+int ena_com_destroy_io_cq(struct ena_com_dev *ena_dev,
+			  struct ena_com_io_cq *io_cq);
+
+/* ena_com_execute_admin_command - Execute admin command
+ * @admin_queue: admin queue.
+ * @cmd: the admin command to execute.
+ * @cmd_size: the command size.
+ * @cmd_completion: command completion return value.
+ * @cmd_comp_size: command completion size.
+
+ * Submit an admin command and then wait until the device returns a
+ * completion.
+ * The completion will be copied into cmd_comp.
+ *
+ * @return - 0 on success, negative value on failure.
+ */
+int ena_com_execute_admin_command(struct ena_com_admin_queue *admin_queue,
+				  struct ena_admin_aq_entry *cmd,
+				  size_t cmd_size,
+				  struct ena_admin_acq_entry *cmd_comp,
+				  size_t cmd_comp_size);
+
+/* ena_com_init_interrupt_moderation - Init interrupt moderation
+ * @ena_dev: ENA communication layer struct
+ *
+ * @return - 0 on success, negative value on failure.
+ */
+int ena_com_init_interrupt_moderation(struct ena_com_dev *ena_dev);
+
+/* ena_com_interrupt_moderation_supported - Return if interrupt moderation
+ * capability is supported by the device.
+ *
+ * @return - supported or not.
+ */
+bool ena_com_interrupt_moderation_supported(struct ena_com_dev *ena_dev);
+
+/* ena_com_update_nonadaptive_moderation_interval_tx - Update the
+ * non-adaptive interval in Tx direction.
+ * @ena_dev: ENA communication layer struct
+ * @tx_coalesce_usecs: Interval in usec.
+ *
+ * @return - 0 on success, negative value on failure.
+ */
+int ena_com_update_nonadaptive_moderation_interval_tx(struct ena_com_dev *ena_dev,
+						      u32 tx_coalesce_usecs);
+
+/* ena_com_update_nonadaptive_moderation_interval_rx - Update the
+ * non-adaptive interval in Rx direction.
+ * @ena_dev: ENA communication layer struct
+ * @rx_coalesce_usecs: Interval in usec.
+ *
+ * @return - 0 on success, negative value on failure.
+ */
+int ena_com_update_nonadaptive_moderation_interval_rx(struct ena_com_dev *ena_dev,
+						      u32 rx_coalesce_usecs);
+
+/* ena_com_get_nonadaptive_moderation_interval_tx - Retrieve the
+ * non-adaptive interval in Tx direction.
+ * @ena_dev: ENA communication layer struct
+ *
+ * @return - interval in usec
+ */
+unsigned int ena_com_get_nonadaptive_moderation_interval_tx(struct ena_com_dev *ena_dev);
+
+/* ena_com_get_nonadaptive_moderation_interval_rx - Retrieve the
+ * non-adaptive interval in Rx direction.
+ * @ena_dev: ENA communication layer struct
+ *
+ * @return - interval in usec
+ */
+unsigned int ena_com_get_nonadaptive_moderation_interval_rx(struct ena_com_dev *ena_dev);
+
+/* ena_com_config_dev_mode - Configure the placement policy of the device.
+ * @ena_dev: ENA communication layer struct
+ * @llq_features: LLQ feature descriptor, retrieve via
+ *		   ena_com_get_dev_attr_feat.
+ * @ena_llq_config: The default driver LLQ parameters configurations
+ */
+int ena_com_config_dev_mode(struct ena_com_dev *ena_dev,
+			    struct ena_admin_feature_llq_desc *llq_features,
+			    struct ena_llq_configurations *llq_default_config);
+
+/* ena_com_io_sq_to_ena_dev - Extract ena_com_dev using contained field io_sq.
+ * @io_sq: IO submit queue struct
+ *
+ * @return - ena_com_dev struct extracted from io_sq
+ */
+static inline struct ena_com_dev *ena_com_io_sq_to_ena_dev(struct ena_com_io_sq *io_sq)
+{
+	return container_of(io_sq, struct ena_com_dev, io_sq_queues[io_sq->qid]);
+}
+
+/* ena_com_io_cq_to_ena_dev - Extract ena_com_dev using contained field io_cq.
+ * @io_sq: IO submit queue struct
+ *
+ * @return - ena_com_dev struct extracted from io_sq
+ */
+static inline struct ena_com_dev *ena_com_io_cq_to_ena_dev(struct ena_com_io_cq *io_cq)
+{
+	return container_of(io_cq, struct ena_com_dev, io_cq_queues[io_cq->qid]);
+}
+
+static inline bool ena_com_get_adaptive_moderation_enabled(struct ena_com_dev *ena_dev)
+{
+	return ena_dev->adaptive_coalescing;
+}
+
+static inline void ena_com_enable_adaptive_moderation(struct ena_com_dev *ena_dev)
+{
+	ena_dev->adaptive_coalescing = true;
+}
+
+static inline void ena_com_disable_adaptive_moderation(struct ena_com_dev *ena_dev)
+{
+	ena_dev->adaptive_coalescing = false;
+}
+
+/* ena_com_update_intr_reg - Prepare interrupt register
+ * @intr_reg: interrupt register to update.
+ * @rx_delay_interval: Rx interval in usecs
+ * @tx_delay_interval: Tx interval in usecs
+ * @unmask: unmask enable/disable
+ *
+ * Prepare interrupt update register with the supplied parameters.
+ */
+static inline void ena_com_update_intr_reg(struct ena_eth_io_intr_reg *intr_reg,
+					   u32 rx_delay_interval,
+					   u32 tx_delay_interval,
+					   bool unmask)
+{
+	intr_reg->intr_control = 0;
+	intr_reg->intr_control |= rx_delay_interval &
+		ENA_ETH_IO_INTR_REG_RX_INTR_DELAY_MASK;
+
+	intr_reg->intr_control |=
+		(tx_delay_interval << ENA_ETH_IO_INTR_REG_TX_INTR_DELAY_SHIFT)
+		& ENA_ETH_IO_INTR_REG_TX_INTR_DELAY_MASK;
+
+	if (unmask)
+		intr_reg->intr_control |= ENA_ETH_IO_INTR_REG_INTR_UNMASK_MASK;
+}
+
+static inline u8 *ena_com_get_next_bounce_buffer(struct ena_com_io_bounce_buffer_control *bounce_buf_ctrl)
+{
+	u16 size, buffers_num;
+	u8 *buf;
+
+	size = bounce_buf_ctrl->buffer_size;
+	buffers_num = bounce_buf_ctrl->buffers_num;
+
+	buf = bounce_buf_ctrl->base_buffer +
+		(bounce_buf_ctrl->next_to_use++ & (buffers_num - 1)) * size;
+
+	prefetchw(bounce_buf_ctrl->base_buffer +
+		(bounce_buf_ctrl->next_to_use & (buffers_num - 1)) * size);
+
+	return buf;
+}
+
+#ifdef ENA_EXTENDED_STATS
+int ena_com_get_dev_extended_stats(struct ena_com_dev *ena_dev, char *buff,
+				   u32 len);
+
+int ena_com_extended_stats_set_func_queue(struct ena_com_dev *ena_dev,
+					  u32 funct_queue);
+#endif
+#if defined(__cplusplus)
+}
+#endif /* __cplusplus */
+#endif /* !(ENA_COM) */

--- a/kernel/macOS/ena/ena_com/ena_defs/ena_admin_defs.h
+++ b/kernel/macOS/ena/ena_com/ena_defs/ena_admin_defs.h
@@ -1,0 +1,1694 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+#ifndef _ENA_ADMIN_H_
+#define _ENA_ADMIN_H_
+
+#define ENA_ADMIN_EXTRA_PROPERTIES_STRING_LEN 32
+#define ENA_ADMIN_EXTRA_PROPERTIES_COUNT     32
+
+#define ENA_ADMIN_RSS_KEY_PARTS              10
+
+enum ena_admin_aq_opcode {
+	ENA_ADMIN_CREATE_SQ                         = 1,
+	ENA_ADMIN_DESTROY_SQ                        = 2,
+	ENA_ADMIN_CREATE_CQ                         = 3,
+	ENA_ADMIN_DESTROY_CQ                        = 4,
+	ENA_ADMIN_GET_FEATURE                       = 8,
+	ENA_ADMIN_SET_FEATURE                       = 9,
+	ENA_ADMIN_GET_STATS                         = 11,
+};
+
+enum ena_admin_aq_completion_status {
+	ENA_ADMIN_SUCCESS                           = 0,
+	ENA_ADMIN_RESOURCE_ALLOCATION_FAILURE       = 1,
+	ENA_ADMIN_BAD_OPCODE                        = 2,
+	ENA_ADMIN_UNSUPPORTED_OPCODE                = 3,
+	ENA_ADMIN_MALFORMED_REQUEST                 = 4,
+	/* Additional status is provided in ACQ entry extended_status */
+	ENA_ADMIN_ILLEGAL_PARAMETER                 = 5,
+	ENA_ADMIN_UNKNOWN_ERROR                     = 6,
+	ENA_ADMIN_RESOURCE_BUSY                     = 7,
+};
+
+/* subcommands for the set/get feature admin commands */
+enum ena_admin_aq_feature_id {
+	ENA_ADMIN_DEVICE_ATTRIBUTES                 = 1,
+	ENA_ADMIN_MAX_QUEUES_NUM                    = 2,
+	ENA_ADMIN_HW_HINTS                          = 3,
+	ENA_ADMIN_LLQ                               = 4,
+	ENA_ADMIN_EXTRA_PROPERTIES_STRINGS          = 5,
+	ENA_ADMIN_EXTRA_PROPERTIES_FLAGS            = 6,
+	ENA_ADMIN_MAX_QUEUES_EXT                    = 7,
+	ENA_ADMIN_RSS_HASH_FUNCTION                 = 10,
+	ENA_ADMIN_STATELESS_OFFLOAD_CONFIG          = 11,
+	ENA_ADMIN_RSS_INDIRECTION_TABLE_CONFIG      = 12,
+	ENA_ADMIN_MTU                               = 14,
+	ENA_ADMIN_RSS_HASH_INPUT                    = 18,
+	ENA_ADMIN_INTERRUPT_MODERATION              = 20,
+	ENA_ADMIN_AENQ_CONFIG                       = 26,
+	ENA_ADMIN_LINK_CONFIG                       = 27,
+	ENA_ADMIN_HOST_ATTR_CONFIG                  = 28,
+	ENA_ADMIN_FEATURES_OPCODE_NUM               = 32,
+};
+
+enum ena_admin_placement_policy_type {
+	/* descriptors and headers are in host memory */
+	ENA_ADMIN_PLACEMENT_POLICY_HOST             = 1,
+	/* descriptors and headers are in device memory (a.k.a Low Latency
+	 * Queue)
+	 */
+	ENA_ADMIN_PLACEMENT_POLICY_DEV              = 3,
+};
+
+enum ena_admin_link_types {
+	ENA_ADMIN_LINK_SPEED_1G                     = 0x1,
+	ENA_ADMIN_LINK_SPEED_2_HALF_G               = 0x2,
+	ENA_ADMIN_LINK_SPEED_5G                     = 0x4,
+	ENA_ADMIN_LINK_SPEED_10G                    = 0x8,
+	ENA_ADMIN_LINK_SPEED_25G                    = 0x10,
+	ENA_ADMIN_LINK_SPEED_40G                    = 0x20,
+	ENA_ADMIN_LINK_SPEED_50G                    = 0x40,
+	ENA_ADMIN_LINK_SPEED_100G                   = 0x80,
+	ENA_ADMIN_LINK_SPEED_200G                   = 0x100,
+	ENA_ADMIN_LINK_SPEED_400G                   = 0x200,
+};
+
+enum ena_admin_completion_policy_type {
+	/* completion queue entry for each sq descriptor */
+	ENA_ADMIN_COMPLETION_POLICY_DESC            = 0,
+	/* completion queue entry upon request in sq descriptor */
+	ENA_ADMIN_COMPLETION_POLICY_DESC_ON_DEMAND  = 1,
+	/* current queue head pointer is updated in OS memory upon sq
+	 * descriptor request
+	 */
+	ENA_ADMIN_COMPLETION_POLICY_HEAD_ON_DEMAND  = 2,
+	/* current queue head pointer is updated in OS memory for each sq
+	 * descriptor
+	 */
+	ENA_ADMIN_COMPLETION_POLICY_HEAD            = 3,
+};
+
+/* basic stats return ena_admin_basic_stats while extanded stats return a
+ * buffer (string format) with additional statistics per queue and per
+ * device id
+ */
+enum ena_admin_get_stats_type {
+	ENA_ADMIN_GET_STATS_TYPE_BASIC              = 0,
+	ENA_ADMIN_GET_STATS_TYPE_EXTENDED           = 1,
+	/* extra HW stats for specific network interface */
+	ENA_ADMIN_GET_STATS_TYPE_ENI                = 2,
+};
+
+enum ena_admin_get_stats_scope {
+	ENA_ADMIN_SPECIFIC_QUEUE                    = 0,
+	ENA_ADMIN_ETH_TRAFFIC                       = 1,
+};
+
+struct ena_admin_aq_common_desc {
+	/* 11:0 : command_id
+	 * 15:12 : reserved12
+	 */
+	uint16_t command_id;
+
+	/* as appears in ena_admin_aq_opcode */
+	uint8_t opcode;
+
+	/* 0 : phase
+	 * 1 : ctrl_data - control buffer address valid
+	 * 2 : ctrl_data_indirect - control buffer address
+	 *    points to list of pages with addresses of control
+	 *    buffers
+	 * 7:3 : reserved3
+	 */
+	uint8_t flags;
+};
+
+/* used in ena_admin_aq_entry. Can point directly to control data, or to a
+ * page list chunk. Used also at the end of indirect mode page list chunks,
+ * for chaining.
+ */
+struct ena_admin_ctrl_buff_info {
+	uint32_t length;
+
+	struct ena_common_mem_addr address;
+};
+
+struct ena_admin_sq {
+	uint16_t sq_idx;
+
+	/* 4:0 : reserved
+	 * 7:5 : sq_direction - 0x1 - Tx; 0x2 - Rx
+	 */
+	uint8_t sq_identity;
+
+	uint8_t reserved1;
+};
+
+struct ena_admin_aq_entry {
+	struct ena_admin_aq_common_desc aq_common_descriptor;
+
+	union {
+		uint32_t inline_data_w1[3];
+
+		struct ena_admin_ctrl_buff_info control_buffer;
+	} u;
+
+	uint32_t inline_data_w4[12];
+};
+
+struct ena_admin_acq_common_desc {
+	/* command identifier to associate it with the aq descriptor
+	 * 11:0 : command_id
+	 * 15:12 : reserved12
+	 */
+	uint16_t command;
+
+	uint8_t status;
+
+	/* 0 : phase
+	 * 7:1 : reserved1
+	 */
+	uint8_t flags;
+
+	uint16_t extended_status;
+
+	/* indicates to the driver which AQ entry has been consumed by the
+	 * device and could be reused
+	 */
+	uint16_t sq_head_indx;
+};
+
+struct ena_admin_acq_entry {
+	struct ena_admin_acq_common_desc acq_common_descriptor;
+
+	uint32_t response_specific_data[14];
+};
+
+struct ena_admin_aq_create_sq_cmd {
+	struct ena_admin_aq_common_desc aq_common_descriptor;
+
+	/* 4:0 : reserved0_w1
+	 * 7:5 : sq_direction - 0x1 - Tx, 0x2 - Rx
+	 */
+	uint8_t sq_identity;
+
+	uint8_t reserved8_w1;
+
+	/* 3:0 : placement_policy - Describing where the SQ
+	 *    descriptor ring and the SQ packet headers reside:
+	 *    0x1 - descriptors and headers are in OS memory,
+	 *    0x3 - descriptors and headers in device memory
+	 *    (a.k.a Low Latency Queue)
+	 * 6:4 : completion_policy - Describing what policy
+	 *    to use for generation completion entry (cqe) in
+	 *    the CQ associated with this SQ: 0x0 - cqe for each
+	 *    sq descriptor, 0x1 - cqe upon request in sq
+	 *    descriptor, 0x2 - current queue head pointer is
+	 *    updated in OS memory upon sq descriptor request
+	 *    0x3 - current queue head pointer is updated in OS
+	 *    memory for each sq descriptor
+	 * 7 : reserved15_w1
+	 */
+	uint8_t sq_caps_2;
+
+	/* 0 : is_physically_contiguous - Described if the
+	 *    queue ring memory is allocated in physical
+	 *    contiguous pages or split.
+	 * 7:1 : reserved17_w1
+	 */
+	uint8_t sq_caps_3;
+
+	/* associated completion queue id. This CQ must be created prior to SQ
+	 * creation
+	 */
+	uint16_t cq_idx;
+
+	/* submission queue depth in entries */
+	uint16_t sq_depth;
+
+	/* SQ physical base address in OS memory. This field should not be
+	 * used for Low Latency queues. Has to be page aligned.
+	 */
+	struct ena_common_mem_addr sq_ba;
+
+	/* specifies queue head writeback location in OS memory. Valid if
+	 * completion_policy is set to completion_policy_head_on_demand or
+	 * completion_policy_head. Has to be cache aligned
+	 */
+	struct ena_common_mem_addr sq_head_writeback;
+
+	uint32_t reserved0_w7;
+
+	uint32_t reserved0_w8;
+};
+
+enum ena_admin_sq_direction {
+	ENA_ADMIN_SQ_DIRECTION_TX                   = 1,
+	ENA_ADMIN_SQ_DIRECTION_RX                   = 2,
+};
+
+struct ena_admin_acq_create_sq_resp_desc {
+	struct ena_admin_acq_common_desc acq_common_desc;
+
+	uint16_t sq_idx;
+
+	uint16_t reserved;
+
+	/* queue doorbell address as an offset to PCIe MMIO REG BAR */
+	uint32_t sq_doorbell_offset;
+
+	/* low latency queue ring base address as an offset to PCIe MMIO
+	 * LLQ_MEM BAR
+	 */
+	uint32_t llq_descriptors_offset;
+
+	/* low latency queue headers' memory as an offset to PCIe MMIO
+	 * LLQ_MEM BAR
+	 */
+	uint32_t llq_headers_offset;
+};
+
+struct ena_admin_aq_destroy_sq_cmd {
+	struct ena_admin_aq_common_desc aq_common_descriptor;
+
+	struct ena_admin_sq sq;
+};
+
+struct ena_admin_acq_destroy_sq_resp_desc {
+	struct ena_admin_acq_common_desc acq_common_desc;
+};
+
+struct ena_admin_aq_create_cq_cmd {
+	struct ena_admin_aq_common_desc aq_common_descriptor;
+
+	/* 4:0 : reserved5
+	 * 5 : interrupt_mode_enabled - if set, cq operates
+	 *    in interrupt mode, otherwise - polling
+	 * 7:6 : reserved6
+	 */
+	uint8_t cq_caps_1;
+
+	/* 4:0 : cq_entry_size_words - size of CQ entry in
+	 *    32-bit words, valid values: 4, 8.
+	 * 7:5 : reserved7
+	 */
+	uint8_t cq_caps_2;
+
+	/* completion queue depth in # of entries. must be power of 2 */
+	uint16_t cq_depth;
+
+	/* msix vector assigned to this cq */
+	uint32_t msix_vector;
+
+	/* cq physical base address in OS memory. CQ must be physically
+	 * contiguous
+	 */
+	struct ena_common_mem_addr cq_ba;
+};
+
+struct ena_admin_acq_create_cq_resp_desc {
+	struct ena_admin_acq_common_desc acq_common_desc;
+
+	uint16_t cq_idx;
+
+	/* actual cq depth in number of entries */
+	uint16_t cq_actual_depth;
+
+	uint32_t numa_node_register_offset;
+
+	uint32_t cq_head_db_register_offset;
+
+	uint32_t cq_interrupt_unmask_register_offset;
+};
+
+struct ena_admin_aq_destroy_cq_cmd {
+	struct ena_admin_aq_common_desc aq_common_descriptor;
+
+	uint16_t cq_idx;
+
+	uint16_t reserved1;
+};
+
+struct ena_admin_acq_destroy_cq_resp_desc {
+	struct ena_admin_acq_common_desc acq_common_desc;
+};
+
+/* ENA AQ Get Statistics command. Extended statistics are placed in control
+ * buffer pointed by AQ entry
+ */
+struct ena_admin_aq_get_stats_cmd {
+	struct ena_admin_aq_common_desc aq_common_descriptor;
+
+	union {
+		/* command specific inline data */
+		uint32_t inline_data_w1[3];
+
+		struct ena_admin_ctrl_buff_info control_buffer;
+	} u;
+
+	/* stats type as defined in enum ena_admin_get_stats_type */
+	uint8_t type;
+
+	/* stats scope defined in enum ena_admin_get_stats_scope */
+	uint8_t scope;
+
+	uint16_t reserved3;
+
+	/* queue id. used when scope is specific_queue */
+	uint16_t queue_idx;
+
+	/* device id, value 0xFFFF means mine. only privileged device can get
+	 * stats of other device
+	 */
+	uint16_t device_id;
+};
+
+/* Basic Statistics Command. */
+struct ena_admin_basic_stats {
+	uint32_t tx_bytes_low;
+
+	uint32_t tx_bytes_high;
+
+	uint32_t tx_pkts_low;
+
+	uint32_t tx_pkts_high;
+
+	uint32_t rx_bytes_low;
+
+	uint32_t rx_bytes_high;
+
+	uint32_t rx_pkts_low;
+
+	uint32_t rx_pkts_high;
+
+	uint32_t rx_drops_low;
+
+	uint32_t rx_drops_high;
+
+	uint32_t tx_drops_low;
+
+	uint32_t tx_drops_high;
+};
+
+/* ENI Statistics Command. */
+struct ena_admin_eni_stats {
+	/* The number of packets shaped due to inbound aggregate BW
+	 * allowance being exceeded
+	 */
+	uint64_t bw_in_allowance_exceeded;
+
+	/* The number of packets shaped due to outbound aggregate BW
+	 * allowance being exceeded
+	 */
+	uint64_t bw_out_allowance_exceeded;
+
+	/* The number of packets shaped due to PPS allowance being exceeded */
+	uint64_t pps_allowance_exceeded;
+
+	/* The number of packets shaped due to connection tracking
+	 * allowance being exceeded and leading to failure in establishment
+	 * of new connections
+	 */
+	uint64_t conntrack_allowance_exceeded;
+
+	/* The number of packets shaped due to linklocal packet rate
+	 * allowance being exceeded
+	 */
+	uint64_t linklocal_allowance_exceeded;
+};
+
+struct ena_admin_acq_get_stats_resp {
+	struct ena_admin_acq_common_desc acq_common_desc;
+
+	union {
+		uint64_t raw[7];
+
+		struct ena_admin_basic_stats basic_stats;
+
+		struct ena_admin_eni_stats eni_stats;
+	} u;
+};
+
+struct ena_admin_get_set_feature_common_desc {
+	/* 1:0 : select - 0x1 - current value; 0x3 - default
+	 *    value
+	 * 7:3 : reserved3
+	 */
+	uint8_t flags;
+
+	/* as appears in ena_admin_aq_feature_id */
+	uint8_t feature_id;
+
+	/* The driver specifies the max feature version it supports and the
+	 * device responds with the currently supported feature version. The
+	 * field is zero based
+	 */
+	uint8_t feature_version;
+
+	uint8_t reserved8;
+};
+
+struct ena_admin_device_attr_feature_desc {
+	uint32_t impl_id;
+
+	uint32_t device_version;
+
+	/* bitmap of ena_admin_aq_feature_id, which represents supported
+	 * subcommands for the set/get feature admin commands.
+	 */
+	uint32_t supported_features;
+
+	uint32_t reserved3;
+
+	/* Indicates how many bits are used physical address access. */
+	uint32_t phys_addr_width;
+
+	/* Indicates how many bits are used virtual address access. */
+	uint32_t virt_addr_width;
+
+	/* unicast MAC address (in Network byte order) */
+	uint8_t mac_addr[6];
+
+	uint8_t reserved7[2];
+
+	uint32_t max_mtu;
+};
+
+enum ena_admin_llq_header_location {
+	/* header is in descriptor list */
+	ENA_ADMIN_INLINE_HEADER                     = 1,
+	/* header in a separate ring, implies 16B descriptor list entry */
+	ENA_ADMIN_HEADER_RING                       = 2,
+};
+
+enum ena_admin_llq_ring_entry_size {
+	ENA_ADMIN_LIST_ENTRY_SIZE_128B              = 1,
+	ENA_ADMIN_LIST_ENTRY_SIZE_192B              = 2,
+	ENA_ADMIN_LIST_ENTRY_SIZE_256B              = 4,
+};
+
+enum ena_admin_llq_num_descs_before_header {
+	ENA_ADMIN_LLQ_NUM_DESCS_BEFORE_HEADER_0     = 0,
+	ENA_ADMIN_LLQ_NUM_DESCS_BEFORE_HEADER_1     = 1,
+	ENA_ADMIN_LLQ_NUM_DESCS_BEFORE_HEADER_2     = 2,
+	ENA_ADMIN_LLQ_NUM_DESCS_BEFORE_HEADER_4     = 4,
+	ENA_ADMIN_LLQ_NUM_DESCS_BEFORE_HEADER_8     = 8,
+};
+
+/* packet descriptor list entry always starts with one or more descriptors,
+ * followed by a header. The rest of the descriptors are located in the
+ * beginning of the subsequent entry. Stride refers to how the rest of the
+ * descriptors are placed. This field is relevant only for inline header
+ * mode
+ */
+enum ena_admin_llq_stride_ctrl {
+	ENA_ADMIN_SINGLE_DESC_PER_ENTRY             = 1,
+	ENA_ADMIN_MULTIPLE_DESCS_PER_ENTRY          = 2,
+};
+
+enum ena_admin_accel_mode_feat {
+	ENA_ADMIN_DISABLE_META_CACHING              = 0,
+	ENA_ADMIN_LIMIT_TX_BURST                    = 1,
+};
+
+struct ena_admin_accel_mode_get {
+	/* bit field of enum ena_admin_accel_mode_feat */
+	uint16_t supported_flags;
+
+	/* maximum burst size between two doorbells. The size is in bytes */
+	uint16_t max_tx_burst_size;
+};
+
+struct ena_admin_accel_mode_set {
+	/* bit field of enum ena_admin_accel_mode_feat */
+	uint16_t enabled_flags;
+
+	uint16_t reserved;
+};
+
+struct ena_admin_accel_mode_req {
+	union {
+		uint32_t raw[2];
+
+		struct ena_admin_accel_mode_get get;
+
+		struct ena_admin_accel_mode_set set;
+	} u;
+};
+
+struct ena_admin_feature_llq_desc {
+	uint32_t max_llq_num;
+
+	uint32_t max_llq_depth;
+
+	/* specify the header locations the device supports. bitfield of enum
+	 * ena_admin_llq_header_location.
+	 */
+	uint16_t header_location_ctrl_supported;
+
+	/* the header location the driver selected to use. */
+	uint16_t header_location_ctrl_enabled;
+
+	/* if inline header is specified - this is the size of descriptor list
+	 * entry. If header in a separate ring is specified - this is the size
+	 * of header ring entry. bitfield of enum ena_admin_llq_ring_entry_size.
+	 * specify the entry sizes the device supports
+	 */
+	uint16_t entry_size_ctrl_supported;
+
+	/* the entry size the driver selected to use. */
+	uint16_t entry_size_ctrl_enabled;
+
+	/* valid only if inline header is specified. First entry associated with
+	 * the packet includes descriptors and header. Rest of the entries
+	 * occupied by descriptors. This parameter defines the max number of
+	 * descriptors precedding the header in the first entry. The field is
+	 * bitfield of enum ena_admin_llq_num_descs_before_header and specify
+	 * the values the device supports
+	 */
+	uint16_t desc_num_before_header_supported;
+
+	/* the desire field the driver selected to use */
+	uint16_t desc_num_before_header_enabled;
+
+	/* valid only if inline was chosen. bitfield of enum
+	 * ena_admin_llq_stride_ctrl
+	 */
+	uint16_t descriptors_stride_ctrl_supported;
+
+	/* the stride control the driver selected to use */
+	uint16_t descriptors_stride_ctrl_enabled;
+
+	/* reserved */
+	uint32_t reserved1;
+
+	/* accelerated low latency queues requirement. driver needs to
+	 * support those requirements in order to use accelerated llq
+	 */
+	struct ena_admin_accel_mode_req accel_mode;
+};
+
+struct ena_admin_queue_ext_feature_fields {
+	uint32_t max_tx_sq_num;
+
+	uint32_t max_tx_cq_num;
+
+	uint32_t max_rx_sq_num;
+
+	uint32_t max_rx_cq_num;
+
+	uint32_t max_tx_sq_depth;
+
+	uint32_t max_tx_cq_depth;
+
+	uint32_t max_rx_sq_depth;
+
+	uint32_t max_rx_cq_depth;
+
+	uint32_t max_tx_header_size;
+
+	/* Maximum Descriptors number, including meta descriptor, allowed for a
+	 * single Tx packet
+	 */
+	uint16_t max_per_packet_tx_descs;
+
+	/* Maximum Descriptors number allowed for a single Rx packet */
+	uint16_t max_per_packet_rx_descs;
+};
+
+struct ena_admin_queue_feature_desc {
+	uint32_t max_sq_num;
+
+	uint32_t max_sq_depth;
+
+	uint32_t max_cq_num;
+
+	uint32_t max_cq_depth;
+
+	uint32_t max_legacy_llq_num;
+
+	uint32_t max_legacy_llq_depth;
+
+	uint32_t max_header_size;
+
+	/* Maximum Descriptors number, including meta descriptor, allowed for a
+	 * single Tx packet
+	 */
+	uint16_t max_packet_tx_descs;
+
+	/* Maximum Descriptors number allowed for a single Rx packet */
+	uint16_t max_packet_rx_descs;
+};
+
+struct ena_admin_set_feature_mtu_desc {
+	/* exclude L2 */
+	uint32_t mtu;
+};
+
+struct ena_admin_get_extra_properties_strings_desc {
+	uint32_t count;
+};
+
+struct ena_admin_get_extra_properties_flags_desc {
+	uint32_t flags;
+};
+
+struct ena_admin_set_feature_host_attr_desc {
+	/* host OS info base address in OS memory. host info is 4KB of
+	 * physically contiguous
+	 */
+	struct ena_common_mem_addr os_info_ba;
+
+	/* host debug area base address in OS memory. debug area must be
+	 * physically contiguous
+	 */
+	struct ena_common_mem_addr debug_ba;
+
+	/* debug area size */
+	uint32_t debug_area_size;
+};
+
+struct ena_admin_feature_intr_moder_desc {
+	/* interrupt delay granularity in usec */
+	uint16_t intr_delay_resolution;
+
+	uint16_t reserved;
+};
+
+struct ena_admin_get_feature_link_desc {
+	/* Link speed in Mb */
+	uint32_t speed;
+
+	/* bit field of enum ena_admin_link types */
+	uint32_t supported;
+
+	/* 0 : autoneg
+	 * 1 : duplex - Full Duplex
+	 * 31:2 : reserved2
+	 */
+	uint32_t flags;
+};
+
+struct ena_admin_feature_aenq_desc {
+	/* bitmask for AENQ groups the device can report */
+	uint32_t supported_groups;
+
+	/* bitmask for AENQ groups to report */
+	uint32_t enabled_groups;
+};
+
+struct ena_admin_feature_offload_desc {
+	/* 0 : TX_L3_csum_ipv4
+	 * 1 : TX_L4_ipv4_csum_part - The checksum field
+	 *    should be initialized with pseudo header checksum
+	 * 2 : TX_L4_ipv4_csum_full
+	 * 3 : TX_L4_ipv6_csum_part - The checksum field
+	 *    should be initialized with pseudo header checksum
+	 * 4 : TX_L4_ipv6_csum_full
+	 * 5 : tso_ipv4
+	 * 6 : tso_ipv6
+	 * 7 : tso_ecn
+	 */
+	uint32_t tx;
+
+	/* Receive side supported stateless offload
+	 * 0 : RX_L3_csum_ipv4 - IPv4 checksum
+	 * 1 : RX_L4_ipv4_csum - TCP/UDP/IPv4 checksum
+	 * 2 : RX_L4_ipv6_csum - TCP/UDP/IPv6 checksum
+	 * 3 : RX_hash - Hash calculation
+	 */
+	uint32_t rx_supported;
+
+	uint32_t rx_enabled;
+};
+
+enum ena_admin_hash_functions {
+	ENA_ADMIN_TOEPLITZ                          = 1,
+	ENA_ADMIN_CRC32                             = 2,
+};
+
+struct ena_admin_feature_rss_flow_hash_control {
+	uint32_t key_parts;
+
+	uint32_t reserved;
+
+	uint32_t key[ENA_ADMIN_RSS_KEY_PARTS];
+};
+
+struct ena_admin_feature_rss_flow_hash_function {
+	/* 7:0 : funcs - bitmask of ena_admin_hash_functions */
+	uint32_t supported_func;
+
+	/* 7:0 : selected_func - bitmask of
+	 *    ena_admin_hash_functions
+	 */
+	uint32_t selected_func;
+
+	/* initial value */
+	uint32_t init_val;
+};
+
+/* RSS flow hash protocols */
+enum ena_admin_flow_hash_proto {
+	ENA_ADMIN_RSS_TCP4                          = 0,
+	ENA_ADMIN_RSS_UDP4                          = 1,
+	ENA_ADMIN_RSS_TCP6                          = 2,
+	ENA_ADMIN_RSS_UDP6                          = 3,
+	ENA_ADMIN_RSS_IP4                           = 4,
+	ENA_ADMIN_RSS_IP6                           = 5,
+	ENA_ADMIN_RSS_IP4_FRAG                      = 6,
+	ENA_ADMIN_RSS_NOT_IP                        = 7,
+	/* TCPv6 with extension header */
+	ENA_ADMIN_RSS_TCP6_EX                       = 8,
+	/* IPv6 with extension header */
+	ENA_ADMIN_RSS_IP6_EX                        = 9,
+	ENA_ADMIN_RSS_PROTO_NUM                     = 16,
+};
+
+/* RSS flow hash fields */
+enum ena_admin_flow_hash_fields {
+	/* Ethernet Dest Addr */
+	ENA_ADMIN_RSS_L2_DA                         = BIT(0),
+	/* Ethernet Src Addr */
+	ENA_ADMIN_RSS_L2_SA                         = BIT(1),
+	/* ipv4/6 Dest Addr */
+	ENA_ADMIN_RSS_L3_DA                         = BIT(2),
+	/* ipv4/6 Src Addr */
+	ENA_ADMIN_RSS_L3_SA                         = BIT(3),
+	/* tcp/udp Dest Port */
+	ENA_ADMIN_RSS_L4_DP                         = BIT(4),
+	/* tcp/udp Src Port */
+	ENA_ADMIN_RSS_L4_SP                         = BIT(5),
+};
+
+struct ena_admin_proto_input {
+	/* flow hash fields (bitwise according to ena_admin_flow_hash_fields) */
+	uint16_t fields;
+
+	uint16_t reserved2;
+};
+
+struct ena_admin_feature_rss_hash_control {
+	struct ena_admin_proto_input supported_fields[ENA_ADMIN_RSS_PROTO_NUM];
+
+	struct ena_admin_proto_input selected_fields[ENA_ADMIN_RSS_PROTO_NUM];
+
+	struct ena_admin_proto_input reserved2[ENA_ADMIN_RSS_PROTO_NUM];
+
+	struct ena_admin_proto_input reserved3[ENA_ADMIN_RSS_PROTO_NUM];
+};
+
+struct ena_admin_feature_rss_flow_hash_input {
+	/* supported hash input sorting
+	 * 1 : L3_sort - support swap L3 addresses if DA is
+	 *    smaller than SA
+	 * 2 : L4_sort - support swap L4 ports if DP smaller
+	 *    SP
+	 */
+	uint16_t supported_input_sort;
+
+	/* enabled hash input sorting
+	 * 1 : enable_L3_sort - enable swap L3 addresses if
+	 *    DA smaller than SA
+	 * 2 : enable_L4_sort - enable swap L4 ports if DP
+	 *    smaller than SP
+	 */
+	uint16_t enabled_input_sort;
+};
+
+enum ena_admin_os_type {
+	ENA_ADMIN_OS_LINUX                          = 1,
+	ENA_ADMIN_OS_WIN                            = 2,
+	ENA_ADMIN_OS_DPDK                           = 3,
+	ENA_ADMIN_OS_FREEBSD                        = 4,
+	ENA_ADMIN_OS_IPXE                           = 5,
+	ENA_ADMIN_OS_ESXI                           = 6,
+	ENA_ADMIN_OS_MACOS                          = 7,
+	ENA_ADMIN_OS_GROUPS_NUM                     = 7,
+};
+
+struct ena_admin_host_info {
+	/* defined in enum ena_admin_os_type */
+	uint32_t os_type;
+
+	/* os distribution string format */
+	uint8_t os_dist_str[128];
+
+	/* OS distribution numeric format */
+	uint32_t os_dist;
+
+	/* kernel version string format */
+	uint8_t kernel_ver_str[32];
+
+	/* Kernel version numeric format */
+	uint32_t kernel_ver;
+
+	/* 7:0 : major
+	 * 15:8 : minor
+	 * 23:16 : sub_minor
+	 * 31:24 : module_type
+	 */
+	uint32_t driver_version;
+
+	/* features bitmap */
+	uint32_t supported_network_features[2];
+
+	/* ENA spec version of driver */
+	uint16_t ena_spec_version;
+
+	/* ENA device's Bus, Device and Function
+	 * 2:0 : function
+	 * 7:3 : device
+	 * 15:8 : bus
+	 */
+	uint16_t bdf;
+
+	/* Number of CPUs */
+	uint16_t num_cpus;
+
+	uint16_t reserved;
+
+	/* 0 : reserved
+	 * 1 : rx_offset
+	 * 2 : interrupt_moderation
+	 * 3 : rx_buf_mirroring
+	 * 4 : rss_configurable_function_key
+	 * 31:5 : reserved
+	 */
+	uint32_t driver_supported_features;
+};
+
+struct ena_admin_rss_ind_table_entry {
+	uint16_t cq_idx;
+
+	uint16_t reserved;
+};
+
+struct ena_admin_feature_rss_ind_table {
+	/* min supported table size (2^min_size) */
+	uint16_t min_size;
+
+	/* max supported table size (2^max_size) */
+	uint16_t max_size;
+
+	/* table size (2^size) */
+	uint16_t size;
+
+	/* 0 : one_entry_update - The ENA device supports
+	 *    setting a single RSS table entry
+	 */
+	uint8_t flags;
+
+	uint8_t reserved;
+
+	/* index of the inline entry. 0xFFFFFFFF means invalid */
+	uint32_t inline_index;
+
+	/* used for updating single entry, ignored when setting the entire
+	 * table through the control buffer.
+	 */
+	struct ena_admin_rss_ind_table_entry inline_entry;
+};
+
+/* When hint value is 0, driver should use it's own predefined value */
+struct ena_admin_ena_hw_hints {
+	/* value in ms */
+	uint16_t mmio_read_timeout;
+
+	/* value in ms */
+	uint16_t driver_watchdog_timeout;
+
+	/* Per packet tx completion timeout. value in ms */
+	uint16_t missing_tx_completion_timeout;
+
+	uint16_t missed_tx_completion_count_threshold_to_reset;
+
+	/* value in ms */
+	uint16_t admin_completion_tx_timeout;
+
+	uint16_t netdev_wd_timeout;
+
+	uint16_t max_tx_sgl_size;
+
+	uint16_t max_rx_sgl_size;
+
+	uint16_t reserved[8];
+};
+
+struct ena_admin_get_feat_cmd {
+	struct ena_admin_aq_common_desc aq_common_descriptor;
+
+	struct ena_admin_ctrl_buff_info control_buffer;
+
+	struct ena_admin_get_set_feature_common_desc feat_common;
+
+	uint32_t raw[11];
+};
+
+struct ena_admin_queue_ext_feature_desc {
+	/* version */
+	uint8_t version;
+
+	uint8_t reserved1[3];
+
+	union {
+		struct ena_admin_queue_ext_feature_fields max_queue_ext;
+
+		uint32_t raw[10];
+	};
+};
+
+struct ena_admin_get_feat_resp {
+	struct ena_admin_acq_common_desc acq_common_desc;
+
+	union {
+		uint32_t raw[14];
+
+		struct ena_admin_device_attr_feature_desc dev_attr;
+
+		struct ena_admin_feature_llq_desc llq;
+
+		struct ena_admin_queue_feature_desc max_queue;
+
+		struct ena_admin_queue_ext_feature_desc max_queue_ext;
+
+		struct ena_admin_feature_aenq_desc aenq;
+
+		struct ena_admin_get_feature_link_desc link;
+
+		struct ena_admin_feature_offload_desc offload;
+
+		struct ena_admin_feature_rss_flow_hash_function flow_hash_func;
+
+		struct ena_admin_feature_rss_flow_hash_input flow_hash_input;
+
+		struct ena_admin_feature_rss_ind_table ind_table;
+
+		struct ena_admin_feature_intr_moder_desc intr_moderation;
+
+		struct ena_admin_ena_hw_hints hw_hints;
+
+		struct ena_admin_get_extra_properties_strings_desc extra_properties_strings;
+
+		struct ena_admin_get_extra_properties_flags_desc extra_properties_flags;
+	} u;
+};
+
+struct ena_admin_set_feat_cmd {
+	struct ena_admin_aq_common_desc aq_common_descriptor;
+
+	struct ena_admin_ctrl_buff_info control_buffer;
+
+	struct ena_admin_get_set_feature_common_desc feat_common;
+
+	union {
+		uint32_t raw[11];
+
+		/* mtu size */
+		struct ena_admin_set_feature_mtu_desc mtu;
+
+		/* host attributes */
+		struct ena_admin_set_feature_host_attr_desc host_attr;
+
+		/* AENQ configuration */
+		struct ena_admin_feature_aenq_desc aenq;
+
+		/* rss flow hash function */
+		struct ena_admin_feature_rss_flow_hash_function flow_hash_func;
+
+		/* rss flow hash input */
+		struct ena_admin_feature_rss_flow_hash_input flow_hash_input;
+
+		/* rss indirection table */
+		struct ena_admin_feature_rss_ind_table ind_table;
+
+		/* LLQ configuration */
+		struct ena_admin_feature_llq_desc llq;
+	} u;
+};
+
+struct ena_admin_set_feat_resp {
+	struct ena_admin_acq_common_desc acq_common_desc;
+
+	union {
+		uint32_t raw[14];
+	} u;
+};
+
+struct ena_admin_aenq_common_desc {
+	uint16_t group;
+
+	uint16_t syndrome;
+
+	/* 0 : phase
+	 * 7:1 : reserved - MBZ
+	 */
+	uint8_t flags;
+
+	uint8_t reserved1[3];
+
+	uint32_t timestamp_low;
+
+	uint32_t timestamp_high;
+};
+
+/* asynchronous event notification groups */
+enum ena_admin_aenq_group {
+	ENA_ADMIN_LINK_CHANGE                       = 0,
+	ENA_ADMIN_FATAL_ERROR                       = 1,
+	ENA_ADMIN_WARNING                           = 2,
+	ENA_ADMIN_NOTIFICATION                      = 3,
+	ENA_ADMIN_KEEP_ALIVE                        = 4,
+	ENA_ADMIN_AENQ_GROUPS_NUM                   = 5,
+};
+
+enum ena_admin_aenq_notification_syndrome {
+	ENA_ADMIN_SUSPEND                           = 0,
+	ENA_ADMIN_RESUME                            = 1,
+	ENA_ADMIN_UPDATE_HINTS                      = 2,
+};
+
+struct ena_admin_aenq_entry {
+	struct ena_admin_aenq_common_desc aenq_common_desc;
+
+	/* command specific inline data */
+	uint32_t inline_data_w4[12];
+};
+
+struct ena_admin_aenq_link_change_desc {
+	struct ena_admin_aenq_common_desc aenq_common_desc;
+
+	/* 0 : link_status */
+	uint32_t flags;
+};
+
+struct ena_admin_aenq_keep_alive_desc {
+	struct ena_admin_aenq_common_desc aenq_common_desc;
+
+	uint32_t rx_drops_low;
+
+	uint32_t rx_drops_high;
+
+	uint32_t tx_drops_low;
+
+	uint32_t tx_drops_high;
+};
+
+struct ena_admin_ena_mmio_req_read_less_resp {
+	uint16_t req_id;
+
+	uint16_t reg_off;
+
+	/* value is valid when poll is cleared */
+	uint32_t reg_val;
+};
+
+/* aq_common_desc */
+#define ENA_ADMIN_AQ_COMMON_DESC_COMMAND_ID_MASK            GENMASK(11, 0)
+#define ENA_ADMIN_AQ_COMMON_DESC_PHASE_MASK                 BIT(0)
+#define ENA_ADMIN_AQ_COMMON_DESC_CTRL_DATA_SHIFT            1
+#define ENA_ADMIN_AQ_COMMON_DESC_CTRL_DATA_MASK             BIT(1)
+#define ENA_ADMIN_AQ_COMMON_DESC_CTRL_DATA_INDIRECT_SHIFT   2
+#define ENA_ADMIN_AQ_COMMON_DESC_CTRL_DATA_INDIRECT_MASK    BIT(2)
+
+/* sq */
+#define ENA_ADMIN_SQ_SQ_DIRECTION_SHIFT                     5
+#define ENA_ADMIN_SQ_SQ_DIRECTION_MASK                      GENMASK(7, 5)
+
+/* acq_common_desc */
+#define ENA_ADMIN_ACQ_COMMON_DESC_COMMAND_ID_MASK           GENMASK(11, 0)
+#define ENA_ADMIN_ACQ_COMMON_DESC_PHASE_MASK                BIT(0)
+
+/* aq_create_sq_cmd */
+#define ENA_ADMIN_AQ_CREATE_SQ_CMD_SQ_DIRECTION_SHIFT       5
+#define ENA_ADMIN_AQ_CREATE_SQ_CMD_SQ_DIRECTION_MASK        GENMASK(7, 5)
+#define ENA_ADMIN_AQ_CREATE_SQ_CMD_PLACEMENT_POLICY_MASK    GENMASK(3, 0)
+#define ENA_ADMIN_AQ_CREATE_SQ_CMD_COMPLETION_POLICY_SHIFT  4
+#define ENA_ADMIN_AQ_CREATE_SQ_CMD_COMPLETION_POLICY_MASK   GENMASK(6, 4)
+#define ENA_ADMIN_AQ_CREATE_SQ_CMD_IS_PHYSICALLY_CONTIGUOUS_MASK BIT(0)
+
+/* aq_create_cq_cmd */
+#define ENA_ADMIN_AQ_CREATE_CQ_CMD_INTERRUPT_MODE_ENABLED_SHIFT 5
+#define ENA_ADMIN_AQ_CREATE_CQ_CMD_INTERRUPT_MODE_ENABLED_MASK BIT(5)
+#define ENA_ADMIN_AQ_CREATE_CQ_CMD_CQ_ENTRY_SIZE_WORDS_MASK GENMASK(4, 0)
+
+/* get_set_feature_common_desc */
+#define ENA_ADMIN_GET_SET_FEATURE_COMMON_DESC_SELECT_MASK   GENMASK(1, 0)
+
+/* get_feature_link_desc */
+#define ENA_ADMIN_GET_FEATURE_LINK_DESC_AUTONEG_MASK        BIT(0)
+#define ENA_ADMIN_GET_FEATURE_LINK_DESC_DUPLEX_SHIFT        1
+#define ENA_ADMIN_GET_FEATURE_LINK_DESC_DUPLEX_MASK         BIT(1)
+
+/* feature_offload_desc */
+#define ENA_ADMIN_FEATURE_OFFLOAD_DESC_TX_L3_CSUM_IPV4_MASK BIT(0)
+#define ENA_ADMIN_FEATURE_OFFLOAD_DESC_TX_L4_IPV4_CSUM_PART_SHIFT 1
+#define ENA_ADMIN_FEATURE_OFFLOAD_DESC_TX_L4_IPV4_CSUM_PART_MASK BIT(1)
+#define ENA_ADMIN_FEATURE_OFFLOAD_DESC_TX_L4_IPV4_CSUM_FULL_SHIFT 2
+#define ENA_ADMIN_FEATURE_OFFLOAD_DESC_TX_L4_IPV4_CSUM_FULL_MASK BIT(2)
+#define ENA_ADMIN_FEATURE_OFFLOAD_DESC_TX_L4_IPV6_CSUM_PART_SHIFT 3
+#define ENA_ADMIN_FEATURE_OFFLOAD_DESC_TX_L4_IPV6_CSUM_PART_MASK BIT(3)
+#define ENA_ADMIN_FEATURE_OFFLOAD_DESC_TX_L4_IPV6_CSUM_FULL_SHIFT 4
+#define ENA_ADMIN_FEATURE_OFFLOAD_DESC_TX_L4_IPV6_CSUM_FULL_MASK BIT(4)
+#define ENA_ADMIN_FEATURE_OFFLOAD_DESC_TSO_IPV4_SHIFT       5
+#define ENA_ADMIN_FEATURE_OFFLOAD_DESC_TSO_IPV4_MASK        BIT(5)
+#define ENA_ADMIN_FEATURE_OFFLOAD_DESC_TSO_IPV6_SHIFT       6
+#define ENA_ADMIN_FEATURE_OFFLOAD_DESC_TSO_IPV6_MASK        BIT(6)
+#define ENA_ADMIN_FEATURE_OFFLOAD_DESC_TSO_ECN_SHIFT        7
+#define ENA_ADMIN_FEATURE_OFFLOAD_DESC_TSO_ECN_MASK         BIT(7)
+#define ENA_ADMIN_FEATURE_OFFLOAD_DESC_RX_L3_CSUM_IPV4_MASK BIT(0)
+#define ENA_ADMIN_FEATURE_OFFLOAD_DESC_RX_L4_IPV4_CSUM_SHIFT 1
+#define ENA_ADMIN_FEATURE_OFFLOAD_DESC_RX_L4_IPV4_CSUM_MASK BIT(1)
+#define ENA_ADMIN_FEATURE_OFFLOAD_DESC_RX_L4_IPV6_CSUM_SHIFT 2
+#define ENA_ADMIN_FEATURE_OFFLOAD_DESC_RX_L4_IPV6_CSUM_MASK BIT(2)
+#define ENA_ADMIN_FEATURE_OFFLOAD_DESC_RX_HASH_SHIFT        3
+#define ENA_ADMIN_FEATURE_OFFLOAD_DESC_RX_HASH_MASK         BIT(3)
+
+/* feature_rss_flow_hash_function */
+#define ENA_ADMIN_FEATURE_RSS_FLOW_HASH_FUNCTION_FUNCS_MASK GENMASK(7, 0)
+#define ENA_ADMIN_FEATURE_RSS_FLOW_HASH_FUNCTION_SELECTED_FUNC_MASK GENMASK(7, 0)
+
+/* feature_rss_flow_hash_input */
+#define ENA_ADMIN_FEATURE_RSS_FLOW_HASH_INPUT_L3_SORT_SHIFT 1
+#define ENA_ADMIN_FEATURE_RSS_FLOW_HASH_INPUT_L3_SORT_MASK  BIT(1)
+#define ENA_ADMIN_FEATURE_RSS_FLOW_HASH_INPUT_L4_SORT_SHIFT 2
+#define ENA_ADMIN_FEATURE_RSS_FLOW_HASH_INPUT_L4_SORT_MASK  BIT(2)
+#define ENA_ADMIN_FEATURE_RSS_FLOW_HASH_INPUT_ENABLE_L3_SORT_SHIFT 1
+#define ENA_ADMIN_FEATURE_RSS_FLOW_HASH_INPUT_ENABLE_L3_SORT_MASK BIT(1)
+#define ENA_ADMIN_FEATURE_RSS_FLOW_HASH_INPUT_ENABLE_L4_SORT_SHIFT 2
+#define ENA_ADMIN_FEATURE_RSS_FLOW_HASH_INPUT_ENABLE_L4_SORT_MASK BIT(2)
+
+/* host_info */
+#define ENA_ADMIN_HOST_INFO_MAJOR_MASK                      GENMASK(7, 0)
+#define ENA_ADMIN_HOST_INFO_MINOR_SHIFT                     8
+#define ENA_ADMIN_HOST_INFO_MINOR_MASK                      GENMASK(15, 8)
+#define ENA_ADMIN_HOST_INFO_SUB_MINOR_SHIFT                 16
+#define ENA_ADMIN_HOST_INFO_SUB_MINOR_MASK                  GENMASK(23, 16)
+#define ENA_ADMIN_HOST_INFO_MODULE_TYPE_SHIFT               24
+#define ENA_ADMIN_HOST_INFO_MODULE_TYPE_MASK                GENMASK(31, 24)
+#define ENA_ADMIN_HOST_INFO_FUNCTION_MASK                   GENMASK(2, 0)
+#define ENA_ADMIN_HOST_INFO_DEVICE_SHIFT                    3
+#define ENA_ADMIN_HOST_INFO_DEVICE_MASK                     GENMASK(7, 3)
+#define ENA_ADMIN_HOST_INFO_BUS_SHIFT                       8
+#define ENA_ADMIN_HOST_INFO_BUS_MASK                        GENMASK(15, 8)
+#define ENA_ADMIN_HOST_INFO_RX_OFFSET_SHIFT                 1
+#define ENA_ADMIN_HOST_INFO_RX_OFFSET_MASK                  BIT(1)
+#define ENA_ADMIN_HOST_INFO_INTERRUPT_MODERATION_SHIFT      2
+#define ENA_ADMIN_HOST_INFO_INTERRUPT_MODERATION_MASK       BIT(2)
+#define ENA_ADMIN_HOST_INFO_RX_BUF_MIRRORING_SHIFT          3
+#define ENA_ADMIN_HOST_INFO_RX_BUF_MIRRORING_MASK           BIT(3)
+#define ENA_ADMIN_HOST_INFO_RSS_CONFIGURABLE_FUNCTION_KEY_SHIFT 4
+#define ENA_ADMIN_HOST_INFO_RSS_CONFIGURABLE_FUNCTION_KEY_MASK BIT(4)
+
+/* feature_rss_ind_table */
+#define ENA_ADMIN_FEATURE_RSS_IND_TABLE_ONE_ENTRY_UPDATE_MASK BIT(0)
+
+/* aenq_common_desc */
+#define ENA_ADMIN_AENQ_COMMON_DESC_PHASE_MASK               BIT(0)
+
+/* aenq_link_change_desc */
+#define ENA_ADMIN_AENQ_LINK_CHANGE_DESC_LINK_STATUS_MASK    BIT(0)
+
+#if !defined(DEFS_LINUX_MAINLINE)
+static inline uint16_t get_ena_admin_aq_common_desc_command_id(const struct ena_admin_aq_common_desc *p)
+{
+	return p->command_id & ENA_ADMIN_AQ_COMMON_DESC_COMMAND_ID_MASK;
+}
+
+static inline void set_ena_admin_aq_common_desc_command_id(struct ena_admin_aq_common_desc *p, uint16_t val)
+{
+	p->command_id |= val & ENA_ADMIN_AQ_COMMON_DESC_COMMAND_ID_MASK;
+}
+
+static inline uint8_t get_ena_admin_aq_common_desc_phase(const struct ena_admin_aq_common_desc *p)
+{
+	return p->flags & ENA_ADMIN_AQ_COMMON_DESC_PHASE_MASK;
+}
+
+static inline void set_ena_admin_aq_common_desc_phase(struct ena_admin_aq_common_desc *p, uint8_t val)
+{
+	p->flags |= val & ENA_ADMIN_AQ_COMMON_DESC_PHASE_MASK;
+}
+
+static inline uint8_t get_ena_admin_aq_common_desc_ctrl_data(const struct ena_admin_aq_common_desc *p)
+{
+	return (p->flags & ENA_ADMIN_AQ_COMMON_DESC_CTRL_DATA_MASK) >> ENA_ADMIN_AQ_COMMON_DESC_CTRL_DATA_SHIFT;
+}
+
+static inline void set_ena_admin_aq_common_desc_ctrl_data(struct ena_admin_aq_common_desc *p, uint8_t val)
+{
+	p->flags |= (val << ENA_ADMIN_AQ_COMMON_DESC_CTRL_DATA_SHIFT) & ENA_ADMIN_AQ_COMMON_DESC_CTRL_DATA_MASK;
+}
+
+static inline uint8_t get_ena_admin_aq_common_desc_ctrl_data_indirect(const struct ena_admin_aq_common_desc *p)
+{
+	return (p->flags & ENA_ADMIN_AQ_COMMON_DESC_CTRL_DATA_INDIRECT_MASK) >> ENA_ADMIN_AQ_COMMON_DESC_CTRL_DATA_INDIRECT_SHIFT;
+}
+
+static inline void set_ena_admin_aq_common_desc_ctrl_data_indirect(struct ena_admin_aq_common_desc *p, uint8_t val)
+{
+	p->flags |= (val << ENA_ADMIN_AQ_COMMON_DESC_CTRL_DATA_INDIRECT_SHIFT) & ENA_ADMIN_AQ_COMMON_DESC_CTRL_DATA_INDIRECT_MASK;
+}
+
+static inline uint8_t get_ena_admin_sq_sq_direction(const struct ena_admin_sq *p)
+{
+	return (p->sq_identity & ENA_ADMIN_SQ_SQ_DIRECTION_MASK) >> ENA_ADMIN_SQ_SQ_DIRECTION_SHIFT;
+}
+
+static inline void set_ena_admin_sq_sq_direction(struct ena_admin_sq *p, uint8_t val)
+{
+	p->sq_identity |= (val << ENA_ADMIN_SQ_SQ_DIRECTION_SHIFT) & ENA_ADMIN_SQ_SQ_DIRECTION_MASK;
+}
+
+static inline uint16_t get_ena_admin_acq_common_desc_command_id(const struct ena_admin_acq_common_desc *p)
+{
+	return p->command & ENA_ADMIN_ACQ_COMMON_DESC_COMMAND_ID_MASK;
+}
+
+static inline void set_ena_admin_acq_common_desc_command_id(struct ena_admin_acq_common_desc *p, uint16_t val)
+{
+	p->command |= val & ENA_ADMIN_ACQ_COMMON_DESC_COMMAND_ID_MASK;
+}
+
+static inline uint8_t get_ena_admin_acq_common_desc_phase(const struct ena_admin_acq_common_desc *p)
+{
+	return p->flags & ENA_ADMIN_ACQ_COMMON_DESC_PHASE_MASK;
+}
+
+static inline void set_ena_admin_acq_common_desc_phase(struct ena_admin_acq_common_desc *p, uint8_t val)
+{
+	p->flags |= val & ENA_ADMIN_ACQ_COMMON_DESC_PHASE_MASK;
+}
+
+static inline uint8_t get_ena_admin_aq_create_sq_cmd_sq_direction(const struct ena_admin_aq_create_sq_cmd *p)
+{
+	return (p->sq_identity & ENA_ADMIN_AQ_CREATE_SQ_CMD_SQ_DIRECTION_MASK) >> ENA_ADMIN_AQ_CREATE_SQ_CMD_SQ_DIRECTION_SHIFT;
+}
+
+static inline void set_ena_admin_aq_create_sq_cmd_sq_direction(struct ena_admin_aq_create_sq_cmd *p, uint8_t val)
+{
+	p->sq_identity |= (val << ENA_ADMIN_AQ_CREATE_SQ_CMD_SQ_DIRECTION_SHIFT) & ENA_ADMIN_AQ_CREATE_SQ_CMD_SQ_DIRECTION_MASK;
+}
+
+static inline uint8_t get_ena_admin_aq_create_sq_cmd_placement_policy(const struct ena_admin_aq_create_sq_cmd *p)
+{
+	return p->sq_caps_2 & ENA_ADMIN_AQ_CREATE_SQ_CMD_PLACEMENT_POLICY_MASK;
+}
+
+static inline void set_ena_admin_aq_create_sq_cmd_placement_policy(struct ena_admin_aq_create_sq_cmd *p, uint8_t val)
+{
+	p->sq_caps_2 |= val & ENA_ADMIN_AQ_CREATE_SQ_CMD_PLACEMENT_POLICY_MASK;
+}
+
+static inline uint8_t get_ena_admin_aq_create_sq_cmd_completion_policy(const struct ena_admin_aq_create_sq_cmd *p)
+{
+	return (p->sq_caps_2 & ENA_ADMIN_AQ_CREATE_SQ_CMD_COMPLETION_POLICY_MASK) >> ENA_ADMIN_AQ_CREATE_SQ_CMD_COMPLETION_POLICY_SHIFT;
+}
+
+static inline void set_ena_admin_aq_create_sq_cmd_completion_policy(struct ena_admin_aq_create_sq_cmd *p, uint8_t val)
+{
+	p->sq_caps_2 |= (val << ENA_ADMIN_AQ_CREATE_SQ_CMD_COMPLETION_POLICY_SHIFT) & ENA_ADMIN_AQ_CREATE_SQ_CMD_COMPLETION_POLICY_MASK;
+}
+
+static inline uint8_t get_ena_admin_aq_create_sq_cmd_is_physically_contiguous(const struct ena_admin_aq_create_sq_cmd *p)
+{
+	return p->sq_caps_3 & ENA_ADMIN_AQ_CREATE_SQ_CMD_IS_PHYSICALLY_CONTIGUOUS_MASK;
+}
+
+static inline void set_ena_admin_aq_create_sq_cmd_is_physically_contiguous(struct ena_admin_aq_create_sq_cmd *p, uint8_t val)
+{
+	p->sq_caps_3 |= val & ENA_ADMIN_AQ_CREATE_SQ_CMD_IS_PHYSICALLY_CONTIGUOUS_MASK;
+}
+
+static inline uint8_t get_ena_admin_aq_create_cq_cmd_interrupt_mode_enabled(const struct ena_admin_aq_create_cq_cmd *p)
+{
+	return (p->cq_caps_1 & ENA_ADMIN_AQ_CREATE_CQ_CMD_INTERRUPT_MODE_ENABLED_MASK) >> ENA_ADMIN_AQ_CREATE_CQ_CMD_INTERRUPT_MODE_ENABLED_SHIFT;
+}
+
+static inline void set_ena_admin_aq_create_cq_cmd_interrupt_mode_enabled(struct ena_admin_aq_create_cq_cmd *p, uint8_t val)
+{
+	p->cq_caps_1 |= (val << ENA_ADMIN_AQ_CREATE_CQ_CMD_INTERRUPT_MODE_ENABLED_SHIFT) & ENA_ADMIN_AQ_CREATE_CQ_CMD_INTERRUPT_MODE_ENABLED_MASK;
+}
+
+static inline uint8_t get_ena_admin_aq_create_cq_cmd_cq_entry_size_words(const struct ena_admin_aq_create_cq_cmd *p)
+{
+	return p->cq_caps_2 & ENA_ADMIN_AQ_CREATE_CQ_CMD_CQ_ENTRY_SIZE_WORDS_MASK;
+}
+
+static inline void set_ena_admin_aq_create_cq_cmd_cq_entry_size_words(struct ena_admin_aq_create_cq_cmd *p, uint8_t val)
+{
+	p->cq_caps_2 |= val & ENA_ADMIN_AQ_CREATE_CQ_CMD_CQ_ENTRY_SIZE_WORDS_MASK;
+}
+
+static inline uint8_t get_ena_admin_get_set_feature_common_desc_select(const struct ena_admin_get_set_feature_common_desc *p)
+{
+	return p->flags & ENA_ADMIN_GET_SET_FEATURE_COMMON_DESC_SELECT_MASK;
+}
+
+static inline void set_ena_admin_get_set_feature_common_desc_select(struct ena_admin_get_set_feature_common_desc *p, uint8_t val)
+{
+	p->flags |= val & ENA_ADMIN_GET_SET_FEATURE_COMMON_DESC_SELECT_MASK;
+}
+
+static inline uint32_t get_ena_admin_get_feature_link_desc_autoneg(const struct ena_admin_get_feature_link_desc *p)
+{
+	return p->flags & ENA_ADMIN_GET_FEATURE_LINK_DESC_AUTONEG_MASK;
+}
+
+static inline void set_ena_admin_get_feature_link_desc_autoneg(struct ena_admin_get_feature_link_desc *p, uint32_t val)
+{
+	p->flags |= val & ENA_ADMIN_GET_FEATURE_LINK_DESC_AUTONEG_MASK;
+}
+
+static inline uint32_t get_ena_admin_get_feature_link_desc_duplex(const struct ena_admin_get_feature_link_desc *p)
+{
+	return (p->flags & ENA_ADMIN_GET_FEATURE_LINK_DESC_DUPLEX_MASK) >> ENA_ADMIN_GET_FEATURE_LINK_DESC_DUPLEX_SHIFT;
+}
+
+static inline void set_ena_admin_get_feature_link_desc_duplex(struct ena_admin_get_feature_link_desc *p, uint32_t val)
+{
+	p->flags |= (val << ENA_ADMIN_GET_FEATURE_LINK_DESC_DUPLEX_SHIFT) & ENA_ADMIN_GET_FEATURE_LINK_DESC_DUPLEX_MASK;
+}
+
+static inline uint32_t get_ena_admin_feature_offload_desc_TX_L3_csum_ipv4(const struct ena_admin_feature_offload_desc *p)
+{
+	return p->tx & ENA_ADMIN_FEATURE_OFFLOAD_DESC_TX_L3_CSUM_IPV4_MASK;
+}
+
+static inline void set_ena_admin_feature_offload_desc_TX_L3_csum_ipv4(struct ena_admin_feature_offload_desc *p, uint32_t val)
+{
+	p->tx |= val & ENA_ADMIN_FEATURE_OFFLOAD_DESC_TX_L3_CSUM_IPV4_MASK;
+}
+
+static inline uint32_t get_ena_admin_feature_offload_desc_TX_L4_ipv4_csum_part(const struct ena_admin_feature_offload_desc *p)
+{
+	return (p->tx & ENA_ADMIN_FEATURE_OFFLOAD_DESC_TX_L4_IPV4_CSUM_PART_MASK) >> ENA_ADMIN_FEATURE_OFFLOAD_DESC_TX_L4_IPV4_CSUM_PART_SHIFT;
+}
+
+static inline void set_ena_admin_feature_offload_desc_TX_L4_ipv4_csum_part(struct ena_admin_feature_offload_desc *p, uint32_t val)
+{
+	p->tx |= (val << ENA_ADMIN_FEATURE_OFFLOAD_DESC_TX_L4_IPV4_CSUM_PART_SHIFT) & ENA_ADMIN_FEATURE_OFFLOAD_DESC_TX_L4_IPV4_CSUM_PART_MASK;
+}
+
+static inline uint32_t get_ena_admin_feature_offload_desc_TX_L4_ipv4_csum_full(const struct ena_admin_feature_offload_desc *p)
+{
+	return (p->tx & ENA_ADMIN_FEATURE_OFFLOAD_DESC_TX_L4_IPV4_CSUM_FULL_MASK) >> ENA_ADMIN_FEATURE_OFFLOAD_DESC_TX_L4_IPV4_CSUM_FULL_SHIFT;
+}
+
+static inline void set_ena_admin_feature_offload_desc_TX_L4_ipv4_csum_full(struct ena_admin_feature_offload_desc *p, uint32_t val)
+{
+	p->tx |= (val << ENA_ADMIN_FEATURE_OFFLOAD_DESC_TX_L4_IPV4_CSUM_FULL_SHIFT) & ENA_ADMIN_FEATURE_OFFLOAD_DESC_TX_L4_IPV4_CSUM_FULL_MASK;
+}
+
+static inline uint32_t get_ena_admin_feature_offload_desc_TX_L4_ipv6_csum_part(const struct ena_admin_feature_offload_desc *p)
+{
+	return (p->tx & ENA_ADMIN_FEATURE_OFFLOAD_DESC_TX_L4_IPV6_CSUM_PART_MASK) >> ENA_ADMIN_FEATURE_OFFLOAD_DESC_TX_L4_IPV6_CSUM_PART_SHIFT;
+}
+
+static inline void set_ena_admin_feature_offload_desc_TX_L4_ipv6_csum_part(struct ena_admin_feature_offload_desc *p, uint32_t val)
+{
+	p->tx |= (val << ENA_ADMIN_FEATURE_OFFLOAD_DESC_TX_L4_IPV6_CSUM_PART_SHIFT) & ENA_ADMIN_FEATURE_OFFLOAD_DESC_TX_L4_IPV6_CSUM_PART_MASK;
+}
+
+static inline uint32_t get_ena_admin_feature_offload_desc_TX_L4_ipv6_csum_full(const struct ena_admin_feature_offload_desc *p)
+{
+	return (p->tx & ENA_ADMIN_FEATURE_OFFLOAD_DESC_TX_L4_IPV6_CSUM_FULL_MASK) >> ENA_ADMIN_FEATURE_OFFLOAD_DESC_TX_L4_IPV6_CSUM_FULL_SHIFT;
+}
+
+static inline void set_ena_admin_feature_offload_desc_TX_L4_ipv6_csum_full(struct ena_admin_feature_offload_desc *p, uint32_t val)
+{
+	p->tx |= (val << ENA_ADMIN_FEATURE_OFFLOAD_DESC_TX_L4_IPV6_CSUM_FULL_SHIFT) & ENA_ADMIN_FEATURE_OFFLOAD_DESC_TX_L4_IPV6_CSUM_FULL_MASK;
+}
+
+static inline uint32_t get_ena_admin_feature_offload_desc_tso_ipv4(const struct ena_admin_feature_offload_desc *p)
+{
+	return (p->tx & ENA_ADMIN_FEATURE_OFFLOAD_DESC_TSO_IPV4_MASK) >> ENA_ADMIN_FEATURE_OFFLOAD_DESC_TSO_IPV4_SHIFT;
+}
+
+static inline void set_ena_admin_feature_offload_desc_tso_ipv4(struct ena_admin_feature_offload_desc *p, uint32_t val)
+{
+	p->tx |= (val << ENA_ADMIN_FEATURE_OFFLOAD_DESC_TSO_IPV4_SHIFT) & ENA_ADMIN_FEATURE_OFFLOAD_DESC_TSO_IPV4_MASK;
+}
+
+static inline uint32_t get_ena_admin_feature_offload_desc_tso_ipv6(const struct ena_admin_feature_offload_desc *p)
+{
+	return (p->tx & ENA_ADMIN_FEATURE_OFFLOAD_DESC_TSO_IPV6_MASK) >> ENA_ADMIN_FEATURE_OFFLOAD_DESC_TSO_IPV6_SHIFT;
+}
+
+static inline void set_ena_admin_feature_offload_desc_tso_ipv6(struct ena_admin_feature_offload_desc *p, uint32_t val)
+{
+	p->tx |= (val << ENA_ADMIN_FEATURE_OFFLOAD_DESC_TSO_IPV6_SHIFT) & ENA_ADMIN_FEATURE_OFFLOAD_DESC_TSO_IPV6_MASK;
+}
+
+static inline uint32_t get_ena_admin_feature_offload_desc_tso_ecn(const struct ena_admin_feature_offload_desc *p)
+{
+	return (p->tx & ENA_ADMIN_FEATURE_OFFLOAD_DESC_TSO_ECN_MASK) >> ENA_ADMIN_FEATURE_OFFLOAD_DESC_TSO_ECN_SHIFT;
+}
+
+static inline void set_ena_admin_feature_offload_desc_tso_ecn(struct ena_admin_feature_offload_desc *p, uint32_t val)
+{
+	p->tx |= (val << ENA_ADMIN_FEATURE_OFFLOAD_DESC_TSO_ECN_SHIFT) & ENA_ADMIN_FEATURE_OFFLOAD_DESC_TSO_ECN_MASK;
+}
+
+static inline uint32_t get_ena_admin_feature_offload_desc_RX_L3_csum_ipv4(const struct ena_admin_feature_offload_desc *p)
+{
+	return p->rx_supported & ENA_ADMIN_FEATURE_OFFLOAD_DESC_RX_L3_CSUM_IPV4_MASK;
+}
+
+static inline void set_ena_admin_feature_offload_desc_RX_L3_csum_ipv4(struct ena_admin_feature_offload_desc *p, uint32_t val)
+{
+	p->rx_supported |= val & ENA_ADMIN_FEATURE_OFFLOAD_DESC_RX_L3_CSUM_IPV4_MASK;
+}
+
+static inline uint32_t get_ena_admin_feature_offload_desc_RX_L4_ipv4_csum(const struct ena_admin_feature_offload_desc *p)
+{
+	return (p->rx_supported & ENA_ADMIN_FEATURE_OFFLOAD_DESC_RX_L4_IPV4_CSUM_MASK) >> ENA_ADMIN_FEATURE_OFFLOAD_DESC_RX_L4_IPV4_CSUM_SHIFT;
+}
+
+static inline void set_ena_admin_feature_offload_desc_RX_L4_ipv4_csum(struct ena_admin_feature_offload_desc *p, uint32_t val)
+{
+	p->rx_supported |= (val << ENA_ADMIN_FEATURE_OFFLOAD_DESC_RX_L4_IPV4_CSUM_SHIFT) & ENA_ADMIN_FEATURE_OFFLOAD_DESC_RX_L4_IPV4_CSUM_MASK;
+}
+
+static inline uint32_t get_ena_admin_feature_offload_desc_RX_L4_ipv6_csum(const struct ena_admin_feature_offload_desc *p)
+{
+	return (p->rx_supported & ENA_ADMIN_FEATURE_OFFLOAD_DESC_RX_L4_IPV6_CSUM_MASK) >> ENA_ADMIN_FEATURE_OFFLOAD_DESC_RX_L4_IPV6_CSUM_SHIFT;
+}
+
+static inline void set_ena_admin_feature_offload_desc_RX_L4_ipv6_csum(struct ena_admin_feature_offload_desc *p, uint32_t val)
+{
+	p->rx_supported |= (val << ENA_ADMIN_FEATURE_OFFLOAD_DESC_RX_L4_IPV6_CSUM_SHIFT) & ENA_ADMIN_FEATURE_OFFLOAD_DESC_RX_L4_IPV6_CSUM_MASK;
+}
+
+static inline uint32_t get_ena_admin_feature_offload_desc_RX_hash(const struct ena_admin_feature_offload_desc *p)
+{
+	return (p->rx_supported & ENA_ADMIN_FEATURE_OFFLOAD_DESC_RX_HASH_MASK) >> ENA_ADMIN_FEATURE_OFFLOAD_DESC_RX_HASH_SHIFT;
+}
+
+static inline void set_ena_admin_feature_offload_desc_RX_hash(struct ena_admin_feature_offload_desc *p, uint32_t val)
+{
+	p->rx_supported |= (val << ENA_ADMIN_FEATURE_OFFLOAD_DESC_RX_HASH_SHIFT) & ENA_ADMIN_FEATURE_OFFLOAD_DESC_RX_HASH_MASK;
+}
+
+static inline uint32_t get_ena_admin_feature_rss_flow_hash_function_funcs(const struct ena_admin_feature_rss_flow_hash_function *p)
+{
+	return p->supported_func & ENA_ADMIN_FEATURE_RSS_FLOW_HASH_FUNCTION_FUNCS_MASK;
+}
+
+static inline void set_ena_admin_feature_rss_flow_hash_function_funcs(struct ena_admin_feature_rss_flow_hash_function *p, uint32_t val)
+{
+	p->supported_func |= val & ENA_ADMIN_FEATURE_RSS_FLOW_HASH_FUNCTION_FUNCS_MASK;
+}
+
+static inline uint32_t get_ena_admin_feature_rss_flow_hash_function_selected_func(const struct ena_admin_feature_rss_flow_hash_function *p)
+{
+	return p->selected_func & ENA_ADMIN_FEATURE_RSS_FLOW_HASH_FUNCTION_SELECTED_FUNC_MASK;
+}
+
+static inline void set_ena_admin_feature_rss_flow_hash_function_selected_func(struct ena_admin_feature_rss_flow_hash_function *p, uint32_t val)
+{
+	p->selected_func |= val & ENA_ADMIN_FEATURE_RSS_FLOW_HASH_FUNCTION_SELECTED_FUNC_MASK;
+}
+
+static inline uint16_t get_ena_admin_feature_rss_flow_hash_input_L3_sort(const struct ena_admin_feature_rss_flow_hash_input *p)
+{
+	return (p->supported_input_sort & ENA_ADMIN_FEATURE_RSS_FLOW_HASH_INPUT_L3_SORT_MASK) >> ENA_ADMIN_FEATURE_RSS_FLOW_HASH_INPUT_L3_SORT_SHIFT;
+}
+
+static inline void set_ena_admin_feature_rss_flow_hash_input_L3_sort(struct ena_admin_feature_rss_flow_hash_input *p, uint16_t val)
+{
+	p->supported_input_sort |= (val << ENA_ADMIN_FEATURE_RSS_FLOW_HASH_INPUT_L3_SORT_SHIFT) & ENA_ADMIN_FEATURE_RSS_FLOW_HASH_INPUT_L3_SORT_MASK;
+}
+
+static inline uint16_t get_ena_admin_feature_rss_flow_hash_input_L4_sort(const struct ena_admin_feature_rss_flow_hash_input *p)
+{
+	return (p->supported_input_sort & ENA_ADMIN_FEATURE_RSS_FLOW_HASH_INPUT_L4_SORT_MASK) >> ENA_ADMIN_FEATURE_RSS_FLOW_HASH_INPUT_L4_SORT_SHIFT;
+}
+
+static inline void set_ena_admin_feature_rss_flow_hash_input_L4_sort(struct ena_admin_feature_rss_flow_hash_input *p, uint16_t val)
+{
+	p->supported_input_sort |= (val << ENA_ADMIN_FEATURE_RSS_FLOW_HASH_INPUT_L4_SORT_SHIFT) & ENA_ADMIN_FEATURE_RSS_FLOW_HASH_INPUT_L4_SORT_MASK;
+}
+
+static inline uint16_t get_ena_admin_feature_rss_flow_hash_input_enable_L3_sort(const struct ena_admin_feature_rss_flow_hash_input *p)
+{
+	return (p->enabled_input_sort & ENA_ADMIN_FEATURE_RSS_FLOW_HASH_INPUT_ENABLE_L3_SORT_MASK) >> ENA_ADMIN_FEATURE_RSS_FLOW_HASH_INPUT_ENABLE_L3_SORT_SHIFT;
+}
+
+static inline void set_ena_admin_feature_rss_flow_hash_input_enable_L3_sort(struct ena_admin_feature_rss_flow_hash_input *p, uint16_t val)
+{
+	p->enabled_input_sort |= (val << ENA_ADMIN_FEATURE_RSS_FLOW_HASH_INPUT_ENABLE_L3_SORT_SHIFT) & ENA_ADMIN_FEATURE_RSS_FLOW_HASH_INPUT_ENABLE_L3_SORT_MASK;
+}
+
+static inline uint16_t get_ena_admin_feature_rss_flow_hash_input_enable_L4_sort(const struct ena_admin_feature_rss_flow_hash_input *p)
+{
+	return (p->enabled_input_sort & ENA_ADMIN_FEATURE_RSS_FLOW_HASH_INPUT_ENABLE_L4_SORT_MASK) >> ENA_ADMIN_FEATURE_RSS_FLOW_HASH_INPUT_ENABLE_L4_SORT_SHIFT;
+}
+
+static inline void set_ena_admin_feature_rss_flow_hash_input_enable_L4_sort(struct ena_admin_feature_rss_flow_hash_input *p, uint16_t val)
+{
+	p->enabled_input_sort |= (val << ENA_ADMIN_FEATURE_RSS_FLOW_HASH_INPUT_ENABLE_L4_SORT_SHIFT) & ENA_ADMIN_FEATURE_RSS_FLOW_HASH_INPUT_ENABLE_L4_SORT_MASK;
+}
+
+static inline uint32_t get_ena_admin_host_info_major(const struct ena_admin_host_info *p)
+{
+	return p->driver_version & ENA_ADMIN_HOST_INFO_MAJOR_MASK;
+}
+
+static inline void set_ena_admin_host_info_major(struct ena_admin_host_info *p, uint32_t val)
+{
+	p->driver_version |= val & ENA_ADMIN_HOST_INFO_MAJOR_MASK;
+}
+
+static inline uint32_t get_ena_admin_host_info_minor(const struct ena_admin_host_info *p)
+{
+	return (p->driver_version & ENA_ADMIN_HOST_INFO_MINOR_MASK) >> ENA_ADMIN_HOST_INFO_MINOR_SHIFT;
+}
+
+static inline void set_ena_admin_host_info_minor(struct ena_admin_host_info *p, uint32_t val)
+{
+	p->driver_version |= (val << ENA_ADMIN_HOST_INFO_MINOR_SHIFT) & ENA_ADMIN_HOST_INFO_MINOR_MASK;
+}
+
+static inline uint32_t get_ena_admin_host_info_sub_minor(const struct ena_admin_host_info *p)
+{
+	return (p->driver_version & ENA_ADMIN_HOST_INFO_SUB_MINOR_MASK) >> ENA_ADMIN_HOST_INFO_SUB_MINOR_SHIFT;
+}
+
+static inline void set_ena_admin_host_info_sub_minor(struct ena_admin_host_info *p, uint32_t val)
+{
+	p->driver_version |= (val << ENA_ADMIN_HOST_INFO_SUB_MINOR_SHIFT) & ENA_ADMIN_HOST_INFO_SUB_MINOR_MASK;
+}
+
+static inline uint32_t get_ena_admin_host_info_module_type(const struct ena_admin_host_info *p)
+{
+	return (p->driver_version & ENA_ADMIN_HOST_INFO_MODULE_TYPE_MASK) >> ENA_ADMIN_HOST_INFO_MODULE_TYPE_SHIFT;
+}
+
+static inline void set_ena_admin_host_info_module_type(struct ena_admin_host_info *p, uint32_t val)
+{
+	p->driver_version |= (val << ENA_ADMIN_HOST_INFO_MODULE_TYPE_SHIFT) & ENA_ADMIN_HOST_INFO_MODULE_TYPE_MASK;
+}
+
+static inline uint16_t get_ena_admin_host_info_function(const struct ena_admin_host_info *p)
+{
+	return p->bdf & ENA_ADMIN_HOST_INFO_FUNCTION_MASK;
+}
+
+static inline void set_ena_admin_host_info_function(struct ena_admin_host_info *p, uint16_t val)
+{
+	p->bdf |= val & ENA_ADMIN_HOST_INFO_FUNCTION_MASK;
+}
+
+static inline uint16_t get_ena_admin_host_info_device(const struct ena_admin_host_info *p)
+{
+	return (p->bdf & ENA_ADMIN_HOST_INFO_DEVICE_MASK) >> ENA_ADMIN_HOST_INFO_DEVICE_SHIFT;
+}
+
+static inline void set_ena_admin_host_info_device(struct ena_admin_host_info *p, uint16_t val)
+{
+	p->bdf |= (val << ENA_ADMIN_HOST_INFO_DEVICE_SHIFT) & ENA_ADMIN_HOST_INFO_DEVICE_MASK;
+}
+
+static inline uint16_t get_ena_admin_host_info_bus(const struct ena_admin_host_info *p)
+{
+	return (p->bdf & ENA_ADMIN_HOST_INFO_BUS_MASK) >> ENA_ADMIN_HOST_INFO_BUS_SHIFT;
+}
+
+static inline void set_ena_admin_host_info_bus(struct ena_admin_host_info *p, uint16_t val)
+{
+	p->bdf |= (val << ENA_ADMIN_HOST_INFO_BUS_SHIFT) & ENA_ADMIN_HOST_INFO_BUS_MASK;
+}
+
+static inline uint32_t get_ena_admin_host_info_rx_offset(const struct ena_admin_host_info *p)
+{
+	return (p->driver_supported_features & ENA_ADMIN_HOST_INFO_RX_OFFSET_MASK) >> ENA_ADMIN_HOST_INFO_RX_OFFSET_SHIFT;
+}
+
+static inline void set_ena_admin_host_info_rx_offset(struct ena_admin_host_info *p, uint32_t val)
+{
+	p->driver_supported_features |= (val << ENA_ADMIN_HOST_INFO_RX_OFFSET_SHIFT) & ENA_ADMIN_HOST_INFO_RX_OFFSET_MASK;
+}
+
+static inline uint32_t get_ena_admin_host_info_interrupt_moderation(const struct ena_admin_host_info *p)
+{
+	return (p->driver_supported_features & ENA_ADMIN_HOST_INFO_INTERRUPT_MODERATION_MASK) >> ENA_ADMIN_HOST_INFO_INTERRUPT_MODERATION_SHIFT;
+}
+
+static inline void set_ena_admin_host_info_interrupt_moderation(struct ena_admin_host_info *p, uint32_t val)
+{
+	p->driver_supported_features |= (val << ENA_ADMIN_HOST_INFO_INTERRUPT_MODERATION_SHIFT) & ENA_ADMIN_HOST_INFO_INTERRUPT_MODERATION_MASK;
+}
+
+static inline uint32_t get_ena_admin_host_info_rx_buf_mirroring(const struct ena_admin_host_info *p)
+{
+	return (p->driver_supported_features & ENA_ADMIN_HOST_INFO_RX_BUF_MIRRORING_MASK) >> ENA_ADMIN_HOST_INFO_RX_BUF_MIRRORING_SHIFT;
+}
+
+static inline void set_ena_admin_host_info_rx_buf_mirroring(struct ena_admin_host_info *p, uint32_t val)
+{
+	p->driver_supported_features |= (val << ENA_ADMIN_HOST_INFO_RX_BUF_MIRRORING_SHIFT) & ENA_ADMIN_HOST_INFO_RX_BUF_MIRRORING_MASK;
+}
+
+static inline uint32_t get_ena_admin_host_info_rss_configurable_function_key(const struct ena_admin_host_info *p)
+{
+	return (p->driver_supported_features & ENA_ADMIN_HOST_INFO_RSS_CONFIGURABLE_FUNCTION_KEY_MASK) >> ENA_ADMIN_HOST_INFO_RSS_CONFIGURABLE_FUNCTION_KEY_SHIFT;
+}
+
+static inline void set_ena_admin_host_info_rss_configurable_function_key(struct ena_admin_host_info *p, uint32_t val)
+{
+	p->driver_supported_features |= (val << ENA_ADMIN_HOST_INFO_RSS_CONFIGURABLE_FUNCTION_KEY_SHIFT) & ENA_ADMIN_HOST_INFO_RSS_CONFIGURABLE_FUNCTION_KEY_MASK;
+}
+
+static inline uint8_t get_ena_admin_feature_rss_ind_table_one_entry_update(const struct ena_admin_feature_rss_ind_table *p)
+{
+	return p->flags & ENA_ADMIN_FEATURE_RSS_IND_TABLE_ONE_ENTRY_UPDATE_MASK;
+}
+
+static inline void set_ena_admin_feature_rss_ind_table_one_entry_update(struct ena_admin_feature_rss_ind_table *p, uint8_t val)
+{
+	p->flags |= val & ENA_ADMIN_FEATURE_RSS_IND_TABLE_ONE_ENTRY_UPDATE_MASK;
+}
+
+static inline uint8_t get_ena_admin_aenq_common_desc_phase(const struct ena_admin_aenq_common_desc *p)
+{
+	return p->flags & ENA_ADMIN_AENQ_COMMON_DESC_PHASE_MASK;
+}
+
+static inline void set_ena_admin_aenq_common_desc_phase(struct ena_admin_aenq_common_desc *p, uint8_t val)
+{
+	p->flags |= val & ENA_ADMIN_AENQ_COMMON_DESC_PHASE_MASK;
+}
+
+static inline uint32_t get_ena_admin_aenq_link_change_desc_link_status(const struct ena_admin_aenq_link_change_desc *p)
+{
+	return p->flags & ENA_ADMIN_AENQ_LINK_CHANGE_DESC_LINK_STATUS_MASK;
+}
+
+static inline void set_ena_admin_aenq_link_change_desc_link_status(struct ena_admin_aenq_link_change_desc *p, uint32_t val)
+{
+	p->flags |= val & ENA_ADMIN_AENQ_LINK_CHANGE_DESC_LINK_STATUS_MASK;
+}
+
+#endif /* !defined(DEFS_LINUX_MAINLINE) */
+#endif /* _ENA_ADMIN_H_ */

--- a/kernel/macOS/ena/ena_com/ena_defs/ena_common_defs.h
+++ b/kernel/macOS/ena/ena_com/ena_defs/ena_common_defs.h
@@ -1,0 +1,19 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+#ifndef _ENA_COMMON_H_
+#define _ENA_COMMON_H_
+
+#define ENA_COMMON_SPEC_VERSION_MAJOR        2
+#define ENA_COMMON_SPEC_VERSION_MINOR        0
+
+/* ENA operates with 48-bit memory addresses. ena_mem_addr_t */
+struct ena_common_mem_addr {
+	uint32_t mem_addr_low;
+
+	uint16_t mem_addr_high;
+
+	/* MBZ */
+	uint16_t reserved16;
+};
+
+#endif /* _ENA_COMMON_H_ */

--- a/kernel/macOS/ena/ena_com/ena_defs/ena_eth_io_defs.h
+++ b/kernel/macOS/ena/ena_com/ena_defs/ena_eth_io_defs.h
@@ -1,0 +1,940 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+#ifndef _ENA_ETH_IO_H_
+#define _ENA_ETH_IO_H_
+
+enum ena_eth_io_l3_proto_index {
+	ENA_ETH_IO_L3_PROTO_UNKNOWN                 = 0,
+	ENA_ETH_IO_L3_PROTO_IPV4                    = 8,
+	ENA_ETH_IO_L3_PROTO_IPV6                    = 11,
+	ENA_ETH_IO_L3_PROTO_FCOE                    = 21,
+	ENA_ETH_IO_L3_PROTO_ROCE                    = 22,
+};
+
+enum ena_eth_io_l4_proto_index {
+	ENA_ETH_IO_L4_PROTO_UNKNOWN                 = 0,
+	ENA_ETH_IO_L4_PROTO_TCP                     = 12,
+	ENA_ETH_IO_L4_PROTO_UDP                     = 13,
+	ENA_ETH_IO_L4_PROTO_ROUTEABLE_ROCE          = 23,
+};
+
+struct ena_eth_io_tx_desc {
+	/* 15:0 : length - Buffer length in bytes, must
+	 *    include any packet trailers that the ENA supposed
+	 *    to update like End-to-End CRC, Authentication GMAC
+	 *    etc. This length must not include the
+	 *    'Push_Buffer' length. This length must not include
+	 *    the 4-byte added in the end for 802.3 Ethernet FCS
+	 * 21:16 : req_id_hi - Request ID[15:10]
+	 * 22 : reserved22 - MBZ
+	 * 23 : meta_desc - MBZ
+	 * 24 : phase
+	 * 25 : reserved1 - MBZ
+	 * 26 : first - Indicates first descriptor in
+	 *    transaction
+	 * 27 : last - Indicates last descriptor in
+	 *    transaction
+	 * 28 : comp_req - Indicates whether completion
+	 *    should be posted, after packet is transmitted.
+	 *    Valid only for first descriptor
+	 * 30:29 : reserved29 - MBZ
+	 * 31 : reserved31 - MBZ
+	 */
+	uint32_t len_ctrl;
+
+	/* 3:0 : l3_proto_idx - L3 protocol. This field
+	 *    required when l3_csum_en,l3_csum or tso_en are set.
+	 * 4 : DF - IPv4 DF, must be 0 if packet is IPv4 and
+	 *    DF flags of the IPv4 header is 0. Otherwise must
+	 *    be set to 1
+	 * 6:5 : reserved5
+	 * 7 : tso_en - Enable TSO, For TCP only.
+	 * 12:8 : l4_proto_idx - L4 protocol. This field need
+	 *    to be set when l4_csum_en or tso_en are set.
+	 * 13 : l3_csum_en - enable IPv4 header checksum.
+	 * 14 : l4_csum_en - enable TCP/UDP checksum.
+	 * 15 : ethernet_fcs_dis - when set, the controller
+	 *    will not append the 802.3 Ethernet Frame Check
+	 *    Sequence to the packet
+	 * 16 : reserved16
+	 * 17 : l4_csum_partial - L4 partial checksum. when
+	 *    set to 0, the ENA calculates the L4 checksum,
+	 *    where the Destination Address required for the
+	 *    TCP/UDP pseudo-header is taken from the actual
+	 *    packet L3 header. when set to 1, the ENA doesn't
+	 *    calculate the sum of the pseudo-header, instead,
+	 *    the checksum field of the L4 is used instead. When
+	 *    TSO enabled, the checksum of the pseudo-header
+	 *    must not include the tcp length field. L4 partial
+	 *    checksum should be used for IPv6 packet that
+	 *    contains Routing Headers.
+	 * 20:18 : reserved18 - MBZ
+	 * 21 : reserved21 - MBZ
+	 * 31:22 : req_id_lo - Request ID[9:0]
+	 */
+	uint32_t meta_ctrl;
+
+	uint32_t buff_addr_lo;
+
+	/* address high and header size
+	 * 15:0 : addr_hi - Buffer Pointer[47:32]
+	 * 23:16 : reserved16_w2
+	 * 31:24 : header_length - Header length. For Low
+	 *    Latency Queues, this fields indicates the number
+	 *    of bytes written to the headers' memory. For
+	 *    normal queues, if packet is TCP or UDP, and longer
+	 *    than max_header_size, then this field should be
+	 *    set to the sum of L4 header offset and L4 header
+	 *    size(without options), otherwise, this field
+	 *    should be set to 0. For both modes, this field
+	 *    must not exceed the max_header_size.
+	 *    max_header_size value is reported by the Max
+	 *    Queues Feature descriptor
+	 */
+	uint32_t buff_addr_hi_hdr_sz;
+};
+
+struct ena_eth_io_tx_meta_desc {
+	/* 9:0 : req_id_lo - Request ID[9:0]
+	 * 11:10 : reserved10 - MBZ
+	 * 12 : reserved12 - MBZ
+	 * 13 : reserved13 - MBZ
+	 * 14 : ext_valid - if set, offset fields in Word2
+	 *    are valid Also MSS High in Word 0 and bits [31:24]
+	 *    in Word 3
+	 * 15 : reserved15
+	 * 19:16 : mss_hi
+	 * 20 : eth_meta_type - 0: Tx Metadata Descriptor, 1:
+	 *    Extended Metadata Descriptor
+	 * 21 : meta_store - Store extended metadata in queue
+	 *    cache
+	 * 22 : reserved22 - MBZ
+	 * 23 : meta_desc - MBO
+	 * 24 : phase
+	 * 25 : reserved25 - MBZ
+	 * 26 : first - Indicates first descriptor in
+	 *    transaction
+	 * 27 : last - Indicates last descriptor in
+	 *    transaction
+	 * 28 : comp_req - Indicates whether completion
+	 *    should be posted, after packet is transmitted.
+	 *    Valid only for first descriptor
+	 * 30:29 : reserved29 - MBZ
+	 * 31 : reserved31 - MBZ
+	 */
+	uint32_t len_ctrl;
+
+	/* 5:0 : req_id_hi
+	 * 31:6 : reserved6 - MBZ
+	 */
+	uint32_t word1;
+
+	/* 7:0 : l3_hdr_len
+	 * 15:8 : l3_hdr_off
+	 * 21:16 : l4_hdr_len_in_words - counts the L4 header
+	 *    length in words. there is an explicit assumption
+	 *    that L4 header appears right after L3 header and
+	 *    L4 offset is based on l3_hdr_off+l3_hdr_len
+	 * 31:22 : mss_lo
+	 */
+	uint32_t word2;
+
+	uint32_t reserved;
+};
+
+struct ena_eth_io_tx_cdesc {
+	/* Request ID[15:0] */
+	uint16_t req_id;
+
+	uint8_t status;
+
+	/* flags
+	 * 0 : phase
+	 * 7:1 : reserved1
+	 */
+	uint8_t flags;
+
+	uint16_t sub_qid;
+
+	uint16_t sq_head_idx;
+};
+
+struct ena_eth_io_rx_desc {
+	/* In bytes. 0 means 64KB */
+	uint16_t length;
+
+	/* MBZ */
+	uint8_t reserved2;
+
+	/* 0 : phase
+	 * 1 : reserved1 - MBZ
+	 * 2 : first - Indicates first descriptor in
+	 *    transaction
+	 * 3 : last - Indicates last descriptor in transaction
+	 * 4 : comp_req
+	 * 5 : reserved5 - MBO
+	 * 7:6 : reserved6 - MBZ
+	 */
+	uint8_t ctrl;
+
+	uint16_t req_id;
+
+	/* MBZ */
+	uint16_t reserved6;
+
+	uint32_t buff_addr_lo;
+
+	uint16_t buff_addr_hi;
+
+	/* MBZ */
+	uint16_t reserved16_w3;
+};
+
+/* 4-word format Note: all ethernet parsing information are valid only when
+ * last=1
+ */
+struct ena_eth_io_rx_cdesc_base {
+	/* 4:0 : l3_proto_idx
+	 * 6:5 : src_vlan_cnt
+	 * 7 : reserved7 - MBZ
+	 * 12:8 : l4_proto_idx
+	 * 13 : l3_csum_err - when set, either the L3
+	 *    checksum error detected, or, the controller didn't
+	 *    validate the checksum. This bit is valid only when
+	 *    l3_proto_idx indicates IPv4 packet
+	 * 14 : l4_csum_err - when set, either the L4
+	 *    checksum error detected, or, the controller didn't
+	 *    validate the checksum. This bit is valid only when
+	 *    l4_proto_idx indicates TCP/UDP packet, and,
+	 *    ipv4_frag is not set. This bit is valid only when
+	 *    l4_csum_checked below is set.
+	 * 15 : ipv4_frag - Indicates IPv4 fragmented packet
+	 * 16 : l4_csum_checked - L4 checksum was verified
+	 *    (could be OK or error), when cleared the status of
+	 *    checksum is unknown
+	 * 23:17 : reserved17 - MBZ
+	 * 24 : phase
+	 * 25 : l3_csum2 - second checksum engine result
+	 * 26 : first - Indicates first descriptor in
+	 *    transaction
+	 * 27 : last - Indicates last descriptor in
+	 *    transaction
+	 * 29:28 : reserved28
+	 * 30 : buffer - 0: Metadata descriptor. 1: Buffer
+	 *    Descriptor was used
+	 * 31 : reserved31
+	 */
+	uint32_t status;
+
+	uint16_t length;
+
+	uint16_t req_id;
+
+	/* 32-bit hash result */
+	uint32_t hash;
+
+	uint16_t sub_qid;
+
+	uint8_t offset;
+
+	uint8_t reserved;
+};
+
+/* 8-word format */
+struct ena_eth_io_rx_cdesc_ext {
+	struct ena_eth_io_rx_cdesc_base base;
+
+	uint32_t buff_addr_lo;
+
+	uint16_t buff_addr_hi;
+
+	uint16_t reserved16;
+
+	uint32_t reserved_w6;
+
+	uint32_t reserved_w7;
+};
+
+struct ena_eth_io_intr_reg {
+	/* 14:0 : rx_intr_delay
+	 * 29:15 : tx_intr_delay
+	 * 30 : intr_unmask
+	 * 31 : reserved
+	 */
+	uint32_t intr_control;
+};
+
+struct ena_eth_io_numa_node_cfg_reg {
+	/* 7:0 : numa
+	 * 30:8 : reserved
+	 * 31 : enabled
+	 */
+	uint32_t numa_cfg;
+};
+
+/* tx_desc */
+#define ENA_ETH_IO_TX_DESC_LENGTH_MASK                      GENMASK(15, 0)
+#define ENA_ETH_IO_TX_DESC_REQ_ID_HI_SHIFT                  16
+#define ENA_ETH_IO_TX_DESC_REQ_ID_HI_MASK                   GENMASK(21, 16)
+#define ENA_ETH_IO_TX_DESC_META_DESC_SHIFT                  23
+#define ENA_ETH_IO_TX_DESC_META_DESC_MASK                   BIT(23)
+#define ENA_ETH_IO_TX_DESC_PHASE_SHIFT                      24
+#define ENA_ETH_IO_TX_DESC_PHASE_MASK                       BIT(24)
+#define ENA_ETH_IO_TX_DESC_FIRST_SHIFT                      26
+#define ENA_ETH_IO_TX_DESC_FIRST_MASK                       BIT(26)
+#define ENA_ETH_IO_TX_DESC_LAST_SHIFT                       27
+#define ENA_ETH_IO_TX_DESC_LAST_MASK                        BIT(27)
+#define ENA_ETH_IO_TX_DESC_COMP_REQ_SHIFT                   28
+#define ENA_ETH_IO_TX_DESC_COMP_REQ_MASK                    BIT(28)
+#define ENA_ETH_IO_TX_DESC_L3_PROTO_IDX_MASK                GENMASK(3, 0)
+#define ENA_ETH_IO_TX_DESC_DF_SHIFT                         4
+#define ENA_ETH_IO_TX_DESC_DF_MASK                          BIT(4)
+#define ENA_ETH_IO_TX_DESC_TSO_EN_SHIFT                     7
+#define ENA_ETH_IO_TX_DESC_TSO_EN_MASK                      BIT(7)
+#define ENA_ETH_IO_TX_DESC_L4_PROTO_IDX_SHIFT               8
+#define ENA_ETH_IO_TX_DESC_L4_PROTO_IDX_MASK                GENMASK(12, 8)
+#define ENA_ETH_IO_TX_DESC_L3_CSUM_EN_SHIFT                 13
+#define ENA_ETH_IO_TX_DESC_L3_CSUM_EN_MASK                  BIT(13)
+#define ENA_ETH_IO_TX_DESC_L4_CSUM_EN_SHIFT                 14
+#define ENA_ETH_IO_TX_DESC_L4_CSUM_EN_MASK                  BIT(14)
+#define ENA_ETH_IO_TX_DESC_ETHERNET_FCS_DIS_SHIFT           15
+#define ENA_ETH_IO_TX_DESC_ETHERNET_FCS_DIS_MASK            BIT(15)
+#define ENA_ETH_IO_TX_DESC_L4_CSUM_PARTIAL_SHIFT            17
+#define ENA_ETH_IO_TX_DESC_L4_CSUM_PARTIAL_MASK             BIT(17)
+#define ENA_ETH_IO_TX_DESC_REQ_ID_LO_SHIFT                  22
+#define ENA_ETH_IO_TX_DESC_REQ_ID_LO_MASK                   GENMASK(31, 22)
+#define ENA_ETH_IO_TX_DESC_ADDR_HI_MASK                     GENMASK(15, 0)
+#define ENA_ETH_IO_TX_DESC_HEADER_LENGTH_SHIFT              24
+#define ENA_ETH_IO_TX_DESC_HEADER_LENGTH_MASK               GENMASK(31, 24)
+
+/* tx_meta_desc */
+#define ENA_ETH_IO_TX_META_DESC_REQ_ID_LO_MASK              GENMASK(9, 0)
+#define ENA_ETH_IO_TX_META_DESC_EXT_VALID_SHIFT             14
+#define ENA_ETH_IO_TX_META_DESC_EXT_VALID_MASK              BIT(14)
+#define ENA_ETH_IO_TX_META_DESC_MSS_HI_SHIFT                16
+#define ENA_ETH_IO_TX_META_DESC_MSS_HI_MASK                 GENMASK(19, 16)
+#define ENA_ETH_IO_TX_META_DESC_ETH_META_TYPE_SHIFT         20
+#define ENA_ETH_IO_TX_META_DESC_ETH_META_TYPE_MASK          BIT(20)
+#define ENA_ETH_IO_TX_META_DESC_META_STORE_SHIFT            21
+#define ENA_ETH_IO_TX_META_DESC_META_STORE_MASK             BIT(21)
+#define ENA_ETH_IO_TX_META_DESC_META_DESC_SHIFT             23
+#define ENA_ETH_IO_TX_META_DESC_META_DESC_MASK              BIT(23)
+#define ENA_ETH_IO_TX_META_DESC_PHASE_SHIFT                 24
+#define ENA_ETH_IO_TX_META_DESC_PHASE_MASK                  BIT(24)
+#define ENA_ETH_IO_TX_META_DESC_FIRST_SHIFT                 26
+#define ENA_ETH_IO_TX_META_DESC_FIRST_MASK                  BIT(26)
+#define ENA_ETH_IO_TX_META_DESC_LAST_SHIFT                  27
+#define ENA_ETH_IO_TX_META_DESC_LAST_MASK                   BIT(27)
+#define ENA_ETH_IO_TX_META_DESC_COMP_REQ_SHIFT              28
+#define ENA_ETH_IO_TX_META_DESC_COMP_REQ_MASK               BIT(28)
+#define ENA_ETH_IO_TX_META_DESC_REQ_ID_HI_MASK              GENMASK(5, 0)
+#define ENA_ETH_IO_TX_META_DESC_L3_HDR_LEN_MASK             GENMASK(7, 0)
+#define ENA_ETH_IO_TX_META_DESC_L3_HDR_OFF_SHIFT            8
+#define ENA_ETH_IO_TX_META_DESC_L3_HDR_OFF_MASK             GENMASK(15, 8)
+#define ENA_ETH_IO_TX_META_DESC_L4_HDR_LEN_IN_WORDS_SHIFT   16
+#define ENA_ETH_IO_TX_META_DESC_L4_HDR_LEN_IN_WORDS_MASK    GENMASK(21, 16)
+#define ENA_ETH_IO_TX_META_DESC_MSS_LO_SHIFT                22
+#define ENA_ETH_IO_TX_META_DESC_MSS_LO_MASK                 GENMASK(31, 22)
+
+/* tx_cdesc */
+#define ENA_ETH_IO_TX_CDESC_PHASE_MASK                      BIT(0)
+
+/* rx_desc */
+#define ENA_ETH_IO_RX_DESC_PHASE_MASK                       BIT(0)
+#define ENA_ETH_IO_RX_DESC_FIRST_SHIFT                      2
+#define ENA_ETH_IO_RX_DESC_FIRST_MASK                       BIT(2)
+#define ENA_ETH_IO_RX_DESC_LAST_SHIFT                       3
+#define ENA_ETH_IO_RX_DESC_LAST_MASK                        BIT(3)
+#define ENA_ETH_IO_RX_DESC_COMP_REQ_SHIFT                   4
+#define ENA_ETH_IO_RX_DESC_COMP_REQ_MASK                    BIT(4)
+
+/* rx_cdesc_base */
+#define ENA_ETH_IO_RX_CDESC_BASE_L3_PROTO_IDX_MASK          GENMASK(4, 0)
+#define ENA_ETH_IO_RX_CDESC_BASE_SRC_VLAN_CNT_SHIFT         5
+#define ENA_ETH_IO_RX_CDESC_BASE_SRC_VLAN_CNT_MASK          GENMASK(6, 5)
+#define ENA_ETH_IO_RX_CDESC_BASE_L4_PROTO_IDX_SHIFT         8
+#define ENA_ETH_IO_RX_CDESC_BASE_L4_PROTO_IDX_MASK          GENMASK(12, 8)
+#define ENA_ETH_IO_RX_CDESC_BASE_L3_CSUM_ERR_SHIFT          13
+#define ENA_ETH_IO_RX_CDESC_BASE_L3_CSUM_ERR_MASK           BIT(13)
+#define ENA_ETH_IO_RX_CDESC_BASE_L4_CSUM_ERR_SHIFT          14
+#define ENA_ETH_IO_RX_CDESC_BASE_L4_CSUM_ERR_MASK           BIT(14)
+#define ENA_ETH_IO_RX_CDESC_BASE_IPV4_FRAG_SHIFT            15
+#define ENA_ETH_IO_RX_CDESC_BASE_IPV4_FRAG_MASK             BIT(15)
+#define ENA_ETH_IO_RX_CDESC_BASE_L4_CSUM_CHECKED_SHIFT      16
+#define ENA_ETH_IO_RX_CDESC_BASE_L4_CSUM_CHECKED_MASK       BIT(16)
+#define ENA_ETH_IO_RX_CDESC_BASE_PHASE_SHIFT                24
+#define ENA_ETH_IO_RX_CDESC_BASE_PHASE_MASK                 BIT(24)
+#define ENA_ETH_IO_RX_CDESC_BASE_L3_CSUM2_SHIFT             25
+#define ENA_ETH_IO_RX_CDESC_BASE_L3_CSUM2_MASK              BIT(25)
+#define ENA_ETH_IO_RX_CDESC_BASE_FIRST_SHIFT                26
+#define ENA_ETH_IO_RX_CDESC_BASE_FIRST_MASK                 BIT(26)
+#define ENA_ETH_IO_RX_CDESC_BASE_LAST_SHIFT                 27
+#define ENA_ETH_IO_RX_CDESC_BASE_LAST_MASK                  BIT(27)
+#define ENA_ETH_IO_RX_CDESC_BASE_BUFFER_SHIFT               30
+#define ENA_ETH_IO_RX_CDESC_BASE_BUFFER_MASK                BIT(30)
+
+/* intr_reg */
+#define ENA_ETH_IO_INTR_REG_RX_INTR_DELAY_MASK              GENMASK(14, 0)
+#define ENA_ETH_IO_INTR_REG_TX_INTR_DELAY_SHIFT             15
+#define ENA_ETH_IO_INTR_REG_TX_INTR_DELAY_MASK              GENMASK(29, 15)
+#define ENA_ETH_IO_INTR_REG_INTR_UNMASK_SHIFT               30
+#define ENA_ETH_IO_INTR_REG_INTR_UNMASK_MASK                BIT(30)
+
+/* numa_node_cfg_reg */
+#define ENA_ETH_IO_NUMA_NODE_CFG_REG_NUMA_MASK              GENMASK(7, 0)
+#define ENA_ETH_IO_NUMA_NODE_CFG_REG_ENABLED_SHIFT          31
+#define ENA_ETH_IO_NUMA_NODE_CFG_REG_ENABLED_MASK           BIT(31)
+
+#if !defined(DEFS_LINUX_MAINLINE)
+static inline uint32_t get_ena_eth_io_tx_desc_length(const struct ena_eth_io_tx_desc *p)
+{
+	return p->len_ctrl & ENA_ETH_IO_TX_DESC_LENGTH_MASK;
+}
+
+static inline void set_ena_eth_io_tx_desc_length(struct ena_eth_io_tx_desc *p, uint32_t val)
+{
+	p->len_ctrl |= val & ENA_ETH_IO_TX_DESC_LENGTH_MASK;
+}
+
+static inline uint32_t get_ena_eth_io_tx_desc_req_id_hi(const struct ena_eth_io_tx_desc *p)
+{
+	return (p->len_ctrl & ENA_ETH_IO_TX_DESC_REQ_ID_HI_MASK) >> ENA_ETH_IO_TX_DESC_REQ_ID_HI_SHIFT;
+}
+
+static inline void set_ena_eth_io_tx_desc_req_id_hi(struct ena_eth_io_tx_desc *p, uint32_t val)
+{
+	p->len_ctrl |= (val << ENA_ETH_IO_TX_DESC_REQ_ID_HI_SHIFT) & ENA_ETH_IO_TX_DESC_REQ_ID_HI_MASK;
+}
+
+static inline uint32_t get_ena_eth_io_tx_desc_meta_desc(const struct ena_eth_io_tx_desc *p)
+{
+	return (p->len_ctrl & ENA_ETH_IO_TX_DESC_META_DESC_MASK) >> ENA_ETH_IO_TX_DESC_META_DESC_SHIFT;
+}
+
+static inline void set_ena_eth_io_tx_desc_meta_desc(struct ena_eth_io_tx_desc *p, uint32_t val)
+{
+	p->len_ctrl |= (val << ENA_ETH_IO_TX_DESC_META_DESC_SHIFT) & ENA_ETH_IO_TX_DESC_META_DESC_MASK;
+}
+
+static inline uint32_t get_ena_eth_io_tx_desc_phase(const struct ena_eth_io_tx_desc *p)
+{
+	return (p->len_ctrl & ENA_ETH_IO_TX_DESC_PHASE_MASK) >> ENA_ETH_IO_TX_DESC_PHASE_SHIFT;
+}
+
+static inline void set_ena_eth_io_tx_desc_phase(struct ena_eth_io_tx_desc *p, uint32_t val)
+{
+	p->len_ctrl |= (val << ENA_ETH_IO_TX_DESC_PHASE_SHIFT) & ENA_ETH_IO_TX_DESC_PHASE_MASK;
+}
+
+static inline uint32_t get_ena_eth_io_tx_desc_first(const struct ena_eth_io_tx_desc *p)
+{
+	return (p->len_ctrl & ENA_ETH_IO_TX_DESC_FIRST_MASK) >> ENA_ETH_IO_TX_DESC_FIRST_SHIFT;
+}
+
+static inline void set_ena_eth_io_tx_desc_first(struct ena_eth_io_tx_desc *p, uint32_t val)
+{
+	p->len_ctrl |= (val << ENA_ETH_IO_TX_DESC_FIRST_SHIFT) & ENA_ETH_IO_TX_DESC_FIRST_MASK;
+}
+
+static inline uint32_t get_ena_eth_io_tx_desc_last(const struct ena_eth_io_tx_desc *p)
+{
+	return (p->len_ctrl & ENA_ETH_IO_TX_DESC_LAST_MASK) >> ENA_ETH_IO_TX_DESC_LAST_SHIFT;
+}
+
+static inline void set_ena_eth_io_tx_desc_last(struct ena_eth_io_tx_desc *p, uint32_t val)
+{
+	p->len_ctrl |= (val << ENA_ETH_IO_TX_DESC_LAST_SHIFT) & ENA_ETH_IO_TX_DESC_LAST_MASK;
+}
+
+static inline uint32_t get_ena_eth_io_tx_desc_comp_req(const struct ena_eth_io_tx_desc *p)
+{
+	return (p->len_ctrl & ENA_ETH_IO_TX_DESC_COMP_REQ_MASK) >> ENA_ETH_IO_TX_DESC_COMP_REQ_SHIFT;
+}
+
+static inline void set_ena_eth_io_tx_desc_comp_req(struct ena_eth_io_tx_desc *p, uint32_t val)
+{
+	p->len_ctrl |= (val << ENA_ETH_IO_TX_DESC_COMP_REQ_SHIFT) & ENA_ETH_IO_TX_DESC_COMP_REQ_MASK;
+}
+
+static inline uint32_t get_ena_eth_io_tx_desc_l3_proto_idx(const struct ena_eth_io_tx_desc *p)
+{
+	return p->meta_ctrl & ENA_ETH_IO_TX_DESC_L3_PROTO_IDX_MASK;
+}
+
+static inline void set_ena_eth_io_tx_desc_l3_proto_idx(struct ena_eth_io_tx_desc *p, uint32_t val)
+{
+	p->meta_ctrl |= val & ENA_ETH_IO_TX_DESC_L3_PROTO_IDX_MASK;
+}
+
+static inline uint32_t get_ena_eth_io_tx_desc_DF(const struct ena_eth_io_tx_desc *p)
+{
+	return (p->meta_ctrl & ENA_ETH_IO_TX_DESC_DF_MASK) >> ENA_ETH_IO_TX_DESC_DF_SHIFT;
+}
+
+static inline void set_ena_eth_io_tx_desc_DF(struct ena_eth_io_tx_desc *p, uint32_t val)
+{
+	p->meta_ctrl |= (val << ENA_ETH_IO_TX_DESC_DF_SHIFT) & ENA_ETH_IO_TX_DESC_DF_MASK;
+}
+
+static inline uint32_t get_ena_eth_io_tx_desc_tso_en(const struct ena_eth_io_tx_desc *p)
+{
+	return (p->meta_ctrl & ENA_ETH_IO_TX_DESC_TSO_EN_MASK) >> ENA_ETH_IO_TX_DESC_TSO_EN_SHIFT;
+}
+
+static inline void set_ena_eth_io_tx_desc_tso_en(struct ena_eth_io_tx_desc *p, uint32_t val)
+{
+	p->meta_ctrl |= (val << ENA_ETH_IO_TX_DESC_TSO_EN_SHIFT) & ENA_ETH_IO_TX_DESC_TSO_EN_MASK;
+}
+
+static inline uint32_t get_ena_eth_io_tx_desc_l4_proto_idx(const struct ena_eth_io_tx_desc *p)
+{
+	return (p->meta_ctrl & ENA_ETH_IO_TX_DESC_L4_PROTO_IDX_MASK) >> ENA_ETH_IO_TX_DESC_L4_PROTO_IDX_SHIFT;
+}
+
+static inline void set_ena_eth_io_tx_desc_l4_proto_idx(struct ena_eth_io_tx_desc *p, uint32_t val)
+{
+	p->meta_ctrl |= (val << ENA_ETH_IO_TX_DESC_L4_PROTO_IDX_SHIFT) & ENA_ETH_IO_TX_DESC_L4_PROTO_IDX_MASK;
+}
+
+static inline uint32_t get_ena_eth_io_tx_desc_l3_csum_en(const struct ena_eth_io_tx_desc *p)
+{
+	return (p->meta_ctrl & ENA_ETH_IO_TX_DESC_L3_CSUM_EN_MASK) >> ENA_ETH_IO_TX_DESC_L3_CSUM_EN_SHIFT;
+}
+
+static inline void set_ena_eth_io_tx_desc_l3_csum_en(struct ena_eth_io_tx_desc *p, uint32_t val)
+{
+	p->meta_ctrl |= (val << ENA_ETH_IO_TX_DESC_L3_CSUM_EN_SHIFT) & ENA_ETH_IO_TX_DESC_L3_CSUM_EN_MASK;
+}
+
+static inline uint32_t get_ena_eth_io_tx_desc_l4_csum_en(const struct ena_eth_io_tx_desc *p)
+{
+	return (p->meta_ctrl & ENA_ETH_IO_TX_DESC_L4_CSUM_EN_MASK) >> ENA_ETH_IO_TX_DESC_L4_CSUM_EN_SHIFT;
+}
+
+static inline void set_ena_eth_io_tx_desc_l4_csum_en(struct ena_eth_io_tx_desc *p, uint32_t val)
+{
+	p->meta_ctrl |= (val << ENA_ETH_IO_TX_DESC_L4_CSUM_EN_SHIFT) & ENA_ETH_IO_TX_DESC_L4_CSUM_EN_MASK;
+}
+
+static inline uint32_t get_ena_eth_io_tx_desc_ethernet_fcs_dis(const struct ena_eth_io_tx_desc *p)
+{
+	return (p->meta_ctrl & ENA_ETH_IO_TX_DESC_ETHERNET_FCS_DIS_MASK) >> ENA_ETH_IO_TX_DESC_ETHERNET_FCS_DIS_SHIFT;
+}
+
+static inline void set_ena_eth_io_tx_desc_ethernet_fcs_dis(struct ena_eth_io_tx_desc *p, uint32_t val)
+{
+	p->meta_ctrl |= (val << ENA_ETH_IO_TX_DESC_ETHERNET_FCS_DIS_SHIFT) & ENA_ETH_IO_TX_DESC_ETHERNET_FCS_DIS_MASK;
+}
+
+static inline uint32_t get_ena_eth_io_tx_desc_l4_csum_partial(const struct ena_eth_io_tx_desc *p)
+{
+	return (p->meta_ctrl & ENA_ETH_IO_TX_DESC_L4_CSUM_PARTIAL_MASK) >> ENA_ETH_IO_TX_DESC_L4_CSUM_PARTIAL_SHIFT;
+}
+
+static inline void set_ena_eth_io_tx_desc_l4_csum_partial(struct ena_eth_io_tx_desc *p, uint32_t val)
+{
+	p->meta_ctrl |= (val << ENA_ETH_IO_TX_DESC_L4_CSUM_PARTIAL_SHIFT) & ENA_ETH_IO_TX_DESC_L4_CSUM_PARTIAL_MASK;
+}
+
+static inline uint32_t get_ena_eth_io_tx_desc_req_id_lo(const struct ena_eth_io_tx_desc *p)
+{
+	return (p->meta_ctrl & ENA_ETH_IO_TX_DESC_REQ_ID_LO_MASK) >> ENA_ETH_IO_TX_DESC_REQ_ID_LO_SHIFT;
+}
+
+static inline void set_ena_eth_io_tx_desc_req_id_lo(struct ena_eth_io_tx_desc *p, uint32_t val)
+{
+	p->meta_ctrl |= (val << ENA_ETH_IO_TX_DESC_REQ_ID_LO_SHIFT) & ENA_ETH_IO_TX_DESC_REQ_ID_LO_MASK;
+}
+
+static inline uint32_t get_ena_eth_io_tx_desc_addr_hi(const struct ena_eth_io_tx_desc *p)
+{
+	return p->buff_addr_hi_hdr_sz & ENA_ETH_IO_TX_DESC_ADDR_HI_MASK;
+}
+
+static inline void set_ena_eth_io_tx_desc_addr_hi(struct ena_eth_io_tx_desc *p, uint32_t val)
+{
+	p->buff_addr_hi_hdr_sz |= val & ENA_ETH_IO_TX_DESC_ADDR_HI_MASK;
+}
+
+static inline uint32_t get_ena_eth_io_tx_desc_header_length(const struct ena_eth_io_tx_desc *p)
+{
+	return (p->buff_addr_hi_hdr_sz & ENA_ETH_IO_TX_DESC_HEADER_LENGTH_MASK) >> ENA_ETH_IO_TX_DESC_HEADER_LENGTH_SHIFT;
+}
+
+static inline void set_ena_eth_io_tx_desc_header_length(struct ena_eth_io_tx_desc *p, uint32_t val)
+{
+	p->buff_addr_hi_hdr_sz |= (val << ENA_ETH_IO_TX_DESC_HEADER_LENGTH_SHIFT) & ENA_ETH_IO_TX_DESC_HEADER_LENGTH_MASK;
+}
+
+static inline uint32_t get_ena_eth_io_tx_meta_desc_req_id_lo(const struct ena_eth_io_tx_meta_desc *p)
+{
+	return p->len_ctrl & ENA_ETH_IO_TX_META_DESC_REQ_ID_LO_MASK;
+}
+
+static inline void set_ena_eth_io_tx_meta_desc_req_id_lo(struct ena_eth_io_tx_meta_desc *p, uint32_t val)
+{
+	p->len_ctrl |= val & ENA_ETH_IO_TX_META_DESC_REQ_ID_LO_MASK;
+}
+
+static inline uint32_t get_ena_eth_io_tx_meta_desc_ext_valid(const struct ena_eth_io_tx_meta_desc *p)
+{
+	return (p->len_ctrl & ENA_ETH_IO_TX_META_DESC_EXT_VALID_MASK) >> ENA_ETH_IO_TX_META_DESC_EXT_VALID_SHIFT;
+}
+
+static inline void set_ena_eth_io_tx_meta_desc_ext_valid(struct ena_eth_io_tx_meta_desc *p, uint32_t val)
+{
+	p->len_ctrl |= (val << ENA_ETH_IO_TX_META_DESC_EXT_VALID_SHIFT) & ENA_ETH_IO_TX_META_DESC_EXT_VALID_MASK;
+}
+
+static inline uint32_t get_ena_eth_io_tx_meta_desc_mss_hi(const struct ena_eth_io_tx_meta_desc *p)
+{
+	return (p->len_ctrl & ENA_ETH_IO_TX_META_DESC_MSS_HI_MASK) >> ENA_ETH_IO_TX_META_DESC_MSS_HI_SHIFT;
+}
+
+static inline void set_ena_eth_io_tx_meta_desc_mss_hi(struct ena_eth_io_tx_meta_desc *p, uint32_t val)
+{
+	p->len_ctrl |= (val << ENA_ETH_IO_TX_META_DESC_MSS_HI_SHIFT) & ENA_ETH_IO_TX_META_DESC_MSS_HI_MASK;
+}
+
+static inline uint32_t get_ena_eth_io_tx_meta_desc_eth_meta_type(const struct ena_eth_io_tx_meta_desc *p)
+{
+	return (p->len_ctrl & ENA_ETH_IO_TX_META_DESC_ETH_META_TYPE_MASK) >> ENA_ETH_IO_TX_META_DESC_ETH_META_TYPE_SHIFT;
+}
+
+static inline void set_ena_eth_io_tx_meta_desc_eth_meta_type(struct ena_eth_io_tx_meta_desc *p, uint32_t val)
+{
+	p->len_ctrl |= (val << ENA_ETH_IO_TX_META_DESC_ETH_META_TYPE_SHIFT) & ENA_ETH_IO_TX_META_DESC_ETH_META_TYPE_MASK;
+}
+
+static inline uint32_t get_ena_eth_io_tx_meta_desc_meta_store(const struct ena_eth_io_tx_meta_desc *p)
+{
+	return (p->len_ctrl & ENA_ETH_IO_TX_META_DESC_META_STORE_MASK) >> ENA_ETH_IO_TX_META_DESC_META_STORE_SHIFT;
+}
+
+static inline void set_ena_eth_io_tx_meta_desc_meta_store(struct ena_eth_io_tx_meta_desc *p, uint32_t val)
+{
+	p->len_ctrl |= (val << ENA_ETH_IO_TX_META_DESC_META_STORE_SHIFT) & ENA_ETH_IO_TX_META_DESC_META_STORE_MASK;
+}
+
+static inline uint32_t get_ena_eth_io_tx_meta_desc_meta_desc(const struct ena_eth_io_tx_meta_desc *p)
+{
+	return (p->len_ctrl & ENA_ETH_IO_TX_META_DESC_META_DESC_MASK) >> ENA_ETH_IO_TX_META_DESC_META_DESC_SHIFT;
+}
+
+static inline void set_ena_eth_io_tx_meta_desc_meta_desc(struct ena_eth_io_tx_meta_desc *p, uint32_t val)
+{
+	p->len_ctrl |= (val << ENA_ETH_IO_TX_META_DESC_META_DESC_SHIFT) & ENA_ETH_IO_TX_META_DESC_META_DESC_MASK;
+}
+
+static inline uint32_t get_ena_eth_io_tx_meta_desc_phase(const struct ena_eth_io_tx_meta_desc *p)
+{
+	return (p->len_ctrl & ENA_ETH_IO_TX_META_DESC_PHASE_MASK) >> ENA_ETH_IO_TX_META_DESC_PHASE_SHIFT;
+}
+
+static inline void set_ena_eth_io_tx_meta_desc_phase(struct ena_eth_io_tx_meta_desc *p, uint32_t val)
+{
+	p->len_ctrl |= (val << ENA_ETH_IO_TX_META_DESC_PHASE_SHIFT) & ENA_ETH_IO_TX_META_DESC_PHASE_MASK;
+}
+
+static inline uint32_t get_ena_eth_io_tx_meta_desc_first(const struct ena_eth_io_tx_meta_desc *p)
+{
+	return (p->len_ctrl & ENA_ETH_IO_TX_META_DESC_FIRST_MASK) >> ENA_ETH_IO_TX_META_DESC_FIRST_SHIFT;
+}
+
+static inline void set_ena_eth_io_tx_meta_desc_first(struct ena_eth_io_tx_meta_desc *p, uint32_t val)
+{
+	p->len_ctrl |= (val << ENA_ETH_IO_TX_META_DESC_FIRST_SHIFT) & ENA_ETH_IO_TX_META_DESC_FIRST_MASK;
+}
+
+static inline uint32_t get_ena_eth_io_tx_meta_desc_last(const struct ena_eth_io_tx_meta_desc *p)
+{
+	return (p->len_ctrl & ENA_ETH_IO_TX_META_DESC_LAST_MASK) >> ENA_ETH_IO_TX_META_DESC_LAST_SHIFT;
+}
+
+static inline void set_ena_eth_io_tx_meta_desc_last(struct ena_eth_io_tx_meta_desc *p, uint32_t val)
+{
+	p->len_ctrl |= (val << ENA_ETH_IO_TX_META_DESC_LAST_SHIFT) & ENA_ETH_IO_TX_META_DESC_LAST_MASK;
+}
+
+static inline uint32_t get_ena_eth_io_tx_meta_desc_comp_req(const struct ena_eth_io_tx_meta_desc *p)
+{
+	return (p->len_ctrl & ENA_ETH_IO_TX_META_DESC_COMP_REQ_MASK) >> ENA_ETH_IO_TX_META_DESC_COMP_REQ_SHIFT;
+}
+
+static inline void set_ena_eth_io_tx_meta_desc_comp_req(struct ena_eth_io_tx_meta_desc *p, uint32_t val)
+{
+	p->len_ctrl |= (val << ENA_ETH_IO_TX_META_DESC_COMP_REQ_SHIFT) & ENA_ETH_IO_TX_META_DESC_COMP_REQ_MASK;
+}
+
+static inline uint32_t get_ena_eth_io_tx_meta_desc_req_id_hi(const struct ena_eth_io_tx_meta_desc *p)
+{
+	return p->word1 & ENA_ETH_IO_TX_META_DESC_REQ_ID_HI_MASK;
+}
+
+static inline void set_ena_eth_io_tx_meta_desc_req_id_hi(struct ena_eth_io_tx_meta_desc *p, uint32_t val)
+{
+	p->word1 |= val & ENA_ETH_IO_TX_META_DESC_REQ_ID_HI_MASK;
+}
+
+static inline uint32_t get_ena_eth_io_tx_meta_desc_l3_hdr_len(const struct ena_eth_io_tx_meta_desc *p)
+{
+	return p->word2 & ENA_ETH_IO_TX_META_DESC_L3_HDR_LEN_MASK;
+}
+
+static inline void set_ena_eth_io_tx_meta_desc_l3_hdr_len(struct ena_eth_io_tx_meta_desc *p, uint32_t val)
+{
+	p->word2 |= val & ENA_ETH_IO_TX_META_DESC_L3_HDR_LEN_MASK;
+}
+
+static inline uint32_t get_ena_eth_io_tx_meta_desc_l3_hdr_off(const struct ena_eth_io_tx_meta_desc *p)
+{
+	return (p->word2 & ENA_ETH_IO_TX_META_DESC_L3_HDR_OFF_MASK) >> ENA_ETH_IO_TX_META_DESC_L3_HDR_OFF_SHIFT;
+}
+
+static inline void set_ena_eth_io_tx_meta_desc_l3_hdr_off(struct ena_eth_io_tx_meta_desc *p, uint32_t val)
+{
+	p->word2 |= (val << ENA_ETH_IO_TX_META_DESC_L3_HDR_OFF_SHIFT) & ENA_ETH_IO_TX_META_DESC_L3_HDR_OFF_MASK;
+}
+
+static inline uint32_t get_ena_eth_io_tx_meta_desc_l4_hdr_len_in_words(const struct ena_eth_io_tx_meta_desc *p)
+{
+	return (p->word2 & ENA_ETH_IO_TX_META_DESC_L4_HDR_LEN_IN_WORDS_MASK) >> ENA_ETH_IO_TX_META_DESC_L4_HDR_LEN_IN_WORDS_SHIFT;
+}
+
+static inline void set_ena_eth_io_tx_meta_desc_l4_hdr_len_in_words(struct ena_eth_io_tx_meta_desc *p, uint32_t val)
+{
+	p->word2 |= (val << ENA_ETH_IO_TX_META_DESC_L4_HDR_LEN_IN_WORDS_SHIFT) & ENA_ETH_IO_TX_META_DESC_L4_HDR_LEN_IN_WORDS_MASK;
+}
+
+static inline uint32_t get_ena_eth_io_tx_meta_desc_mss_lo(const struct ena_eth_io_tx_meta_desc *p)
+{
+	return (p->word2 & ENA_ETH_IO_TX_META_DESC_MSS_LO_MASK) >> ENA_ETH_IO_TX_META_DESC_MSS_LO_SHIFT;
+}
+
+static inline void set_ena_eth_io_tx_meta_desc_mss_lo(struct ena_eth_io_tx_meta_desc *p, uint32_t val)
+{
+	p->word2 |= (val << ENA_ETH_IO_TX_META_DESC_MSS_LO_SHIFT) & ENA_ETH_IO_TX_META_DESC_MSS_LO_MASK;
+}
+
+static inline uint8_t get_ena_eth_io_tx_cdesc_phase(const struct ena_eth_io_tx_cdesc *p)
+{
+	return p->flags & ENA_ETH_IO_TX_CDESC_PHASE_MASK;
+}
+
+static inline void set_ena_eth_io_tx_cdesc_phase(struct ena_eth_io_tx_cdesc *p, uint8_t val)
+{
+	p->flags |= val & ENA_ETH_IO_TX_CDESC_PHASE_MASK;
+}
+
+static inline uint8_t get_ena_eth_io_rx_desc_phase(const struct ena_eth_io_rx_desc *p)
+{
+	return p->ctrl & ENA_ETH_IO_RX_DESC_PHASE_MASK;
+}
+
+static inline void set_ena_eth_io_rx_desc_phase(struct ena_eth_io_rx_desc *p, uint8_t val)
+{
+	p->ctrl |= val & ENA_ETH_IO_RX_DESC_PHASE_MASK;
+}
+
+static inline uint8_t get_ena_eth_io_rx_desc_first(const struct ena_eth_io_rx_desc *p)
+{
+	return (p->ctrl & ENA_ETH_IO_RX_DESC_FIRST_MASK) >> ENA_ETH_IO_RX_DESC_FIRST_SHIFT;
+}
+
+static inline void set_ena_eth_io_rx_desc_first(struct ena_eth_io_rx_desc *p, uint8_t val)
+{
+	p->ctrl |= (val << ENA_ETH_IO_RX_DESC_FIRST_SHIFT) & ENA_ETH_IO_RX_DESC_FIRST_MASK;
+}
+
+static inline uint8_t get_ena_eth_io_rx_desc_last(const struct ena_eth_io_rx_desc *p)
+{
+	return (p->ctrl & ENA_ETH_IO_RX_DESC_LAST_MASK) >> ENA_ETH_IO_RX_DESC_LAST_SHIFT;
+}
+
+static inline void set_ena_eth_io_rx_desc_last(struct ena_eth_io_rx_desc *p, uint8_t val)
+{
+	p->ctrl |= (val << ENA_ETH_IO_RX_DESC_LAST_SHIFT) & ENA_ETH_IO_RX_DESC_LAST_MASK;
+}
+
+static inline uint8_t get_ena_eth_io_rx_desc_comp_req(const struct ena_eth_io_rx_desc *p)
+{
+	return (p->ctrl & ENA_ETH_IO_RX_DESC_COMP_REQ_MASK) >> ENA_ETH_IO_RX_DESC_COMP_REQ_SHIFT;
+}
+
+static inline void set_ena_eth_io_rx_desc_comp_req(struct ena_eth_io_rx_desc *p, uint8_t val)
+{
+	p->ctrl |= (val << ENA_ETH_IO_RX_DESC_COMP_REQ_SHIFT) & ENA_ETH_IO_RX_DESC_COMP_REQ_MASK;
+}
+
+static inline uint32_t get_ena_eth_io_rx_cdesc_base_l3_proto_idx(const struct ena_eth_io_rx_cdesc_base *p)
+{
+	return p->status & ENA_ETH_IO_RX_CDESC_BASE_L3_PROTO_IDX_MASK;
+}
+
+static inline void set_ena_eth_io_rx_cdesc_base_l3_proto_idx(struct ena_eth_io_rx_cdesc_base *p, uint32_t val)
+{
+	p->status |= val & ENA_ETH_IO_RX_CDESC_BASE_L3_PROTO_IDX_MASK;
+}
+
+static inline uint32_t get_ena_eth_io_rx_cdesc_base_src_vlan_cnt(const struct ena_eth_io_rx_cdesc_base *p)
+{
+	return (p->status & ENA_ETH_IO_RX_CDESC_BASE_SRC_VLAN_CNT_MASK) >> ENA_ETH_IO_RX_CDESC_BASE_SRC_VLAN_CNT_SHIFT;
+}
+
+static inline void set_ena_eth_io_rx_cdesc_base_src_vlan_cnt(struct ena_eth_io_rx_cdesc_base *p, uint32_t val)
+{
+	p->status |= (val << ENA_ETH_IO_RX_CDESC_BASE_SRC_VLAN_CNT_SHIFT) & ENA_ETH_IO_RX_CDESC_BASE_SRC_VLAN_CNT_MASK;
+}
+
+static inline uint32_t get_ena_eth_io_rx_cdesc_base_l4_proto_idx(const struct ena_eth_io_rx_cdesc_base *p)
+{
+	return (p->status & ENA_ETH_IO_RX_CDESC_BASE_L4_PROTO_IDX_MASK) >> ENA_ETH_IO_RX_CDESC_BASE_L4_PROTO_IDX_SHIFT;
+}
+
+static inline void set_ena_eth_io_rx_cdesc_base_l4_proto_idx(struct ena_eth_io_rx_cdesc_base *p, uint32_t val)
+{
+	p->status |= (val << ENA_ETH_IO_RX_CDESC_BASE_L4_PROTO_IDX_SHIFT) & ENA_ETH_IO_RX_CDESC_BASE_L4_PROTO_IDX_MASK;
+}
+
+static inline uint32_t get_ena_eth_io_rx_cdesc_base_l3_csum_err(const struct ena_eth_io_rx_cdesc_base *p)
+{
+	return (p->status & ENA_ETH_IO_RX_CDESC_BASE_L3_CSUM_ERR_MASK) >> ENA_ETH_IO_RX_CDESC_BASE_L3_CSUM_ERR_SHIFT;
+}
+
+static inline void set_ena_eth_io_rx_cdesc_base_l3_csum_err(struct ena_eth_io_rx_cdesc_base *p, uint32_t val)
+{
+	p->status |= (val << ENA_ETH_IO_RX_CDESC_BASE_L3_CSUM_ERR_SHIFT) & ENA_ETH_IO_RX_CDESC_BASE_L3_CSUM_ERR_MASK;
+}
+
+static inline uint32_t get_ena_eth_io_rx_cdesc_base_l4_csum_err(const struct ena_eth_io_rx_cdesc_base *p)
+{
+	return (p->status & ENA_ETH_IO_RX_CDESC_BASE_L4_CSUM_ERR_MASK) >> ENA_ETH_IO_RX_CDESC_BASE_L4_CSUM_ERR_SHIFT;
+}
+
+static inline void set_ena_eth_io_rx_cdesc_base_l4_csum_err(struct ena_eth_io_rx_cdesc_base *p, uint32_t val)
+{
+	p->status |= (val << ENA_ETH_IO_RX_CDESC_BASE_L4_CSUM_ERR_SHIFT) & ENA_ETH_IO_RX_CDESC_BASE_L4_CSUM_ERR_MASK;
+}
+
+static inline uint32_t get_ena_eth_io_rx_cdesc_base_ipv4_frag(const struct ena_eth_io_rx_cdesc_base *p)
+{
+	return (p->status & ENA_ETH_IO_RX_CDESC_BASE_IPV4_FRAG_MASK) >> ENA_ETH_IO_RX_CDESC_BASE_IPV4_FRAG_SHIFT;
+}
+
+static inline void set_ena_eth_io_rx_cdesc_base_ipv4_frag(struct ena_eth_io_rx_cdesc_base *p, uint32_t val)
+{
+	p->status |= (val << ENA_ETH_IO_RX_CDESC_BASE_IPV4_FRAG_SHIFT) & ENA_ETH_IO_RX_CDESC_BASE_IPV4_FRAG_MASK;
+}
+
+static inline uint32_t get_ena_eth_io_rx_cdesc_base_l4_csum_checked(const struct ena_eth_io_rx_cdesc_base *p)
+{
+	return (p->status & ENA_ETH_IO_RX_CDESC_BASE_L4_CSUM_CHECKED_MASK) >> ENA_ETH_IO_RX_CDESC_BASE_L4_CSUM_CHECKED_SHIFT;
+}
+
+static inline void set_ena_eth_io_rx_cdesc_base_l4_csum_checked(struct ena_eth_io_rx_cdesc_base *p, uint32_t val)
+{
+	p->status |= (val << ENA_ETH_IO_RX_CDESC_BASE_L4_CSUM_CHECKED_SHIFT) & ENA_ETH_IO_RX_CDESC_BASE_L4_CSUM_CHECKED_MASK;
+}
+
+static inline uint32_t get_ena_eth_io_rx_cdesc_base_phase(const struct ena_eth_io_rx_cdesc_base *p)
+{
+	return (p->status & ENA_ETH_IO_RX_CDESC_BASE_PHASE_MASK) >> ENA_ETH_IO_RX_CDESC_BASE_PHASE_SHIFT;
+}
+
+static inline void set_ena_eth_io_rx_cdesc_base_phase(struct ena_eth_io_rx_cdesc_base *p, uint32_t val)
+{
+	p->status |= (val << ENA_ETH_IO_RX_CDESC_BASE_PHASE_SHIFT) & ENA_ETH_IO_RX_CDESC_BASE_PHASE_MASK;
+}
+
+static inline uint32_t get_ena_eth_io_rx_cdesc_base_l3_csum2(const struct ena_eth_io_rx_cdesc_base *p)
+{
+	return (p->status & ENA_ETH_IO_RX_CDESC_BASE_L3_CSUM2_MASK) >> ENA_ETH_IO_RX_CDESC_BASE_L3_CSUM2_SHIFT;
+}
+
+static inline void set_ena_eth_io_rx_cdesc_base_l3_csum2(struct ena_eth_io_rx_cdesc_base *p, uint32_t val)
+{
+	p->status |= (val << ENA_ETH_IO_RX_CDESC_BASE_L3_CSUM2_SHIFT) & ENA_ETH_IO_RX_CDESC_BASE_L3_CSUM2_MASK;
+}
+
+static inline uint32_t get_ena_eth_io_rx_cdesc_base_first(const struct ena_eth_io_rx_cdesc_base *p)
+{
+	return (p->status & ENA_ETH_IO_RX_CDESC_BASE_FIRST_MASK) >> ENA_ETH_IO_RX_CDESC_BASE_FIRST_SHIFT;
+}
+
+static inline void set_ena_eth_io_rx_cdesc_base_first(struct ena_eth_io_rx_cdesc_base *p, uint32_t val)
+{
+	p->status |= (val << ENA_ETH_IO_RX_CDESC_BASE_FIRST_SHIFT) & ENA_ETH_IO_RX_CDESC_BASE_FIRST_MASK;
+}
+
+static inline uint32_t get_ena_eth_io_rx_cdesc_base_last(const struct ena_eth_io_rx_cdesc_base *p)
+{
+	return (p->status & ENA_ETH_IO_RX_CDESC_BASE_LAST_MASK) >> ENA_ETH_IO_RX_CDESC_BASE_LAST_SHIFT;
+}
+
+static inline void set_ena_eth_io_rx_cdesc_base_last(struct ena_eth_io_rx_cdesc_base *p, uint32_t val)
+{
+	p->status |= (val << ENA_ETH_IO_RX_CDESC_BASE_LAST_SHIFT) & ENA_ETH_IO_RX_CDESC_BASE_LAST_MASK;
+}
+
+static inline uint32_t get_ena_eth_io_rx_cdesc_base_buffer(const struct ena_eth_io_rx_cdesc_base *p)
+{
+	return (p->status & ENA_ETH_IO_RX_CDESC_BASE_BUFFER_MASK) >> ENA_ETH_IO_RX_CDESC_BASE_BUFFER_SHIFT;
+}
+
+static inline void set_ena_eth_io_rx_cdesc_base_buffer(struct ena_eth_io_rx_cdesc_base *p, uint32_t val)
+{
+	p->status |= (val << ENA_ETH_IO_RX_CDESC_BASE_BUFFER_SHIFT) & ENA_ETH_IO_RX_CDESC_BASE_BUFFER_MASK;
+}
+
+static inline uint32_t get_ena_eth_io_intr_reg_rx_intr_delay(const struct ena_eth_io_intr_reg *p)
+{
+	return p->intr_control & ENA_ETH_IO_INTR_REG_RX_INTR_DELAY_MASK;
+}
+
+static inline void set_ena_eth_io_intr_reg_rx_intr_delay(struct ena_eth_io_intr_reg *p, uint32_t val)
+{
+	p->intr_control |= val & ENA_ETH_IO_INTR_REG_RX_INTR_DELAY_MASK;
+}
+
+static inline uint32_t get_ena_eth_io_intr_reg_tx_intr_delay(const struct ena_eth_io_intr_reg *p)
+{
+	return (p->intr_control & ENA_ETH_IO_INTR_REG_TX_INTR_DELAY_MASK) >> ENA_ETH_IO_INTR_REG_TX_INTR_DELAY_SHIFT;
+}
+
+static inline void set_ena_eth_io_intr_reg_tx_intr_delay(struct ena_eth_io_intr_reg *p, uint32_t val)
+{
+	p->intr_control |= (val << ENA_ETH_IO_INTR_REG_TX_INTR_DELAY_SHIFT) & ENA_ETH_IO_INTR_REG_TX_INTR_DELAY_MASK;
+}
+
+static inline uint32_t get_ena_eth_io_intr_reg_intr_unmask(const struct ena_eth_io_intr_reg *p)
+{
+	return (p->intr_control & ENA_ETH_IO_INTR_REG_INTR_UNMASK_MASK) >> ENA_ETH_IO_INTR_REG_INTR_UNMASK_SHIFT;
+}
+
+static inline void set_ena_eth_io_intr_reg_intr_unmask(struct ena_eth_io_intr_reg *p, uint32_t val)
+{
+	p->intr_control |= (val << ENA_ETH_IO_INTR_REG_INTR_UNMASK_SHIFT) & ENA_ETH_IO_INTR_REG_INTR_UNMASK_MASK;
+}
+
+static inline uint32_t get_ena_eth_io_numa_node_cfg_reg_numa(const struct ena_eth_io_numa_node_cfg_reg *p)
+{
+	return p->numa_cfg & ENA_ETH_IO_NUMA_NODE_CFG_REG_NUMA_MASK;
+}
+
+static inline void set_ena_eth_io_numa_node_cfg_reg_numa(struct ena_eth_io_numa_node_cfg_reg *p, uint32_t val)
+{
+	p->numa_cfg |= val & ENA_ETH_IO_NUMA_NODE_CFG_REG_NUMA_MASK;
+}
+
+static inline uint32_t get_ena_eth_io_numa_node_cfg_reg_enabled(const struct ena_eth_io_numa_node_cfg_reg *p)
+{
+	return (p->numa_cfg & ENA_ETH_IO_NUMA_NODE_CFG_REG_ENABLED_MASK) >> ENA_ETH_IO_NUMA_NODE_CFG_REG_ENABLED_SHIFT;
+}
+
+static inline void set_ena_eth_io_numa_node_cfg_reg_enabled(struct ena_eth_io_numa_node_cfg_reg *p, uint32_t val)
+{
+	p->numa_cfg |= (val << ENA_ETH_IO_NUMA_NODE_CFG_REG_ENABLED_SHIFT) & ENA_ETH_IO_NUMA_NODE_CFG_REG_ENABLED_MASK;
+}
+
+#endif /* !defined(DEFS_LINUX_MAINLINE) */
+#endif /* _ENA_ETH_IO_H_ */

--- a/kernel/macOS/ena/ena_com/ena_defs/ena_gen_info.h
+++ b/kernel/macOS/ena/ena_com/ena_defs/ena_gen_info.h
@@ -1,0 +1,4 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+#define	ENA_GEN_DATE	"Fri Sep 18 17:09:00 IDT 2020"
+#define	ENA_GEN_COMMIT	"0f80d82"

--- a/kernel/macOS/ena/ena_com/ena_defs/ena_includes.h
+++ b/kernel/macOS/ena/ena_com/ena_defs/ena_includes.h
@@ -1,0 +1,4 @@
+#include "ena_common_defs.h"
+#include "ena_regs_defs.h"
+#include "ena_admin_defs.h"
+#include "ena_eth_io_defs.h"

--- a/kernel/macOS/ena/ena_com/ena_defs/ena_regs_defs.h
+++ b/kernel/macOS/ena/ena_com/ena_defs/ena_regs_defs.h
@@ -1,0 +1,129 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+#ifndef _ENA_REGS_H_
+#define _ENA_REGS_H_
+
+enum ena_regs_reset_reason_types {
+	ENA_REGS_RESET_NORMAL                       = 0,
+	ENA_REGS_RESET_KEEP_ALIVE_TO                = 1,
+	ENA_REGS_RESET_ADMIN_TO                     = 2,
+	ENA_REGS_RESET_MISS_TX_CMPL                 = 3,
+	ENA_REGS_RESET_INV_RX_REQ_ID                = 4,
+	ENA_REGS_RESET_INV_TX_REQ_ID                = 5,
+	ENA_REGS_RESET_TOO_MANY_RX_DESCS            = 6,
+	ENA_REGS_RESET_INIT_ERR                     = 7,
+	ENA_REGS_RESET_DRIVER_INVALID_STATE         = 8,
+	ENA_REGS_RESET_OS_TRIGGER                   = 9,
+	ENA_REGS_RESET_OS_NETDEV_WD                 = 10,
+	ENA_REGS_RESET_SHUTDOWN                     = 11,
+	ENA_REGS_RESET_USER_TRIGGER                 = 12,
+	ENA_REGS_RESET_GENERIC                      = 13,
+	ENA_REGS_RESET_MISS_INTERRUPT               = 14,
+	ENA_REGS_RESET_LAST,
+};
+
+/* ena_registers offsets */
+
+/* 0 base */
+#define ENA_REGS_VERSION_OFF                                0x0
+#define ENA_REGS_CONTROLLER_VERSION_OFF                     0x4
+#define ENA_REGS_CAPS_OFF                                   0x8
+#define ENA_REGS_CAPS_EXT_OFF                               0xc
+#define ENA_REGS_AQ_BASE_LO_OFF                             0x10
+#define ENA_REGS_AQ_BASE_HI_OFF                             0x14
+#define ENA_REGS_AQ_CAPS_OFF                                0x18
+#define ENA_REGS_ACQ_BASE_LO_OFF                            0x20
+#define ENA_REGS_ACQ_BASE_HI_OFF                            0x24
+#define ENA_REGS_ACQ_CAPS_OFF                               0x28
+#define ENA_REGS_AQ_DB_OFF                                  0x2c
+#define ENA_REGS_ACQ_TAIL_OFF                               0x30
+#define ENA_REGS_AENQ_CAPS_OFF                              0x34
+#define ENA_REGS_AENQ_BASE_LO_OFF                           0x38
+#define ENA_REGS_AENQ_BASE_HI_OFF                           0x3c
+#define ENA_REGS_AENQ_HEAD_DB_OFF                           0x40
+#define ENA_REGS_AENQ_TAIL_OFF                              0x44
+#define ENA_REGS_INTR_MASK_OFF                              0x4c
+#define ENA_REGS_DEV_CTL_OFF                                0x54
+#define ENA_REGS_DEV_STS_OFF                                0x58
+#define ENA_REGS_MMIO_REG_READ_OFF                          0x5c
+#define ENA_REGS_MMIO_RESP_LO_OFF                           0x60
+#define ENA_REGS_MMIO_RESP_HI_OFF                           0x64
+#define ENA_REGS_RSS_IND_ENTRY_UPDATE_OFF                   0x68
+
+/* version register */
+#define ENA_REGS_VERSION_MINOR_VERSION_MASK                 0xff
+#define ENA_REGS_VERSION_MAJOR_VERSION_SHIFT                8
+#define ENA_REGS_VERSION_MAJOR_VERSION_MASK                 0xff00
+
+/* controller_version register */
+#define ENA_REGS_CONTROLLER_VERSION_SUBMINOR_VERSION_MASK   0xff
+#define ENA_REGS_CONTROLLER_VERSION_MINOR_VERSION_SHIFT     8
+#define ENA_REGS_CONTROLLER_VERSION_MINOR_VERSION_MASK      0xff00
+#define ENA_REGS_CONTROLLER_VERSION_MAJOR_VERSION_SHIFT     16
+#define ENA_REGS_CONTROLLER_VERSION_MAJOR_VERSION_MASK      0xff0000
+#define ENA_REGS_CONTROLLER_VERSION_IMPL_ID_SHIFT           24
+#define ENA_REGS_CONTROLLER_VERSION_IMPL_ID_MASK            0xff000000
+
+/* caps register */
+#define ENA_REGS_CAPS_CONTIGUOUS_QUEUE_REQUIRED_MASK        0x1
+#define ENA_REGS_CAPS_RESET_TIMEOUT_SHIFT                   1
+#define ENA_REGS_CAPS_RESET_TIMEOUT_MASK                    0x3e
+#define ENA_REGS_CAPS_DMA_ADDR_WIDTH_SHIFT                  8
+#define ENA_REGS_CAPS_DMA_ADDR_WIDTH_MASK                   0xff00
+#define ENA_REGS_CAPS_ADMIN_CMD_TO_SHIFT                    16
+#define ENA_REGS_CAPS_ADMIN_CMD_TO_MASK                     0xf0000
+
+/* aq_caps register */
+#define ENA_REGS_AQ_CAPS_AQ_DEPTH_MASK                      0xffff
+#define ENA_REGS_AQ_CAPS_AQ_ENTRY_SIZE_SHIFT                16
+#define ENA_REGS_AQ_CAPS_AQ_ENTRY_SIZE_MASK                 0xffff0000
+
+/* acq_caps register */
+#define ENA_REGS_ACQ_CAPS_ACQ_DEPTH_MASK                    0xffff
+#define ENA_REGS_ACQ_CAPS_ACQ_ENTRY_SIZE_SHIFT              16
+#define ENA_REGS_ACQ_CAPS_ACQ_ENTRY_SIZE_MASK               0xffff0000
+
+/* aenq_caps register */
+#define ENA_REGS_AENQ_CAPS_AENQ_DEPTH_MASK                  0xffff
+#define ENA_REGS_AENQ_CAPS_AENQ_ENTRY_SIZE_SHIFT            16
+#define ENA_REGS_AENQ_CAPS_AENQ_ENTRY_SIZE_MASK             0xffff0000
+
+/* dev_ctl register */
+#define ENA_REGS_DEV_CTL_DEV_RESET_MASK                     0x1
+#define ENA_REGS_DEV_CTL_AQ_RESTART_SHIFT                   1
+#define ENA_REGS_DEV_CTL_AQ_RESTART_MASK                    0x2
+#define ENA_REGS_DEV_CTL_QUIESCENT_SHIFT                    2
+#define ENA_REGS_DEV_CTL_QUIESCENT_MASK                     0x4
+#define ENA_REGS_DEV_CTL_IO_RESUME_SHIFT                    3
+#define ENA_REGS_DEV_CTL_IO_RESUME_MASK                     0x8
+#define ENA_REGS_DEV_CTL_RESET_REASON_SHIFT                 28
+#define ENA_REGS_DEV_CTL_RESET_REASON_MASK                  0xf0000000
+
+/* dev_sts register */
+#define ENA_REGS_DEV_STS_READY_MASK                         0x1
+#define ENA_REGS_DEV_STS_AQ_RESTART_IN_PROGRESS_SHIFT       1
+#define ENA_REGS_DEV_STS_AQ_RESTART_IN_PROGRESS_MASK        0x2
+#define ENA_REGS_DEV_STS_AQ_RESTART_FINISHED_SHIFT          2
+#define ENA_REGS_DEV_STS_AQ_RESTART_FINISHED_MASK           0x4
+#define ENA_REGS_DEV_STS_RESET_IN_PROGRESS_SHIFT            3
+#define ENA_REGS_DEV_STS_RESET_IN_PROGRESS_MASK             0x8
+#define ENA_REGS_DEV_STS_RESET_FINISHED_SHIFT               4
+#define ENA_REGS_DEV_STS_RESET_FINISHED_MASK                0x10
+#define ENA_REGS_DEV_STS_FATAL_ERROR_SHIFT                  5
+#define ENA_REGS_DEV_STS_FATAL_ERROR_MASK                   0x20
+#define ENA_REGS_DEV_STS_QUIESCENT_STATE_IN_PROGRESS_SHIFT  6
+#define ENA_REGS_DEV_STS_QUIESCENT_STATE_IN_PROGRESS_MASK   0x40
+#define ENA_REGS_DEV_STS_QUIESCENT_STATE_ACHIEVED_SHIFT     7
+#define ENA_REGS_DEV_STS_QUIESCENT_STATE_ACHIEVED_MASK      0x80
+
+/* mmio_reg_read register */
+#define ENA_REGS_MMIO_REG_READ_REQ_ID_MASK                  0xffff
+#define ENA_REGS_MMIO_REG_READ_REG_OFF_SHIFT                16
+#define ENA_REGS_MMIO_REG_READ_REG_OFF_MASK                 0xffff0000
+
+/* rss_ind_entry_update register */
+#define ENA_REGS_RSS_IND_ENTRY_UPDATE_INDEX_MASK            0xffff
+#define ENA_REGS_RSS_IND_ENTRY_UPDATE_CQ_IDX_SHIFT          16
+#define ENA_REGS_RSS_IND_ENTRY_UPDATE_CQ_IDX_MASK           0xffff0000
+
+#endif /* _ENA_REGS_H_ */

--- a/kernel/macOS/ena/ena_com/ena_eth_com.c
+++ b/kernel/macOS/ena/ena_com/ena_eth_com.c
@@ -1,0 +1,651 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+#include "ena_eth_com.h"
+
+static struct ena_eth_io_rx_cdesc_base *ena_com_get_next_rx_cdesc(
+	struct ena_com_io_cq *io_cq)
+{
+	struct ena_eth_io_rx_cdesc_base *cdesc;
+	u16 expected_phase, head_masked;
+	u16 desc_phase;
+
+	head_masked = io_cq->head & (io_cq->q_depth - 1);
+	expected_phase = io_cq->phase;
+
+	cdesc = (struct ena_eth_io_rx_cdesc_base *)(io_cq->cdesc_addr.virt_addr
+			+ (head_masked * io_cq->cdesc_entry_size_in_bytes));
+
+	desc_phase = (READ_ONCE32(cdesc->status) & ENA_ETH_IO_RX_CDESC_BASE_PHASE_MASK) >>
+			ENA_ETH_IO_RX_CDESC_BASE_PHASE_SHIFT;
+
+	if (desc_phase != expected_phase)
+		return NULL;
+
+	/* Make sure we read the rest of the descriptor after the phase bit
+	 * has been read
+	 */
+	dma_rmb();
+
+	return cdesc;
+}
+
+static void *get_sq_desc_regular_queue(struct ena_com_io_sq *io_sq)
+{
+	u16 tail_masked;
+	u32 offset;
+
+	tail_masked = io_sq->tail & (io_sq->q_depth - 1);
+
+	offset = tail_masked * io_sq->desc_entry_size;
+
+	return (void *)((uintptr_t)io_sq->desc_addr.virt_addr + offset);
+}
+
+static int ena_com_write_bounce_buffer_to_dev(struct ena_com_io_sq *io_sq,
+						     u8 *bounce_buffer)
+{
+	struct ena_com_llq_info *llq_info = &io_sq->llq_info;
+
+	u16 dst_tail_mask;
+	u32 dst_offset;
+
+	dst_tail_mask = io_sq->tail & (io_sq->q_depth - 1);
+	dst_offset = dst_tail_mask * llq_info->desc_list_entry_size;
+
+	if (is_llq_max_tx_burst_exists(io_sq)) {
+		if (unlikely(!io_sq->entries_in_tx_burst_left)) {
+			ena_trc_err(ena_com_io_sq_to_ena_dev(io_sq),
+				    "Error: trying to send more packets than tx burst allows\n");
+			return ENA_COM_NO_SPACE;
+		}
+
+		io_sq->entries_in_tx_burst_left--;
+		ena_trc_dbg(ena_com_io_sq_to_ena_dev(io_sq),
+			    "Decreasing entries_in_tx_burst_left of queue %d to %d\n",
+			    io_sq->qid, io_sq->entries_in_tx_burst_left);
+	}
+
+	/* Make sure everything was written into the bounce buffer before
+	 * writing the bounce buffer to the device
+	 */
+	wmb();
+
+	/* The line is completed. Copy it to dev */
+	ENA_MEMCPY_TO_DEVICE_64(io_sq->desc_addr.pbuf_dev_addr + dst_offset,
+				bounce_buffer,
+				llq_info->desc_list_entry_size);
+
+	io_sq->tail++;
+
+	/* Switch phase bit in case of wrap around */
+	if (unlikely((io_sq->tail & (io_sq->q_depth - 1)) == 0))
+		io_sq->phase ^= 1;
+
+	return ENA_COM_OK;
+}
+
+static int ena_com_write_header_to_bounce(struct ena_com_io_sq *io_sq,
+						 u8 *header_src,
+						 u16 header_len)
+{
+	struct ena_com_llq_pkt_ctrl *pkt_ctrl = &io_sq->llq_buf_ctrl;
+	struct ena_com_llq_info *llq_info = &io_sq->llq_info;
+	u8 *bounce_buffer = pkt_ctrl->curr_bounce_buf;
+	u16 header_offset;
+
+	if (unlikely(io_sq->mem_queue_type == ENA_ADMIN_PLACEMENT_POLICY_HOST))
+		return 0;
+
+	header_offset =
+		llq_info->descs_num_before_header * io_sq->desc_entry_size;
+
+	if (unlikely((header_offset + header_len) >  llq_info->desc_list_entry_size)) {
+		ena_trc_err(ena_com_io_sq_to_ena_dev(io_sq),
+			    "Trying to write header larger than llq entry can accommodate\n");
+		return ENA_COM_FAULT;
+	}
+
+	if (unlikely(!bounce_buffer)) {
+		ena_trc_err(ena_com_io_sq_to_ena_dev(io_sq),
+			    "Bounce buffer is NULL\n");
+		return ENA_COM_FAULT;
+	}
+
+	memcpy(bounce_buffer + header_offset, header_src, header_len);
+
+	return 0;
+}
+
+static void *get_sq_desc_llq(struct ena_com_io_sq *io_sq)
+{
+	struct ena_com_llq_pkt_ctrl *pkt_ctrl = &io_sq->llq_buf_ctrl;
+	u8 *bounce_buffer;
+	void *sq_desc;
+
+	bounce_buffer = pkt_ctrl->curr_bounce_buf;
+
+	if (unlikely(!bounce_buffer)) {
+		ena_trc_err(ena_com_io_sq_to_ena_dev(io_sq),
+			    "Bounce buffer is NULL\n");
+		return NULL;
+	}
+
+	sq_desc = bounce_buffer + pkt_ctrl->idx * io_sq->desc_entry_size;
+	pkt_ctrl->idx++;
+	pkt_ctrl->descs_left_in_line--;
+
+	return sq_desc;
+}
+
+static int ena_com_close_bounce_buffer(struct ena_com_io_sq *io_sq)
+{
+	struct ena_com_llq_pkt_ctrl *pkt_ctrl = &io_sq->llq_buf_ctrl;
+	struct ena_com_llq_info *llq_info = &io_sq->llq_info;
+	int rc;
+
+	if (unlikely(io_sq->mem_queue_type == ENA_ADMIN_PLACEMENT_POLICY_HOST))
+		return ENA_COM_OK;
+
+	/* bounce buffer was used, so write it and get a new one */
+	if (pkt_ctrl->idx) {
+		rc = ena_com_write_bounce_buffer_to_dev(io_sq,
+							pkt_ctrl->curr_bounce_buf);
+		if (unlikely(rc)) {
+			ena_trc_err(ena_com_io_sq_to_ena_dev(io_sq),
+				    "Failed to write bounce buffer to device\n");
+			return rc;
+		}
+
+		pkt_ctrl->curr_bounce_buf =
+			ena_com_get_next_bounce_buffer(&io_sq->bounce_buf_ctrl);
+		memset(io_sq->llq_buf_ctrl.curr_bounce_buf,
+		       0x0, llq_info->desc_list_entry_size);
+	}
+
+	pkt_ctrl->idx = 0;
+	pkt_ctrl->descs_left_in_line = llq_info->descs_num_before_header;
+	return ENA_COM_OK;
+}
+
+static void *get_sq_desc(struct ena_com_io_sq *io_sq)
+{
+	if (io_sq->mem_queue_type == ENA_ADMIN_PLACEMENT_POLICY_DEV)
+		return get_sq_desc_llq(io_sq);
+
+	return get_sq_desc_regular_queue(io_sq);
+}
+
+static int ena_com_sq_update_llq_tail(struct ena_com_io_sq *io_sq)
+{
+	struct ena_com_llq_pkt_ctrl *pkt_ctrl = &io_sq->llq_buf_ctrl;
+	struct ena_com_llq_info *llq_info = &io_sq->llq_info;
+	int rc;
+
+	if (!pkt_ctrl->descs_left_in_line) {
+		rc = ena_com_write_bounce_buffer_to_dev(io_sq,
+							pkt_ctrl->curr_bounce_buf);
+		if (unlikely(rc)) {
+			ena_trc_err(ena_com_io_sq_to_ena_dev(io_sq),
+				    "Failed to write bounce buffer to device\n");
+			return rc;
+		}
+
+		pkt_ctrl->curr_bounce_buf =
+			ena_com_get_next_bounce_buffer(&io_sq->bounce_buf_ctrl);
+		memset(io_sq->llq_buf_ctrl.curr_bounce_buf,
+		       0x0, llq_info->desc_list_entry_size);
+
+		pkt_ctrl->idx = 0;
+		if (unlikely(llq_info->desc_stride_ctrl == ENA_ADMIN_SINGLE_DESC_PER_ENTRY))
+			pkt_ctrl->descs_left_in_line = 1;
+		else
+			pkt_ctrl->descs_left_in_line =
+			llq_info->desc_list_entry_size / io_sq->desc_entry_size;
+	}
+
+	return ENA_COM_OK;
+}
+
+static int ena_com_sq_update_tail(struct ena_com_io_sq *io_sq)
+{
+	if (io_sq->mem_queue_type == ENA_ADMIN_PLACEMENT_POLICY_DEV)
+		return ena_com_sq_update_llq_tail(io_sq);
+
+	io_sq->tail++;
+
+	/* Switch phase bit in case of wrap around */
+	if (unlikely((io_sq->tail & (io_sq->q_depth - 1)) == 0))
+		io_sq->phase ^= 1;
+
+	return ENA_COM_OK;
+}
+
+static struct ena_eth_io_rx_cdesc_base *
+	ena_com_rx_cdesc_idx_to_ptr(struct ena_com_io_cq *io_cq, u16 idx)
+{
+	idx &= (io_cq->q_depth - 1);
+	return (struct ena_eth_io_rx_cdesc_base *)
+		((uintptr_t)io_cq->cdesc_addr.virt_addr +
+		idx * io_cq->cdesc_entry_size_in_bytes);
+}
+
+static u16 ena_com_cdesc_rx_pkt_get(struct ena_com_io_cq *io_cq,
+					   u16 *first_cdesc_idx)
+{
+	struct ena_eth_io_rx_cdesc_base *cdesc;
+	u16 count = 0, head_masked;
+	u32 last = 0;
+
+	do {
+		cdesc = ena_com_get_next_rx_cdesc(io_cq);
+		if (!cdesc)
+			break;
+
+		ena_com_cq_inc_head(io_cq);
+		count++;
+		last = (READ_ONCE32(cdesc->status) & ENA_ETH_IO_RX_CDESC_BASE_LAST_MASK) >>
+			ENA_ETH_IO_RX_CDESC_BASE_LAST_SHIFT;
+	} while (!last);
+
+	if (last) {
+		*first_cdesc_idx = io_cq->cur_rx_pkt_cdesc_start_idx;
+		count += io_cq->cur_rx_pkt_cdesc_count;
+
+		head_masked = io_cq->head & (io_cq->q_depth - 1);
+
+		io_cq->cur_rx_pkt_cdesc_count = 0;
+		io_cq->cur_rx_pkt_cdesc_start_idx = head_masked;
+
+		ena_trc_dbg(ena_com_io_cq_to_ena_dev(io_cq),
+			    "ENA q_id: %d packets were completed. first desc idx %u descs# %d\n",
+			    io_cq->qid, *first_cdesc_idx, count);
+	} else {
+		io_cq->cur_rx_pkt_cdesc_count += count;
+		count = 0;
+	}
+
+	return count;
+}
+
+static int ena_com_create_meta(struct ena_com_io_sq *io_sq,
+			       struct ena_com_tx_meta *ena_meta)
+{
+	struct ena_eth_io_tx_meta_desc *meta_desc = NULL;
+
+	meta_desc = get_sq_desc(io_sq);
+	if (unlikely(!meta_desc))
+		return ENA_COM_FAULT;
+
+	memset(meta_desc, 0x0, sizeof(struct ena_eth_io_tx_meta_desc));
+
+	meta_desc->len_ctrl |= ENA_ETH_IO_TX_META_DESC_META_DESC_MASK;
+
+	meta_desc->len_ctrl |= ENA_ETH_IO_TX_META_DESC_EXT_VALID_MASK;
+
+	/* bits 0-9 of the mss */
+	meta_desc->word2 |= ((u32)ena_meta->mss <<
+		ENA_ETH_IO_TX_META_DESC_MSS_LO_SHIFT) &
+		ENA_ETH_IO_TX_META_DESC_MSS_LO_MASK;
+	/* bits 10-13 of the mss */
+	meta_desc->len_ctrl |= ((ena_meta->mss >> 10) <<
+		ENA_ETH_IO_TX_META_DESC_MSS_HI_SHIFT) &
+		ENA_ETH_IO_TX_META_DESC_MSS_HI_MASK;
+
+	/* Extended meta desc */
+	meta_desc->len_ctrl |= ENA_ETH_IO_TX_META_DESC_ETH_META_TYPE_MASK;
+	meta_desc->len_ctrl |= ((u32)io_sq->phase <<
+		ENA_ETH_IO_TX_META_DESC_PHASE_SHIFT) &
+		ENA_ETH_IO_TX_META_DESC_PHASE_MASK;
+
+	meta_desc->len_ctrl |= ENA_ETH_IO_TX_META_DESC_FIRST_MASK;
+	meta_desc->len_ctrl |= ENA_ETH_IO_TX_META_DESC_META_STORE_MASK;
+
+	meta_desc->word2 |= ena_meta->l3_hdr_len &
+		ENA_ETH_IO_TX_META_DESC_L3_HDR_LEN_MASK;
+	meta_desc->word2 |= (ena_meta->l3_hdr_offset <<
+		ENA_ETH_IO_TX_META_DESC_L3_HDR_OFF_SHIFT) &
+		ENA_ETH_IO_TX_META_DESC_L3_HDR_OFF_MASK;
+
+	meta_desc->word2 |= ((u32)ena_meta->l4_hdr_len <<
+		ENA_ETH_IO_TX_META_DESC_L4_HDR_LEN_IN_WORDS_SHIFT) &
+		ENA_ETH_IO_TX_META_DESC_L4_HDR_LEN_IN_WORDS_MASK;
+
+	return ena_com_sq_update_tail(io_sq);
+}
+
+static int ena_com_create_and_store_tx_meta_desc(struct ena_com_io_sq *io_sq,
+						 struct ena_com_tx_ctx *ena_tx_ctx,
+						 bool *have_meta)
+{
+	struct ena_com_tx_meta *ena_meta = &ena_tx_ctx->ena_meta;
+
+	/* When disable meta caching is set, don't bother to save the meta and
+	 * compare it to the stored version, just create the meta
+	 */
+	if (io_sq->disable_meta_caching) {
+		if (unlikely(!ena_tx_ctx->meta_valid))
+			return ENA_COM_INVAL;
+
+		*have_meta = true;
+		return ena_com_create_meta(io_sq, ena_meta);
+	}
+
+	if (ena_com_meta_desc_changed(io_sq, ena_tx_ctx)) {
+		*have_meta = true;
+		/* Cache the meta desc */
+		memcpy(&io_sq->cached_tx_meta, ena_meta,
+		       sizeof(struct ena_com_tx_meta));
+		return ena_com_create_meta(io_sq, ena_meta);
+	}
+
+	*have_meta = false;
+	return ENA_COM_OK;
+}
+
+static void ena_com_rx_set_flags(struct ena_com_io_cq *io_cq,
+				 struct ena_com_rx_ctx *ena_rx_ctx,
+				 struct ena_eth_io_rx_cdesc_base *cdesc)
+{
+	ena_rx_ctx->l3_proto = cdesc->status &
+		ENA_ETH_IO_RX_CDESC_BASE_L3_PROTO_IDX_MASK;
+	ena_rx_ctx->l4_proto =
+		(cdesc->status & ENA_ETH_IO_RX_CDESC_BASE_L4_PROTO_IDX_MASK) >>
+		ENA_ETH_IO_RX_CDESC_BASE_L4_PROTO_IDX_SHIFT;
+	ena_rx_ctx->l3_csum_err =
+		!!((cdesc->status & ENA_ETH_IO_RX_CDESC_BASE_L3_CSUM_ERR_MASK) >>
+		ENA_ETH_IO_RX_CDESC_BASE_L3_CSUM_ERR_SHIFT);
+	ena_rx_ctx->l4_csum_err =
+		!!((cdesc->status & ENA_ETH_IO_RX_CDESC_BASE_L4_CSUM_ERR_MASK) >>
+		ENA_ETH_IO_RX_CDESC_BASE_L4_CSUM_ERR_SHIFT);
+	ena_rx_ctx->l4_csum_checked =
+		!!((cdesc->status & ENA_ETH_IO_RX_CDESC_BASE_L4_CSUM_CHECKED_MASK) >>
+		ENA_ETH_IO_RX_CDESC_BASE_L4_CSUM_CHECKED_SHIFT);
+	ena_rx_ctx->hash = cdesc->hash;
+	ena_rx_ctx->frag =
+		(cdesc->status & ENA_ETH_IO_RX_CDESC_BASE_IPV4_FRAG_MASK) >>
+		ENA_ETH_IO_RX_CDESC_BASE_IPV4_FRAG_SHIFT;
+
+	ena_trc_dbg(ena_com_io_cq_to_ena_dev(io_cq),
+		    "l3_proto %d l4_proto %d l3_csum_err %d l4_csum_err %d hash %d frag %d cdesc_status %x\n",
+		    ena_rx_ctx->l3_proto,
+		    ena_rx_ctx->l4_proto,
+		    ena_rx_ctx->l3_csum_err,
+		    ena_rx_ctx->l4_csum_err,
+		    ena_rx_ctx->hash,
+		    ena_rx_ctx->frag,
+		    cdesc->status);
+}
+
+/*****************************************************************************/
+/*****************************     API      **********************************/
+/*****************************************************************************/
+
+int ena_com_prepare_tx(struct ena_com_io_sq *io_sq,
+		       struct ena_com_tx_ctx *ena_tx_ctx,
+		       int *nb_hw_desc)
+{
+	struct ena_eth_io_tx_desc *desc = NULL;
+	struct ena_com_buf *ena_bufs = ena_tx_ctx->ena_bufs;
+	void *buffer_to_push = ena_tx_ctx->push_header;
+	u16 header_len = ena_tx_ctx->header_len;
+	u16 num_bufs = ena_tx_ctx->num_bufs;
+	u16 start_tail = io_sq->tail;
+	int i, rc;
+	bool have_meta;
+	u64 addr_hi;
+
+	ENA_WARN(io_sq->direction != ENA_COM_IO_QUEUE_DIRECTION_TX,
+		 ena_com_io_sq_to_ena_dev(io_sq), "wrong Q type");
+
+	/* num_bufs +1 for potential meta desc */
+	if (unlikely(!ena_com_sq_have_enough_space(io_sq, num_bufs + 1))) {
+		ena_trc_dbg(ena_com_io_sq_to_ena_dev(io_sq),
+			    "Not enough space in the tx queue\n");
+		return ENA_COM_NO_MEM;
+	}
+
+	if (unlikely(header_len > io_sq->tx_max_header_size)) {
+		ena_trc_err(ena_com_io_sq_to_ena_dev(io_sq),
+			    "Header size is too large %d max header: %d\n",
+			    header_len, io_sq->tx_max_header_size);
+		return ENA_COM_INVAL;
+	}
+
+	if (unlikely(io_sq->mem_queue_type == ENA_ADMIN_PLACEMENT_POLICY_DEV
+		     && !buffer_to_push)) {
+		ena_trc_err(ena_com_io_sq_to_ena_dev(io_sq),
+			    "Push header wasn't provided on LLQ mode\n");
+		return ENA_COM_INVAL;
+	}
+
+	rc = ena_com_write_header_to_bounce(io_sq, buffer_to_push, header_len);
+	if (unlikely(rc))
+		return rc;
+
+	rc = ena_com_create_and_store_tx_meta_desc(io_sq, ena_tx_ctx, &have_meta);
+	if (unlikely(rc)) {
+		ena_trc_err(ena_com_io_sq_to_ena_dev(io_sq),
+			    "Failed to create and store tx meta desc\n");
+		return rc;
+	}
+
+	/* If the caller doesn't want to send packets */
+	if (unlikely(!num_bufs && !header_len)) {
+		rc = ena_com_close_bounce_buffer(io_sq);
+		if (rc)
+			ena_trc_err(ena_com_io_sq_to_ena_dev(io_sq),
+				    "Failed to write buffers to LLQ\n");
+		*nb_hw_desc = io_sq->tail - start_tail;
+		return rc;
+	}
+
+	desc = get_sq_desc(io_sq);
+	if (unlikely(!desc))
+		return ENA_COM_FAULT;
+	memset(desc, 0x0, sizeof(struct ena_eth_io_tx_desc));
+
+	/* Set first desc when we don't have meta descriptor */
+	if (!have_meta)
+		desc->len_ctrl |= ENA_ETH_IO_TX_DESC_FIRST_MASK;
+
+	desc->buff_addr_hi_hdr_sz |= ((u32)header_len <<
+		ENA_ETH_IO_TX_DESC_HEADER_LENGTH_SHIFT) &
+		ENA_ETH_IO_TX_DESC_HEADER_LENGTH_MASK;
+	desc->len_ctrl |= ((u32)io_sq->phase << ENA_ETH_IO_TX_DESC_PHASE_SHIFT) &
+		ENA_ETH_IO_TX_DESC_PHASE_MASK;
+
+	desc->len_ctrl |= ENA_ETH_IO_TX_DESC_COMP_REQ_MASK;
+
+	/* Bits 0-9 */
+	desc->meta_ctrl |= ((u32)ena_tx_ctx->req_id <<
+		ENA_ETH_IO_TX_DESC_REQ_ID_LO_SHIFT) &
+		ENA_ETH_IO_TX_DESC_REQ_ID_LO_MASK;
+
+	desc->meta_ctrl |= (ena_tx_ctx->df <<
+		ENA_ETH_IO_TX_DESC_DF_SHIFT) &
+		ENA_ETH_IO_TX_DESC_DF_MASK;
+
+	/* Bits 10-15 */
+	desc->len_ctrl |= ((ena_tx_ctx->req_id >> 10) <<
+		ENA_ETH_IO_TX_DESC_REQ_ID_HI_SHIFT) &
+		ENA_ETH_IO_TX_DESC_REQ_ID_HI_MASK;
+
+	if (ena_tx_ctx->meta_valid) {
+		desc->meta_ctrl |= (ena_tx_ctx->tso_enable <<
+			ENA_ETH_IO_TX_DESC_TSO_EN_SHIFT) &
+			ENA_ETH_IO_TX_DESC_TSO_EN_MASK;
+		desc->meta_ctrl |= ena_tx_ctx->l3_proto &
+			ENA_ETH_IO_TX_DESC_L3_PROTO_IDX_MASK;
+		desc->meta_ctrl |= (ena_tx_ctx->l4_proto <<
+			ENA_ETH_IO_TX_DESC_L4_PROTO_IDX_SHIFT) &
+			ENA_ETH_IO_TX_DESC_L4_PROTO_IDX_MASK;
+		desc->meta_ctrl |= (ena_tx_ctx->l3_csum_enable <<
+			ENA_ETH_IO_TX_DESC_L3_CSUM_EN_SHIFT) &
+			ENA_ETH_IO_TX_DESC_L3_CSUM_EN_MASK;
+		desc->meta_ctrl |= (ena_tx_ctx->l4_csum_enable <<
+			ENA_ETH_IO_TX_DESC_L4_CSUM_EN_SHIFT) &
+			ENA_ETH_IO_TX_DESC_L4_CSUM_EN_MASK;
+		desc->meta_ctrl |= (ena_tx_ctx->l4_csum_partial <<
+			ENA_ETH_IO_TX_DESC_L4_CSUM_PARTIAL_SHIFT) &
+			ENA_ETH_IO_TX_DESC_L4_CSUM_PARTIAL_MASK;
+	}
+
+	for (i = 0; i < num_bufs; i++) {
+		/* The first desc share the same desc as the header */
+		if (likely(i != 0)) {
+			rc = ena_com_sq_update_tail(io_sq);
+			if (unlikely(rc)) {
+				ena_trc_err(ena_com_io_sq_to_ena_dev(io_sq),
+					    "Failed to update sq tail\n");
+				return rc;
+			}
+
+			desc = get_sq_desc(io_sq);
+			if (unlikely(!desc))
+				return ENA_COM_FAULT;
+
+			memset(desc, 0x0, sizeof(struct ena_eth_io_tx_desc));
+
+			desc->len_ctrl |= ((u32)io_sq->phase <<
+				ENA_ETH_IO_TX_DESC_PHASE_SHIFT) &
+				ENA_ETH_IO_TX_DESC_PHASE_MASK;
+		}
+
+		desc->len_ctrl |= ena_bufs->len &
+			ENA_ETH_IO_TX_DESC_LENGTH_MASK;
+
+		addr_hi = ((ena_bufs->paddr &
+			GENMASK_ULL(io_sq->dma_addr_bits - 1, 32)) >> 32);
+
+		desc->buff_addr_lo = (u32)ena_bufs->paddr;
+		desc->buff_addr_hi_hdr_sz |= addr_hi &
+			ENA_ETH_IO_TX_DESC_ADDR_HI_MASK;
+		ena_bufs++;
+	}
+
+	/* set the last desc indicator */
+	desc->len_ctrl |= ENA_ETH_IO_TX_DESC_LAST_MASK;
+
+	rc = ena_com_sq_update_tail(io_sq);
+	if (unlikely(rc)) {
+		ena_trc_err(ena_com_io_sq_to_ena_dev(io_sq),
+			    "Failed to update sq tail of the last descriptor\n");
+		return rc;
+	}
+
+	rc = ena_com_close_bounce_buffer(io_sq);
+	if (rc)
+		ena_trc_err(ena_com_io_sq_to_ena_dev(io_sq),
+			    "Failed when closing bounce buffer\n");
+
+	*nb_hw_desc = io_sq->tail - start_tail;
+	return rc;
+}
+
+int ena_com_rx_pkt(struct ena_com_io_cq *io_cq,
+		   struct ena_com_io_sq *io_sq,
+		   struct ena_com_rx_ctx *ena_rx_ctx)
+{
+	struct ena_com_rx_buf_info *ena_buf = &ena_rx_ctx->ena_bufs[0];
+	struct ena_eth_io_rx_cdesc_base *cdesc = NULL;
+	u16 cdesc_idx = 0;
+	u16 nb_hw_desc;
+	u16 i = 0;
+
+	ENA_WARN(io_cq->direction != ENA_COM_IO_QUEUE_DIRECTION_RX,
+		 ena_com_io_cq_to_ena_dev(io_cq), "wrong Q type");
+
+	nb_hw_desc = ena_com_cdesc_rx_pkt_get(io_cq, &cdesc_idx);
+	if (nb_hw_desc == 0) {
+		ena_rx_ctx->descs = nb_hw_desc;
+		return 0;
+	}
+
+	ena_trc_dbg(ena_com_io_cq_to_ena_dev(io_cq),
+		    "Fetch rx packet: queue %d completed desc: %d\n",
+		    io_cq->qid, nb_hw_desc);
+
+	if (unlikely(nb_hw_desc > ena_rx_ctx->max_bufs)) {
+		ena_trc_err(ena_com_io_cq_to_ena_dev(io_cq),
+			    "Too many RX cdescs (%d) > MAX(%d)\n",
+			    nb_hw_desc, ena_rx_ctx->max_bufs);
+		return ENA_COM_NO_SPACE;
+	}
+
+	cdesc = ena_com_rx_cdesc_idx_to_ptr(io_cq, cdesc_idx);
+	ena_rx_ctx->pkt_offset = cdesc->offset;
+
+	do {
+		ena_buf[i].len = cdesc->length;
+		ena_buf[i].req_id = cdesc->req_id;
+
+		if (++i >= nb_hw_desc)
+			break;
+
+		cdesc = ena_com_rx_cdesc_idx_to_ptr(io_cq, cdesc_idx + i);
+
+	} while (1);
+
+	/* Update SQ head ptr */
+	io_sq->next_to_comp += nb_hw_desc;
+
+	ena_trc_dbg(ena_com_io_cq_to_ena_dev(io_cq),
+		    "[%s][QID#%d] Updating SQ head to: %d\n", __func__,
+		    io_sq->qid, io_sq->next_to_comp);
+
+	/* Get rx flags from the last pkt */
+	ena_com_rx_set_flags(io_cq, ena_rx_ctx, cdesc);
+
+	ena_rx_ctx->descs = nb_hw_desc;
+	return 0;
+}
+
+int ena_com_add_single_rx_desc(struct ena_com_io_sq *io_sq,
+			       struct ena_com_buf *ena_buf,
+			       u16 req_id)
+{
+	struct ena_eth_io_rx_desc *desc;
+
+	ENA_WARN(io_sq->direction != ENA_COM_IO_QUEUE_DIRECTION_RX,
+		 ena_com_io_sq_to_ena_dev(io_sq), "wrong Q type");
+
+	if (unlikely(!ena_com_sq_have_enough_space(io_sq, 1)))
+		return ENA_COM_NO_SPACE;
+
+	desc = get_sq_desc(io_sq);
+	if (unlikely(!desc))
+		return ENA_COM_FAULT;
+
+	memset(desc, 0x0, sizeof(struct ena_eth_io_rx_desc));
+
+	desc->length = ena_buf->len;
+
+	desc->ctrl = ENA_ETH_IO_RX_DESC_FIRST_MASK |
+		     ENA_ETH_IO_RX_DESC_LAST_MASK |
+		     ENA_ETH_IO_RX_DESC_COMP_REQ_MASK |
+		     (io_sq->phase & ENA_ETH_IO_RX_DESC_PHASE_MASK);
+
+	desc->req_id = req_id;
+
+	ena_trc_dbg(ena_com_io_sq_to_ena_dev(io_sq),
+		    "[%s] Adding single RX desc, Queue: %u, req_id: %u\n",
+		    __func__, io_sq->qid, req_id);
+
+	desc->buff_addr_lo = (u32)ena_buf->paddr;
+	desc->buff_addr_hi =
+		((ena_buf->paddr & GENMASK_ULL(io_sq->dma_addr_bits - 1, 32)) >> 32);
+
+	return ena_com_sq_update_tail(io_sq);
+}
+
+bool ena_com_cq_empty(struct ena_com_io_cq *io_cq)
+{
+	struct ena_eth_io_rx_cdesc_base *cdesc;
+
+	cdesc = ena_com_get_next_rx_cdesc(io_cq);
+	if (cdesc)
+		return false;
+	else
+		return true;
+}

--- a/kernel/macOS/ena/ena_com/ena_eth_com.h
+++ b/kernel/macOS/ena/ena_com/ena_eth_com.h
@@ -1,0 +1,261 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef ENA_ETH_COM_H_
+#define ENA_ETH_COM_H_
+
+#if defined(__cplusplus)
+extern "C" {
+#endif
+#include "ena_com.h"
+
+/* head update threshold in units of (queue size / ENA_COMP_HEAD_THRESH) */
+#define ENA_COMP_HEAD_THRESH 4
+
+struct ena_com_tx_ctx {
+	struct ena_com_tx_meta ena_meta;
+	struct ena_com_buf *ena_bufs;
+	/* For LLQ, header buffer - pushed to the device mem space */
+	void *push_header;
+
+	enum ena_eth_io_l3_proto_index l3_proto;
+	enum ena_eth_io_l4_proto_index l4_proto;
+	u16 num_bufs;
+	u16 req_id;
+	/* For regular queue, indicate the size of the header
+	 * For LLQ, indicate the size of the pushed buffer
+	 */
+	u16 header_len;
+
+	u8 meta_valid;
+	u8 tso_enable;
+	u8 l3_csum_enable;
+	u8 l4_csum_enable;
+	u8 l4_csum_partial;
+	u8 df; /* Don't fragment */
+};
+
+struct ena_com_rx_ctx {
+	struct ena_com_rx_buf_info *ena_bufs;
+	enum ena_eth_io_l3_proto_index l3_proto;
+	enum ena_eth_io_l4_proto_index l4_proto;
+	bool l3_csum_err;
+	bool l4_csum_err;
+	u8 l4_csum_checked;
+	/* fragmented packet */
+	bool frag;
+	u32 hash;
+	u16 descs;
+	int max_bufs;
+	u8 pkt_offset;
+};
+
+int ena_com_prepare_tx(struct ena_com_io_sq *io_sq,
+		       struct ena_com_tx_ctx *ena_tx_ctx,
+		       int *nb_hw_desc);
+
+int ena_com_rx_pkt(struct ena_com_io_cq *io_cq,
+		   struct ena_com_io_sq *io_sq,
+		   struct ena_com_rx_ctx *ena_rx_ctx);
+
+int ena_com_add_single_rx_desc(struct ena_com_io_sq *io_sq,
+			       struct ena_com_buf *ena_buf,
+			       u16 req_id);
+
+bool ena_com_cq_empty(struct ena_com_io_cq *io_cq);
+
+static inline void ena_com_unmask_intr(struct ena_com_io_cq *io_cq,
+				       struct ena_eth_io_intr_reg *intr_reg)
+{
+	ENA_REG_WRITE32(io_cq->bus, intr_reg->intr_control, io_cq->unmask_reg);
+}
+
+static inline int ena_com_free_q_entries(struct ena_com_io_sq *io_sq)
+{
+	u16 tail, next_to_comp, cnt;
+
+	next_to_comp = io_sq->next_to_comp;
+	tail = io_sq->tail;
+	cnt = tail - next_to_comp;
+
+	return io_sq->q_depth - 1 - cnt;
+}
+
+/* Check if the submission queue has enough space to hold required_buffers */
+static inline bool ena_com_sq_have_enough_space(struct ena_com_io_sq *io_sq,
+						u16 required_buffers)
+{
+	int temp;
+
+	if (io_sq->mem_queue_type == ENA_ADMIN_PLACEMENT_POLICY_HOST)
+		return ena_com_free_q_entries(io_sq) >= required_buffers;
+
+	/* This calculation doesn't need to be 100% accurate. So to reduce
+	 * the calculation overhead just Subtract 2 lines from the free descs
+	 * (one for the header line and one to compensate the devision
+	 * down calculation.
+	 */
+	temp = required_buffers / io_sq->llq_info.descs_per_entry + 2;
+
+	return ena_com_free_q_entries(io_sq) > temp;
+}
+
+static inline bool ena_com_meta_desc_changed(struct ena_com_io_sq *io_sq,
+					     struct ena_com_tx_ctx *ena_tx_ctx)
+{
+	if (!ena_tx_ctx->meta_valid)
+		return false;
+
+	return !!memcmp(&io_sq->cached_tx_meta,
+			&ena_tx_ctx->ena_meta,
+			sizeof(struct ena_com_tx_meta));
+}
+
+static inline bool is_llq_max_tx_burst_exists(struct ena_com_io_sq *io_sq)
+{
+	return (io_sq->mem_queue_type == ENA_ADMIN_PLACEMENT_POLICY_DEV) &&
+	       io_sq->llq_info.max_entries_in_tx_burst > 0;
+}
+
+static inline bool ena_com_is_doorbell_needed(struct ena_com_io_sq *io_sq,
+					      struct ena_com_tx_ctx *ena_tx_ctx)
+{
+	struct ena_com_llq_info *llq_info;
+	int descs_after_first_entry;
+	int num_entries_needed = 1;
+	u16 num_descs;
+
+	if (!is_llq_max_tx_burst_exists(io_sq))
+		return false;
+
+	llq_info = &io_sq->llq_info;
+	num_descs = ena_tx_ctx->num_bufs;
+
+	if (llq_info->disable_meta_caching ||
+	    unlikely(ena_com_meta_desc_changed(io_sq, ena_tx_ctx)))
+		++num_descs;
+
+	if (num_descs > llq_info->descs_num_before_header) {
+		descs_after_first_entry = num_descs - llq_info->descs_num_before_header;
+		num_entries_needed += DIV_ROUND_UP(descs_after_first_entry,
+						   llq_info->descs_per_entry);
+	}
+
+	ena_trc_dbg(ena_com_io_sq_to_ena_dev(io_sq),
+		    "Queue: %d num_descs: %d num_entries_needed: %d\n",
+		    io_sq->qid, num_descs, num_entries_needed);
+
+	return num_entries_needed > io_sq->entries_in_tx_burst_left;
+}
+
+static inline int ena_com_write_sq_doorbell(struct ena_com_io_sq *io_sq)
+{
+	u16 max_entries_in_tx_burst = io_sq->llq_info.max_entries_in_tx_burst;
+	u16 tail = io_sq->tail;
+
+	ena_trc_dbg(ena_com_io_sq_to_ena_dev(io_sq),
+		    "Write submission queue doorbell for queue: %d tail: %d\n",
+		    io_sq->qid, tail);
+
+	ENA_REG_WRITE32(io_sq->bus, tail, io_sq->db_addr);
+
+	if (is_llq_max_tx_burst_exists(io_sq)) {
+		ena_trc_dbg(ena_com_io_sq_to_ena_dev(io_sq),
+			    "Reset available entries in tx burst for queue %d to %d\n",
+			    io_sq->qid, max_entries_in_tx_burst);
+		io_sq->entries_in_tx_burst_left = max_entries_in_tx_burst;
+	}
+
+	return 0;
+}
+
+static inline int ena_com_update_dev_comp_head(struct ena_com_io_cq *io_cq)
+{
+	u16 unreported_comp, head;
+	bool need_update;
+
+	if (unlikely(io_cq->cq_head_db_reg)) {
+		head = io_cq->head;
+		unreported_comp = head - io_cq->last_head_update;
+		need_update = unreported_comp > (io_cq->q_depth / ENA_COMP_HEAD_THRESH);
+
+		if (unlikely(need_update)) {
+			ena_trc_dbg(ena_com_io_cq_to_ena_dev(io_cq),
+				    "Write completion queue doorbell for queue %d: head: %d\n",
+				    io_cq->qid, head);
+			ENA_REG_WRITE32(io_cq->bus, head, io_cq->cq_head_db_reg);
+			io_cq->last_head_update = head;
+		}
+	}
+
+	return 0;
+}
+
+static inline void ena_com_update_numa_node(struct ena_com_io_cq *io_cq,
+					    u8 numa_node)
+{
+	struct ena_eth_io_numa_node_cfg_reg numa_cfg;
+
+	if (!io_cq->numa_node_cfg_reg)
+		return;
+
+	numa_cfg.numa_cfg = (numa_node & ENA_ETH_IO_NUMA_NODE_CFG_REG_NUMA_MASK)
+		| ENA_ETH_IO_NUMA_NODE_CFG_REG_ENABLED_MASK;
+
+	ENA_REG_WRITE32(io_cq->bus, numa_cfg.numa_cfg, io_cq->numa_node_cfg_reg);
+}
+
+static inline void ena_com_comp_ack(struct ena_com_io_sq *io_sq, u16 elem)
+{
+	io_sq->next_to_comp += elem;
+}
+
+static inline void ena_com_cq_inc_head(struct ena_com_io_cq *io_cq)
+{
+	io_cq->head++;
+
+	/* Switch phase bit in case of wrap around */
+	if (unlikely((io_cq->head & (io_cq->q_depth - 1)) == 0))
+		io_cq->phase ^= 1;
+}
+
+static inline int ena_com_tx_comp_req_id_get(struct ena_com_io_cq *io_cq,
+					     u16 *req_id)
+{
+	u8 expected_phase, cdesc_phase;
+	struct ena_eth_io_tx_cdesc *cdesc;
+	u16 masked_head;
+
+	masked_head = io_cq->head & (io_cq->q_depth - 1);
+	expected_phase = io_cq->phase;
+
+	cdesc = (struct ena_eth_io_tx_cdesc *)
+		((uintptr_t)io_cq->cdesc_addr.virt_addr +
+		(masked_head * io_cq->cdesc_entry_size_in_bytes));
+
+	/* When the current completion descriptor phase isn't the same as the
+	 * expected, it mean that the device still didn't update
+	 * this completion.
+	 */
+	cdesc_phase = READ_ONCE16(cdesc->flags) & ENA_ETH_IO_TX_CDESC_PHASE_MASK;
+	if (cdesc_phase != expected_phase)
+		return ENA_COM_TRY_AGAIN;
+
+	dma_rmb();
+
+	*req_id = READ_ONCE16(cdesc->req_id);
+	if (unlikely(*req_id >= io_cq->q_depth)) {
+		ena_trc_err(ena_com_io_cq_to_ena_dev(io_cq),
+			    "Invalid req id %d\n", cdesc->req_id);
+		return ENA_COM_INVAL;
+	}
+
+	ena_com_cq_inc_head(io_cq);
+
+	return 0;
+}
+
+#if defined(__cplusplus)
+}
+#endif
+#endif /* ENA_ETH_COM_H_ */

--- a/kernel/macOS/ena/ena_com/ena_plat.h
+++ b/kernel/macOS/ena/ena_com/ena_plat.h
@@ -1,0 +1,22 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef ENA_PLAT_H_
+#define ENA_PLAT_H_
+
+
+#if defined(ENA_IPXE)
+#include <ena_plat_ipxe.h>
+#elif defined(__linux__)
+#include <ena_plat_linux.h>
+#elif defined(_WIN32)
+#include <ena_plat_windows.h>
+#elif defined(__FreeBSD__)
+#include <ena_plat_fbsd.h>
+#elif defined(__APPLE__)
+#include <ena_plat_macos.h>
+#else
+#error "Invalid platform"
+#endif
+
+#endif /* ENA_PLAT_H_ */

--- a/kernel/macOS/ena/ena_com/ena_plat_macos.h
+++ b/kernel/macOS/ena/ena_com/ena_plat_macos.h
@@ -1,0 +1,301 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef ENA_COM_ENA_PLAT_MACOS_H_
+#define ENA_COM_ENA_PLAT_MACOS_H_
+
+#include <sys/errno.h>
+#include <stdatomic.h>
+
+#include <IOKit/IOLib.h>
+
+#if defined (__cplusplus)
+#define ENA_COM_API extern "C"
+#else
+#define ENA_COM_API
+#endif
+
+extern int ena_log_level;
+
+#ifndef container_of
+#define container_of(ptr,type,member) ((type*)(((uintptr_t)ptr) - offsetof(type, member)))
+#endif
+
+/* Levels */
+#define ENA_ALERT 	(1 << 0) /* Alerts are providing more error info.     */
+#define ENA_WARNING 	(1 << 1) /* Driver output is more error sensitive.    */
+#define ENA_INFO 	(1 << 2) /* Provides additional driver info. 	      */
+#define ENA_DBG 	(1 << 3) /* Driver output for debugging.	      */
+/* Detailed info that will be printed with ENA_INFO or ENA_DEBUG flag. 	      */
+#define ENA_TXPTH 	(1 << 4) /* Allows TX path tracing. 		      */
+#define ENA_RXPTH 	(1 << 5) /* Allows RX path tracing.		      */
+#define ENA_RSC 	(1 << 6) /* Goes with TXPTH or RXPTH, free/alloc res. */
+#define ENA_IOQ 	(1 << 7) /* Detailed info about IO queues. 	      */
+#define ENA_ADMQ	(1 << 8) /* Detailed info about admin queue. 	      */
+
+#define ena_trace_raw(ctx, level, fmt, args...)			\
+	do {							\
+		(void)(ctx);					\
+		if (((level) & ena_log_level) != (level))	\
+			break;					\
+		printf(fmt, ##args);				\
+	} while (0)
+
+#define ena_trace(ctx, level, fmt, args...)			\
+	ena_trace_raw(ctx, level, "%s(): " fmt " \n", __func__, ##args)
+
+#define ena_trc_dbg(ctx, format, arg...)	ena_trace(ctx, ENA_DBG, format, ##arg)
+#define ena_trc_info(ctx, format, arg...)	ena_trace(ctx, ENA_INFO, format, ##arg)
+#define ena_trc_warn(ctx, format, arg...)	ena_trace(ctx, ENA_WARNING, format, ##arg)
+#define ena_trc_err(ctx, format, arg...)	ena_trace(ctx, ENA_ALERT, format, ##arg)
+
+#define ENA_WARN(cond, ctx, format, arg...)				\
+	do {								\
+		if (unlikely(cond)) {					\
+			ena_trc_err(ctx,				\
+				"Warn failed on %s:%s:%d:" format,	\
+				__FILE__, __func__, __LINE__, ##arg);	\
+		}							\
+	} while (0)
+
+#define ENA_PRIu64	"llu"
+
+#define ENA_INTR_INITIAL_TX_INTERVAL_USECS_PLAT 64
+
+#define ENA_MSLEEP(x)	IOSleep(x)
+#define ENA_USLEEP(x)	IODelay(x)
+
+#define ENA_MAX32(x,y)	max((x), (y))
+#define ENA_MAX16(x,y)	max((x), (y))
+#define ENA_MAX8(x, y)	max((x), (y))
+
+#define ENA_MIN32(x,y)	min((x), (y))
+#define ENA_MIN16(x,y)	min((x), (y))
+#define ENA_MIN8(x, y)	min((x), (y))
+
+#define ENA_UDELAY(x)	IODelay(x)
+
+#define ENA_GET_SYSTEM_TIMEOUT(timeout_us) 				\
+	({								\
+		AbsoluteTime abstime;					\
+		nanoseconds_to_absolutetime((timeout_us)*1000, &abstime); \
+		mach_absolute_time() + abstime;				\
+	})
+#define ENA_TIME_EXPIRE(timeout) ((timeout) < mach_absolute_time())
+
+#define ENA_MIGHT_SLEEP()
+
+#define ENA_REG_WRITE32(bus, value, reg)				\
+	({ 								\
+		(void)(bus); 						\
+		atomic_thread_fence(memory_order_release);		\
+		OSWriteLittleInt32((reg), 0, (value));			\
+	})
+#define ENA_REG_WRITE32_RELAXED(bus, value, reg)			\
+	({ 								\
+		(void)(bus); 						\
+		OSWriteLittleInt32((reg), 0, (value));			\
+	})
+#define ENA_REG_READ32(bus, reg)					\
+	({			 					\
+		(void)(bus); 						\
+		UInt32 value;						\
+		atomic_thread_fence(memory_order_release);		\
+		value = OSReadLittleInt32((reg), 0); 			\
+		atomic_thread_fence(memory_order_acquire);		\
+		(value);						\
+	})
+
+/* return value definition */
+enum {
+	ENA_COM_OK		= 0,
+	ENA_COM_FAULT		= 1,
+	ENA_COM_INVAL		= 2,
+	ENA_COM_NO_MEM		= 3,
+	ENA_COM_NO_SPACE	= 4,
+	ENA_COM_TRY_AGAIN	= 5,
+	ENA_COM_NO_DEVICE	= 6,
+	ENA_COM_PERMISSION	= 7,
+	ENA_COM_UNSUPPORTED	= 8,
+	ENA_COM_TIMER_EXPIRED	= 9,
+};
+
+typedef IOSimpleLock * ena_spinlock_t;
+
+/* Spinlock related methods */
+#define ENA_SPINLOCK_INIT(spinlock) ((spinlock) = IOSimpleLockAlloc())
+#define ENA_SPINLOCK_DESTROY(spinlock) IOSimpleLockFree((spinlock))
+#define ENA_SPINLOCK_LOCK(spinlock, flags)				\
+	do {								\
+		(void)(flags);						\
+		IOSimpleLockLock((spinlock));				\
+	} while (0)
+#define ENA_SPINLOCK_UNLOCK(spinlock, flags)				\
+	do {								\
+		(void)(flags);						\
+		IOSimpleLockUnlock((spinlock));				\
+	} while (0)
+
+/* Wait queue related methods */
+typedef IOLock * ena_wait_event_t;
+
+#define ENA_WAIT_EVENT_INIT(wait_event) ((wait_event) = IOLockAlloc())
+#define ENA_WAIT_EVENTS_DESTROY(admin_queue)				\
+	do {								\
+		struct ena_comp_ctx *comp_ctx;				\
+		int i;							\
+		for (i = 0; i < admin_queue->q_depth; i++) {		\
+			comp_ctx = get_comp_ctxt(admin_queue, i, false); \
+			if (comp_ctx != NULL)				\
+				IOLockFree(comp_ctx->wait_event);	\
+		}							\
+	} while (0)
+#define ENA_WAIT_EVENT_CLEAR(wait_event) IOLockWakeup(wait_event, wait_event, false)
+#define ENA_WAIT_EVENT_WAIT(wait_event, timeout_us)			\
+	do {								\
+		AbsoluteTime time;					\
+		nanoseconds_to_absolutetime((timeout_us)*1000, &time);	\
+		time += mach_absolute_time();				\
+		IOLockLock(wait_event);					\
+		IOLockSleepDeadline(wait_event, wait_event, time, THREAD_UNINT); \
+		IOLockUnlock(wait_event);				\
+	} while (0)
+#define ENA_WAIT_EVENT_SIGNAL(wait_event) 				\
+	IOLockWakeup(wait_event, wait_event, true)
+
+#define ENA_MEMCPY_TO_DEVICE_64(dst, src, size)				\
+	do {								\
+		int offset;						\
+		const UInt64 *from = (const UInt64 *)(src);		\
+		for (offset = 0; offset < (size); offset += 8, ++from)	\
+			_OSWriteInt64((dst), offset, *from);		\
+	} while (0)
+
+#define ENA_MEM_ALLOC_COHERENT_NODE(dmadev, size, virt, phys, handle, node, dev_node) \
+	do {								\
+		(virt) = NULL;						\
+		(void)(dev_node);					\
+	} while (0)
+#define ENA_MEM_ALLOC_COHERENT(dmadev, size, virt, phys, handle)	\
+	((virt) = ena_mem_alloc_coherent(size, &(phys), &(handle)))
+#define ENA_MEM_FREE_COHERENT(dmadev, size, virt, phys, handle)		\
+	do {								\
+		(void)(size);						\
+		ena_mem_free_coherent(handle);				\
+	} while (0)
+
+#define ENA_MEM_ALLOC(dmadev, size)	\
+	({	\
+		void *addr = IOMalloc(size);	\
+		memset(addr, 0, size);	\
+		addr;	\
+	})
+#define ENA_MEM_ALLOC_NODE(dmadev, size, virt, node, dev_node)		\
+	((virt) = NULL)
+#define ENA_MEM_FREE(dmadev, ptr, size)					\
+	{ (void)(dmadev); IOFree((ptr), (size)); }
+#define ENA_DB_SYNC(mem_handle) ((void)(mem_handle))
+
+typedef SInt32 ena_atomic32_t;
+#define ATOMIC32_INC(I32_PTR) OSIncrementAtomic(I32_PTR)
+#define ATOMIC32_DEC(I32_PTR) OSDecrementAtomic(I32_PTR)
+#define ATOMIC32_READ(I32_PTR) (*(volatile ena_atomic32_t *)(I32_PTR))
+#define ATOMIC32_SET(I32_PTR, VAL) 					\
+	(*(volatile ena_atomic32_t *)(I32_PTR) = (VAL))
+
+#define GENMASK(h, l)	(((~0U) - (1U << (l)) + 1) & (~0U >> (32 - 1 - (h))))
+#define GENMASK_ULL(h, l) (((~0ULL) << (l)) & (~0ULL >> (64 - 1 - (h))))
+#define BIT(x)		(1 << (x))
+
+#define SZ_256			(256)
+#define SZ_4K			(4096)
+
+typedef UInt8	u8;
+typedef UInt16	u16;
+typedef UInt32	u32;
+typedef UInt64	u64;
+
+typedef AbsoluteTime ena_time_t;
+
+typedef IOPhysicalAddress dma_addr_t;
+typedef void * ena_mem_handle_t;
+
+ENA_COM_API
+void * ena_mem_alloc_coherent(size_t length,
+	IOPhysicalAddress *physAddr, ena_mem_handle_t *memHandle);
+
+ENA_COM_API
+void ena_mem_free_coherent(ena_mem_handle_t memHandle);
+
+#define __iomem
+#define ____cacheline_aligned __attribute__((aligned(64)))
+
+#define unlikely(x)		__builtin_expect(!!(x), 0)
+#define likely(x)		__builtin_expect(!!(x), 1)
+
+#define prefetch(x)		__builtin_prefetch(x)
+#define prefetchw(x)		__builtin_prefetch(x, 1)
+
+#if	defined(__arm__) || defined(__arm64__)
+static inline void barrier(void) {
+	__asm__ volatile("dmb ish" ::: "memory");
+}
+#elif defined(__i386__) || defined(__x86_64__)
+static inline void barrier(void) {
+	__asm__ volatile("mfence" ::: "memory");
+}
+#endif
+
+#define mb()		atomic_thread_fence(memory_order_acq_rel)
+#define wmb()		atomic_thread_fence(memory_order_release)
+#define rmb()		atomic_thread_fence(memory_order_acquire)
+#define dma_rmb		rmb
+#define mmiowb		wmb
+
+#define	ACCESS_ONCE(x) (*(volatile __typeof(x) *)&(x))
+#define READ_ONCE(x) ({							\
+			__typeof(x) __var;				\
+			barrier();					\
+			__var = ACCESS_ONCE(x);				\
+			barrier();					\
+			__var;						\
+		})
+#define READ_ONCE8(x) READ_ONCE(x)
+#define READ_ONCE16(x) READ_ONCE(x)
+#define READ_ONCE32(x) READ_ONCE(x)
+
+#define MAX_ERRNO 4095
+#define IS_ERR_VALUE(x) unlikely((x) <= (unsigned long)MAX_ERRNO)
+
+static inline long IS_ERR(const void *ptr)
+{
+	return IS_ERR_VALUE((unsigned long)ptr);
+}
+
+static inline void *ERR_PTR(long error)
+{
+	return (void *)error;
+}
+
+static inline long PTR_ERR(const void *ptr)
+{
+	return (long) ptr;
+}
+
+#define upper_32_bits(n) ((u32)(((n) >> 16) >> 16))
+#define lower_32_bits(n) ((u32)(n))
+
+#define DIV_ROUND_UP(n, d) (((n) + (d) - 1) / (d))
+
+#include "ena_defs/ena_includes.h"
+
+#define ENA_FFS(x) ffs(x)
+/* RSS is not used in the driver right now, as OS limit for the number of the IO
+ * queues is 1. It needs to be implemented after multiqueue support will be
+ * added.
+ * As for now, not having RSS key configured at all won't change anything in
+ * the driver's functionality.
+ */
+#define ENA_RSS_FILL_KEY(key, size)
+
+#endif /* ENA_COM_ENA_PLAT_MACOS_H_ */


### PR DESCRIPTION
Driver current version is v1.5.0

This driver implements the ENA interface for the macOS systems, driver is
used on mac1.metal instances on AWS EC2.

Signed-off-by: Ido Segev <idose@amazon.com>
Signed-off-by: Michal Krawczyk <mk@semihalf.com>

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
