### PR TITLE
dpdk/ena: update release notes up to v21.05

### DIFF
--- a/userspace/dpdk/RELEASENOTES.md
+++ b/userspace/dpdk/RELEASENOTES.md
@@ -4,6 +4,25 @@ ___
 
 ### Normal releases
 
+#### v21.02
+_Release of the new version of the driver - r2.2.1_
+
+Bug Fixes:
+* Prevent driver from calling doorbell twice on Tx path when Tx burst doorbell
+  threshold is reached and Tx loop is being stopped right after that.
+* Fix assessment of free Tx SQ space. Correct evaluation of the required space
+  for each packet cannot be done effectively before the burst, because it
+  depends on number of segments for each mbuf. Because of that, the driver
+  should attempt to send each packet before returning error.
+* Fix Tx doorbell statistics, by incrementing appropriate counter also for the
+  case when doorbell is being activated after max Tx burst size is being
+  achieved.
+* Flush Rx buffers mempool cache after Rx queue setup to prevent mbufs from
+  being stuck in the mempool cache of the configuration lcore.
+* Validate Rx requested ID upon acquiring descriptor instead of doing that each
+  time it's being used in the driver code. As a result this value is validated
+  only once and a driver code could be simplified.
+
 #### v20.11
 _Release of the new version of the driver - r2.2.0_
 
@@ -210,6 +229,11 @@ New Features:
 * Use dynamic logging instead of static one.
 * Use new Tx and Rx offloads API (introduced in DPDK v18.02).
 
+Bug Fixes:
+* Fix setting Tx offloads flags in the mbuf on the Rx path.
+* Indicate jumbo frames support in the rx features structure which is supported
+  by the device.
+
 #### v17.08
 Bug Fixes:
 * Fix Tx cleanup to prevent the same buffers being released two times.
@@ -230,6 +254,13 @@ New Features:
   before sending them).
 * Add TSO support for the driver (if the HW is supporting it). To make use of
   that, the preparation routine must be called before sending packet.
+
+Bug Fixes:
+* Use correct field for checking Rx offloads (the Tx field was used before).
+* Fix error handling and configuration for host_info structure.
+
+Minor changes:
+* Use I/O device memory read/write API for I/O manipulations.
 
 #### v16.11
 Bug Fixes:
@@ -259,21 +290,45 @@ Minor changes:
 #### v16.04
 _Release of the driver (unversioned)_
 
-Bug Fixes:
-* Use correct field for checking Rx offloads (the Tx field was used before).
-* Fix error handling and configuration for host_info structure.
-
-Minor changes:
-* Use I/O device memory read/write API for I/O manipulations.
-
-Bug Fixes:
-* Fix setting Tx offloads flags in the mbuf on the Rx path.
-* Indicate jumbo frames support in the rx features structure which is supported
-  by the device.
 
 ### Stable releases
 
 There comes only backported patches.
+
+#### v20.11.1
+Bug fixes:
+* Prevent driver from calling doorbell twice on Tx path when Tx burst doorbell
+  threshold is reached and Tx loop is being stopped right after that. (v21.02)
+* Fix assessment of free Tx SQ space. Correct evaluation of the required space
+  for each packet cannot be done effectively before the burst, because it
+  depends on number of segments for each mbuf. Because of that, the driver
+  should attempt to send each packet before returning error. (v21.02)
+* Fix Tx doorbell statistics, by incrementing appropriate counter also for the
+  case when doorbell is being activated after max Tx burst size is being
+  achieved. (v21.02)
+* Flush Rx buffers mempool cache after Rx queue setup to prevent mbufs from
+  being stuck in the mempool cache of the configuration lcore. (v21.02)
+* Validate Rx requested ID upon acquiring descriptor instead of doing that each
+  time it's being used in the driver code. As a result this value is validated
+  only once and a driver code could be simplified. (v21.02)
+
+#### v19.11.6
+Bug fixes:
+* HAL fixes (v20.11):
+  - Fix release of wait event.
+  - Specify delay operations.
+  - Use min/max macros with type conversion.
+* Align IO CQ allocations to 4K, as it's required by the latest generation HW
+  for the best performance. (v20.11)
+* Fix setting Rx checksum flag in the mbuf. The driver now sets
+  PKT_RX_*_CKSUM_GOOD flag. (v20.11)
+* Fix xstats global stats offset. Previously it was read from the
+  ena_stats_rx_strings instead of the ena_stats_global_strings array,
+  but due to the same values held in both structures, the functionality
+  of the code was still the same. (v20.11)
+
+Minor changes:
+* Remove ENA_ASSERT macro which wasn't used anywhere. (v20.11)
 
 #### v19.11.3
 Bug fixes:
@@ -285,6 +340,16 @@ Bug fixes:
   using maximum allowed IO ring size, making the memory management
   ineffective. (v20.05)
 * Fix build with optimization flag O1. (v20.05)
+
+#### v18.11.11
+Bug fixes:
+* HAL fixes (v20.11):
+  - Fix release of wait event.
+  - Specify delay operations.
+  - Use min/max macros with type conversion.
+
+Minor changes:
+* Remove ENA_ASSERT macro which wasn't used anywhere. (v20.11)
 
 #### v18.11.9
 Bug fixes:

--- a/userspace/dpdk/RELEASENOTES.md
+++ b/userspace/dpdk/RELEASENOTES.md
@@ -4,6 +4,33 @@ ___
 
 ### Normal releases
 
+#### v21.05
+_Release of the new version of the driver - r2.3.0_
+
+Bug Fixes:
+* Disable ops not supported by the secondary process, to give more verbose
+  information to the caller about API violation.
+* Make the ethdev references multi-process safe. As the PCI device pointer is
+  process local and not valid in other processes, the `data` structure should be
+  used instead.
+* Indicate RSS hash presence in the mbuf, by setting the `PKT_RX_RSS_HASH` and
+  setting the capability: `DEV_RX_OFFLOAD_RSS_HASH`.
+* Report default ring size value and do not treat value
+  `RTE_ETH_DEV_FALLBACK_[TR]X_RINGSIZE` as a hint to use the internal default.
+  The fallback value is set by the ethdev layer and it is valid size value,
+  which is used when the application didn't set ring size and driver doesn't
+  report any size, neither.
+* Fix spurious wakeups of the `pthread_cond_timedwait()` in the
+  `ENA_WAIT_EVENT`, which may sometimes happen according to the POSIX.
+* Fix parsing of the unsupported device arguments.
+* Fix parsing of the large LLQ header device argument.
+* Clear mbuf pointers on the Tx queue release function, to avoid situation when
+  the application could receive duplicate mbufs for two different packets.
+
+Minor Changes:
+* Switch memcpy to optimized version on x86 and x86_64.
+* Update ena_com to version from 18.09.2020.
+
 #### v21.02
 _Release of the new version of the driver - r2.2.1_
 
@@ -311,6 +338,11 @@ Bug fixes:
 * Validate Rx requested ID upon acquiring descriptor instead of doing that each
   time it's being used in the driver code. As a result this value is validated
   only once and a driver code could be simplified. (v21.02)
+
+#### v19.11.7
+Bug fixes:
+* Flush Rx buffers mempool cache after Rx queue setup to prevent mbufs from
+  being stuck in the mempool cache of the configuration lcore.
 
 #### v19.11.6
 Bug fixes:


### PR DESCRIPTION
Add release notes for the listed DPDK versions:

* v21.05
* v21.02
* v20.11.1
* v19.11.7
* v19.11.6
* v18.11.11

Fix issues with invalid section placement for v18.02 and v17.02.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
