### PR TITLE
fbsd/ena: update ENA FreeBSD driver to v2.3.1

### DIFF
--- a/kernel/fbsd/ena/README
+++ b/kernel/fbsd/ena/README
@@ -3,7 +3,7 @@ FreeBSD kernel driver for Elastic Network Adapter (ENA) family:
 
 Version:
 ========
-v2.3.0
+v2.3.1
 
 Supported FreeBSD Versions:
 ===========================

--- a/kernel/fbsd/ena/RELEASENOTES.md
+++ b/kernel/fbsd/ena/RELEASENOTES.md
@@ -9,11 +9,24 @@ The driver was verified on the following distributions:
 **Releases:**
 * FreeBSD 11.4
 * FreeBSD 12.2
+* FreeBSD 13.0-BETA3
 
 **Development:**
-* stable/11 - r367416
-* stable/12 - r367418
-* HEAD - 367420
++-----------+---------+--------------+
+| Branch    | ID      | hash         |
++-----------+---------+--------------+
+| stable/11 | n215703 | a069809d907d |
+| stable/12 | n232729 | 2b1f87a83c1c |
+| stable/13 | n244573 | bef16fad3bd2 |
+| HEAD      | n244897 | fae028dd97d8 |
++-----------+---------+--------------+
+
+## r2.3.1 release notes
+**Bug Fixes**
+* Fix resource allocation if the MSIx vector table is not sharing the
+  BAR with the registers. FreeBSD requires all resources to be allocated
+  by the driver, so having unavailable BAR with MSIx vector table on it,
+  will prevent PCI code from allocating MSIx interrupts.
 
 ## r2.3.0 release notes
 **New Features**

--- a/kernel/fbsd/ena/ena.c
+++ b/kernel/fbsd/ena/ena.c
@@ -301,6 +301,11 @@ ena_free_pci_resources(struct ena_adapter *adapter)
 		bus_release_resource(pdev, SYS_RES_MEMORY,
 		    PCIR_BAR(ENA_REG_BAR), adapter->registers);
 	}
+
+	if (adapter->msix != NULL) {
+		bus_release_resource(pdev, SYS_RES_MEMORY,
+		    adapter->msix_rid, adapter->msix);
+	}
 }
 
 static int
@@ -3564,6 +3569,7 @@ ena_attach(device_t pdev)
 	struct ena_adapter *adapter;
 	struct ena_com_dev *ena_dev = NULL;
 	uint32_t max_num_io_queues;
+	int msix_rid;
 	int rid, rc;
 
 	adapter = device_get_softc(pdev);
@@ -3600,6 +3606,20 @@ ena_attach(device_t pdev)
 		    "unable to allocate bus resource: registers!\n");
 		rc = ENOMEM;
 		goto err_dev_free;
+	}
+
+	/* MSIx vector table may reside on BAR0 with registers or on BAR1. */
+	msix_rid = pci_msix_table_bar(pdev);
+	if (msix_rid != rid) {
+		adapter->msix = bus_alloc_resource_any(pdev, SYS_RES_MEMORY,
+		    &msix_rid, RF_ACTIVE);
+		if (unlikely(adapter->msix == NULL)) {
+			device_printf(pdev,
+			    "unable to allocate bus resource: msix!\n");
+			rc = ENOMEM;
+			goto err_pci_free;
+		}
+		adapter->msix_rid = msix_rid;
 	}
 
 	ena_dev->bus = malloc(sizeof(struct ena_bus), M_DEVBUF,
@@ -3767,6 +3787,7 @@ err_com_free:
 	ena_com_mmio_reg_read_request_destroy(ena_dev);
 err_bus_free:
 	free(ena_dev->bus, M_DEVBUF);
+err_pci_free:
 	ena_free_pci_resources(adapter);
 err_dev_free:
 	free(ena_dev, M_DEVBUF);

--- a/kernel/fbsd/ena/ena.h
+++ b/kernel/fbsd/ena/ena.h
@@ -41,7 +41,7 @@
 
 #define DRV_MODULE_VER_MAJOR	2
 #define DRV_MODULE_VER_MINOR	3
-#define DRV_MODULE_VER_SUBMINOR 0
+#define DRV_MODULE_VER_SUBMINOR 1
 
 #define DRV_MODULE_NAME		"ena"
 
@@ -398,6 +398,8 @@ struct ena_adapter {
 	/* OS resources */
 	struct resource *memory;
 	struct resource *registers;
+	struct resource *msix;
+	int msix_rid;
 
 	struct sx global_lock;
 


### PR DESCRIPTION
Changes since last release (v2.3.0)

**Bug Fixes**
* Fix resource allocation if the MSIx vector table is not sharing the
  BAR with the registers. FreeBSD requires all resources to be allocated
  by the driver, so having unavailable BAR with MSIx vector table on it,
  will prevent PCI code from allocating MSIx interrupts.

Signed-off-by: Michal Krawczyk <mk@semihalf.com>

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
