### PR TITLE
Change log level from "err" to "warn" when fallingback to host mode p…

### DIFF
--- a/kernel/linux/ena/ena_netdev.c
+++ b/kernel/linux/ena/ena_netdev.c
@@ -4033,7 +4033,7 @@ static int ena_set_queues_placement_policy(struct pci_dev *pdev,
 
 	llq_feature_mask = 1 << ENA_ADMIN_LLQ;
 	if (!(ena_dev->supported_features & llq_feature_mask)) {
-		dev_err(&pdev->dev,
+		dev_warn(&pdev->dev,
 			"LLQ is not supported Fallback to host mode policy.\n");
 		ena_dev->tx_mem_queue_type = ENA_ADMIN_PLACEMENT_POLICY_HOST;
 		return 0;
@@ -4041,7 +4041,7 @@ static int ena_set_queues_placement_policy(struct pci_dev *pdev,
 
 	rc = ena_com_config_dev_mode(ena_dev, llq, llq_default_configurations);
 	if (unlikely(rc)) {
-		dev_err(&pdev->dev,
+		dev_warn(&pdev->dev,
 			"Failed to configure the device mode.  Fallback to host mode policy.\n");
 		ena_dev->tx_mem_queue_type = ENA_ADMIN_PLACEMENT_POLICY_HOST;
 	}

--- a/kernel/linux/ena/ena_netdev.c
+++ b/kernel/linux/ena/ena_netdev.c
@@ -4041,7 +4041,7 @@ static int ena_set_queues_placement_policy(struct pci_dev *pdev,
 
 	rc = ena_com_config_dev_mode(ena_dev, llq, llq_default_configurations);
 	if (unlikely(rc)) {
-		dev_warn(&pdev->dev,
+		dev_err(&pdev->dev,
 			"Failed to configure the device mode.  Fallback to host mode policy.\n");
 		ena_dev->tx_mem_queue_type = ENA_ADMIN_PLACEMENT_POLICY_HOST;
 	}


### PR DESCRIPTION
*Issue #, if available:*
n/a

*Description of changes:*

Not all ENA devices support LLQ, Falling back to the regular mode is not an error. So log level should be warning level instead of error level.
A lot of users are monitoring error level log messages.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
