### PR TITLE
fbsd/ena: Update ENA driver to v2.5.0

### DIFF
--- a/kernel/fbsd/ena/README.rst
+++ b/kernel/fbsd/ena/README.rst
@@ -45,6 +45,12 @@ is advertised by the device via the Admin Queue), a dedicated MSI-X
 interrupt vector per Tx/Rx queue pair, and CPU cacheline optimized
 data placement.
 
+When RSS is enabled, each Tx/Rx queue pair is bound to a corresponding
+CPU core and its NUMA domain. The order of those bindings is based on
+the RSS bucket mapping. For builds with RSS support disabled, the
+CPU and NUMA management is left to the kernel. CPU and NUMA management
+are only supported on FreeBSD 12 or newer.
+
 The ENA driver supports industry standard TCP/IP offload features such
 as checksum offload and TCP transmit segmentation offload (TSO).
 Receive-side scaling (RSS) is supported for multi-core scaling.

--- a/kernel/fbsd/ena/README.rst
+++ b/kernel/fbsd/ena/README.rst
@@ -4,7 +4,7 @@ FreeBSD kernel driver for Elastic Network Adapter (ENA) family
 Version
 -------
 
-``2.4.1``
+``2.5.0``
 
 Supported FreeBSD Versions
 --------------------------

--- a/kernel/fbsd/ena/RELEASENOTES.md
+++ b/kernel/fbsd/ena/RELEASENOTES.md
@@ -8,18 +8,33 @@ The driver was verified on the following distributions:
 
 **Releases:**
 * FreeBSD 11.4
-* FreeBSD 12.2
+* FreeBSD 12.3
 * FreeBSD 13.0
 
 **Development:**
 +-----------+-------------+
 | Branch    | SHA         |
 +-----------+-------------+
-| stable/11 | 3a5f854f458 |
-| stable/12 | 62bee146aa4 |
-| stable/13 | 704d90845ce |
-| HEAD      | 0e92585cde5 |
+| stable/12 | dfe7186f287 |
+| stable/13 | cb4d27f48ef |
+| HEAD      | b406897911e |
 +-----------+-------------+
+
+## r2.5.0 release notes
+**New Features**
+* Add NUMA awareness to the driver which runs on the kernel with enabled option
+  RSS.
+* Add support for the IPv6 L4 Tx checksum offloads.
+
+**Bug Fixes**
+* Increase lifetime of the timer service to work from the attach to detach in
+  order to be able to handle more device failures.
+* Do not trigger the reset if the ENA device is not responsive.
+
+**Minor Changes**
+* Optimize logic of the Tx path 'req_id' value validation.
+* Rework Makefile in order to read the kernel build options from the SYSDIR.
+  This change makes the requirement for manual Makefile modifications redundant.
 
 ## r2.4.1 release notes
 **New Features**

--- a/kernel/fbsd/ena/ena.c
+++ b/kernel/fbsd/ena/ena.c
@@ -196,7 +196,7 @@ ena_dmamap_callback(void *arg, bus_dma_segment_t *segs, int nseg, int error)
 
 int
 ena_dma_alloc(device_t dmadev, bus_size_t size,
-    ena_mem_handle_t *dma, int mapflags, bus_size_t alignment)
+    ena_mem_handle_t *dma, int mapflags, bus_size_t alignment, int domain)
 {
 	struct ena_adapter* adapter = device_get_softc(dmadev);
 	device_t pdev = adapter->pdev;
@@ -226,6 +226,15 @@ ena_dma_alloc(device_t dmadev, bus_size_t size,
 		ena_log(pdev, ERR, "bus_dma_tag_create failed: %d\n", error);
 		goto fail_tag;
 	}
+
+#if __FreeBSD_version > 1200055
+	error = bus_dma_tag_set_domain(dma->tag, domain);
+	if (unlikely(error != 0)) {
+		ena_log(pdev, ERR, "bus_dma_tag_set_domain failed: %d\n",
+		    error);
+		goto fail_map_create;
+	}
+#endif
 
 	error = bus_dmamem_alloc(dma->tag, (void**) &dma->vaddr,
 	    BUS_DMA_COHERENT | BUS_DMA_ZERO, &dma->map);
@@ -1443,6 +1452,8 @@ ena_create_io_queues(struct ena_adapter *adapter)
 		ctx.queue_size = adapter->requested_tx_ring_size;
 		ctx.msix_vector = msix_vector;
 		ctx.qid = ena_qid;
+		ctx.numa_node = adapter->que[i].domain;
+
 		rc = ena_com_create_io_queue(ena_dev, &ctx);
 		if (rc != 0) {
 			ena_log(adapter->pdev, ERR,
@@ -1460,6 +1471,11 @@ ena_create_io_queues(struct ena_adapter *adapter)
 			ena_com_destroy_io_queue(ena_dev, ena_qid);
 			goto err_tx;
 		}
+
+		if (ctx.numa_node >= 0) {
+			ena_com_update_numa_node(ring->ena_com_io_cq,
+			    ctx.numa_node);
+		}
 	}
 
 	/* Create RX queues */
@@ -1471,6 +1487,8 @@ ena_create_io_queues(struct ena_adapter *adapter)
 		ctx.queue_size = adapter->requested_rx_ring_size;
 		ctx.msix_vector = msix_vector;
 		ctx.qid = ena_qid;
+		ctx.numa_node = adapter->que[i].domain;
+
 		rc = ena_com_create_io_queue(ena_dev, &ctx);
 		if (unlikely(rc != 0)) {
 			ena_log(adapter->pdev, ERR,
@@ -1488,6 +1506,11 @@ ena_create_io_queues(struct ena_adapter *adapter)
 			    " %d rc: %d\n", i, rc);
 			ena_com_destroy_io_queue(ena_dev, ena_qid);
 			goto err_rx;
+		}
+
+		if (ctx.numa_node >= 0) {
+			ena_com_update_numa_node(ring->ena_com_io_cq,
+			    ctx.numa_node);
 		}
 	}
 
@@ -1648,11 +1671,21 @@ ena_setup_io_intr(struct ena_adapter *adapter)
 #ifdef RSS
 	int num_buckets = rss_getnumbuckets();
 	static int last_bind = 0;
+	int cur_bind;
+	int idx;
 #endif
 	int irq_idx;
 
 	if (adapter->msix_entries == NULL)
 		return (EINVAL);
+
+#ifdef RSS
+	if (adapter->first_bind < 0) {
+		adapter->first_bind = last_bind;
+		last_bind = (last_bind + adapter->num_io_queues) % num_buckets;
+	}
+	cur_bind = adapter->first_bind;
+#endif
 
 	for (int i = 0; i < adapter->num_io_queues; i++) {
 		irq_idx = ENA_IO_IRQ_IDX(i);
@@ -1668,10 +1701,20 @@ ena_setup_io_intr(struct ena_adapter *adapter)
 
 #ifdef RSS
 		adapter->que[i].cpu = adapter->irq_tbl[irq_idx].cpu =
-		    rss_getcpu(last_bind);
-		last_bind = (last_bind + 1) % num_buckets;
+		    rss_getcpu(cur_bind);
+		cur_bind = (cur_bind + 1) % num_buckets;
 		CPU_SETOF(adapter->que[i].cpu, &adapter->que[i].cpu_mask);
-#endif
+
+		for (idx = 0; idx < MAXMEMDOM; ++idx) {
+			if (CPU_ISSET(adapter->que[i].cpu, &cpuset_domain[idx]))
+				break;
+		}
+#endif /* RSS */
+#if defined(RSS) && __FreeBSD_version > 1200055
+		adapter->que[i].domain = idx;
+#else
+		adapter->que[i].domain = -1;
+#endif /* defined(RSS) && __FreeBSD_version > 1200055 */
 	}
 
 	return (0);
@@ -3506,6 +3549,7 @@ ena_attach(device_t pdev)
 
 	adapter = device_get_softc(pdev);
 	adapter->pdev = pdev;
+	adapter->first_bind = -1;
 
 	/*
 	 * Set up the timer service - driver is responsible for avoiding

--- a/kernel/fbsd/ena/ena.c
+++ b/kernel/fbsd/ena/ena.c
@@ -3267,6 +3267,18 @@ ena_timer_service(void *data)
 		ena_update_host_info(host_info, adapter->ifp);
 
 	if (unlikely(ENA_FLAG_ISSET(ENA_FLAG_TRIGGER_RESET, adapter))) {
+		/*
+		 * Timeout when validating version indicates that the device
+		 * became unresponsive. If that happens skip the reset and
+		 * reschedule timer service, so the reset can be retried later.
+		 */
+		if (ena_com_validate_version(adapter->ena_dev) ==
+		    ENA_COM_TIMER_EXPIRED) {
+			ena_log(adapter->pdev, WARN,
+			    "FW unresponsive, skipping reset\n");
+			ENA_TIMER_RESET(adapter);
+			return;
+		}
 		ena_log(adapter->pdev, WARN, "Trigger reset is on\n");
 		taskqueue_enqueue(adapter->reset_tq, &adapter->reset_task);
 		return;

--- a/kernel/fbsd/ena/ena.h
+++ b/kernel/fbsd/ena/ena.h
@@ -221,6 +221,7 @@ struct ena_que {
 	int cpu;
 	cpuset_t cpu_mask;
 #endif
+	int domain;
 	struct sysctl_oid *oid;
 };
 
@@ -438,6 +439,7 @@ struct ena_adapter {
 	uint32_t buf_ring_size;
 
 	/* RSS*/
+	int first_bind;
 	struct ena_indir *rss_indir;
 
 	uint8_t mac_addr[ETHER_ADDR_LEN];

--- a/kernel/fbsd/ena/ena.h
+++ b/kernel/fbsd/ena/ena.h
@@ -496,6 +496,14 @@ struct ena_adapter {
 #define ENA_LOCK_UNLOCK()		sx_unlock(&ena_global_lock)
 #define ENA_LOCK_ASSERT()		sx_assert(&ena_global_lock, SA_XLOCKED)
 
+#define	ENA_TIMER_INIT(_adapter)					\
+	callout_init(&(_adapter)->timer_service, true)
+#define ENA_TIMER_DRAIN(_adapter)					\
+	callout_drain(&(_adapter)->timer_service)
+#define	ENA_TIMER_RESET(_adapter)					\
+	callout_reset_sbt(&(_adapter)->timer_service, SBT_1S, SBT_1S,	\
+			ena_timer_service, (void*)(_adapter), 0)
+
 #define clamp_t(type, _x, min, max)	min_t(type, max_t(type, _x, min), max)
 #define clamp_val(val, lo, hi)		clamp_t(__typeof(val), val, lo, hi)
 

--- a/kernel/fbsd/ena/ena.h
+++ b/kernel/fbsd/ena/ena.h
@@ -39,8 +39,8 @@
 #include "ena_com/ena_eth_com.h"
 
 #define DRV_MODULE_VER_MAJOR	2
-#define DRV_MODULE_VER_MINOR	4
-#define DRV_MODULE_VER_SUBMINOR 1
+#define DRV_MODULE_VER_MINOR	5
+#define DRV_MODULE_VER_SUBMINOR 0
 
 #define DRV_MODULE_NAME		"ena"
 

--- a/kernel/fbsd/ena/ena_com/ena_plat.h
+++ b/kernel/fbsd/ena/ena_com/ena_plat.h
@@ -366,7 +366,6 @@ ena_reg_read32(struct ena_bus *bus, bus_size_t offset)
 #define time_after(a,b)	((long)((unsigned long)(b) - (unsigned long)(a)) < 0)
 
 #define VLAN_HLEN 	sizeof(struct ether_vlan_header)
-#define CSUM_OFFLOAD 	(CSUM_IP|CSUM_TCP|CSUM_UDP)
 
 #define prefetch(x)	(void)(x)
 #define prefetchw(x)	(void)(x)

--- a/kernel/fbsd/ena/ena_com/ena_plat.h
+++ b/kernel/fbsd/ena/ena_com/ena_plat.h
@@ -42,6 +42,9 @@ __FBSDID("$FreeBSD$");
 
 #include <sys/bus.h>
 #include <sys/condvar.h>
+#if __FreeBSD_version > 1200055
+#include <sys/domainset.h>
+#endif
 #include <sys/endian.h>
 #include <sys/kernel.h>
 #include <sys/kthread.h>
@@ -170,6 +173,8 @@ static inline long PTR_ERR(const void *ptr)
 #define ENA_COM_TIMER_EXPIRED	ETIMEDOUT
 #define ENA_COM_EIO		EIO
 
+#define ENA_NODE_ANY		(-1)
+
 #define ENA_MSLEEP(x) 		pause_sbt("ena", SBT_1MS * (x), SBT_1MS, 0)
 #define ENA_USLEEP(x) 		pause_sbt("ena", SBT_1US * (x), SBT_1US, 0)
 #define ENA_UDELAY(x) 		DELAY(x)
@@ -277,7 +282,7 @@ typedef struct ifnet ena_netdev;
 void	ena_dmamap_callback(void *arg, bus_dma_segment_t *segs, int nseg,
     int error);
 int	ena_dma_alloc(device_t dmadev, bus_size_t size, ena_mem_handle_t *dma,
-    int mapflags, bus_size_t alignment);
+    int mapflags, bus_size_t alignment, int domain);
 
 static inline uint32_t
 ena_reg_read32(struct ena_bus *bus, bus_size_t offset)
@@ -299,18 +304,42 @@ ena_reg_read32(struct ena_bus *bus, bus_size_t offset)
 	} while (0)
 
 #define ENA_MEM_ALLOC(dmadev, size) malloc(size, M_DEVBUF, M_NOWAIT | M_ZERO)
+
+#if __FreeBSD_version > 1200055
+#define ENA_MEM_ALLOC_NODE(dmadev, size, virt, node, dev_node)		\
+	do {								\
+		(virt) = malloc_domainset((size), M_DEVBUF,		\
+		    (node) < 0 ? DOMAINSET_RR() : DOMAINSET_PREF(node),	\
+		    M_NOWAIT | M_ZERO);					\
+		(void)(dev_node);					\
+	} while (0)
+#else
 #define ENA_MEM_ALLOC_NODE(dmadev, size, virt, node, dev_node) (virt = NULL)
+#endif
+
 #define ENA_MEM_FREE(dmadev, ptr, size)					\
 	do { 								\
 		(void)(size);						\
 		free(ptr, M_DEVBUF);					\
 	} while (0)
+#if __FreeBSD_version > 1200055
 #define ENA_MEM_ALLOC_COHERENT_NODE_ALIGNED(dmadev, size, virt, phys,	\
-    handle, node, dev_node, alignment) 					\
+    dma, node, dev_node, alignment) 					\
+	do {								\
+		ena_dma_alloc((dmadev), (size), &(dma), 0, (alignment),	\
+		    (node));						\
+		(virt) = (void *)(dma).vaddr;				\
+		(phys) = (dma).paddr;					\
+		(void)(dev_node);					\
+	} while (0)
+#else
+#define ENA_MEM_ALLOC_COHERENT_NODE_ALIGNED(dmadev, size, virt, phys,	\
+    dma, node, dev_node, alignment) 					\
 	do {								\
 		((virt) = NULL);					\
 		(void)(dev_node);					\
-	} while (0)
+	} while(0)
+#endif
 
 #define ENA_MEM_ALLOC_COHERENT_NODE(dmadev, size, virt, phys, handle,	\
     node, dev_node)							\
@@ -320,7 +349,8 @@ ena_reg_read32(struct ena_bus *bus, bus_size_t offset)
 #define ENA_MEM_ALLOC_COHERENT_ALIGNED(dmadev, size, virt, phys, dma,	\
     alignment)								\
 	do {								\
-		ena_dma_alloc((dmadev), (size), &(dma), 0, alignment);	\
+		ena_dma_alloc((dmadev), (size), &(dma), 0, (alignment),	\
+		    ENA_NODE_ANY);					\
 		(virt) = (void *)(dma).vaddr;				\
 		(phys) = (dma).paddr;					\
 	} while (0)

--- a/kernel/fbsd/ena/ena_datapath.c
+++ b/kernel/fbsd/ena/ena_datapath.c
@@ -47,7 +47,8 @@ __FBSDID("$FreeBSD$");
 
 static int	ena_tx_cleanup(struct ena_ring *);
 static int	ena_rx_cleanup(struct ena_ring *);
-static inline int validate_tx_req_id(struct ena_ring *, uint16_t);
+static inline int ena_get_tx_req_id(struct ena_ring *tx_ring,
+    struct ena_com_io_cq *io_cq, uint16_t *req_id);
 static void	ena_rx_hash_mbuf(struct ena_ring *, struct ena_com_rx_ctx *,
     struct mbuf *);
 static struct mbuf* ena_rx_mbuf(struct ena_ring *, struct ena_com_rx_buf_info *,
@@ -199,23 +200,27 @@ ena_qflush(if_t ifp)
  *********************************************************************/
 
 static inline int
-validate_tx_req_id(struct ena_ring *tx_ring, uint16_t req_id)
+ena_get_tx_req_id(struct ena_ring *tx_ring, struct ena_com_io_cq *io_cq,
+    uint16_t *req_id)
 {
 	struct ena_adapter *adapter = tx_ring->adapter;
-	struct ena_tx_buffer *tx_info = NULL;
+	int rc;
 
-	if (likely(req_id < tx_ring->ring_size)) {
-		tx_info = &tx_ring->tx_buffer_info[req_id];
-		if (tx_info->mbuf != NULL)
-			return (0);
-		ena_log(adapter->pdev, ERR,
-		    "tx_info doesn't have valid mbuf\n");
+	rc = ena_com_tx_comp_req_id_get(io_cq, req_id);
+	if (rc == ENA_COM_TRY_AGAIN)
+		return (EAGAIN);
+
+	if (unlikely(rc != 0)) {
+		ena_log(adapter->pdev, ERR, "Invalid req_id: %hu\n", *req_id);
+		counter_u64_add(tx_ring->tx_stats.bad_req_id, 1);
+		goto err;
 	}
 
-	ena_log(adapter->pdev, ERR, "Invalid req_id: %hu\n", req_id);
-	counter_u64_add(tx_ring->tx_stats.bad_req_id, 1);
+	if (tx_ring->tx_buffer_info[*req_id].mbuf != NULL)
+		return (0);
 
-	/* Trigger device reset */
+	ena_log(adapter->pdev, ERR, "tx_info doesn't have valid mbuf\n");
+err:
 	ena_trigger_reset(adapter, ENA_REGS_RESET_INV_TX_REQ_ID);
 
 	return (EFAULT);
@@ -261,11 +266,7 @@ ena_tx_cleanup(struct ena_ring *tx_ring)
 		struct ena_tx_buffer *tx_info;
 		struct mbuf *mbuf;
 
-		rc = ena_com_tx_comp_req_id_get(io_cq, &req_id);
-		if (unlikely(rc != 0))
-			break;
-
-		rc = validate_tx_req_id(tx_ring, req_id);
+		rc = ena_get_tx_req_id(tx_ring, io_cq, &req_id);
 		if (unlikely(rc != 0))
 			break;
 

--- a/kernel/fbsd/ena/ena_datapath.c
+++ b/kernel/fbsd/ena/ena_datapath.c
@@ -39,6 +39,8 @@ __FBSDID("$FreeBSD$");
 #include <net/rss_config.h>
 #endif /* RSS */
 
+#include <netinet6/ip6_var.h>
+
 /*********************************************************************
  *  Static functions prototypes
  *********************************************************************/
@@ -711,6 +713,7 @@ ena_tx_csum(struct ena_com_tx_ctx *ena_tx_ctx, struct mbuf *mbuf,
 	uint16_t etype;
 	int ehdrlen;
 	struct ip *ip;
+	int ipproto;
 	int iphlen;
 	struct tcphdr *th;
 	int offset;
@@ -726,6 +729,9 @@ ena_tx_csum(struct ena_com_tx_ctx *ena_tx_ctx, struct mbuf *mbuf,
 		offload = true;
 
 	if ((mbuf->m_pkthdr.csum_flags & CSUM_OFFLOAD) != 0)
+		offload = true;
+
+	if ((mbuf->m_pkthdr.csum_flags & CSUM6_OFFLOAD) != 0)
 		offload = true;
 
 	if (!offload) {
@@ -749,8 +755,27 @@ ena_tx_csum(struct ena_com_tx_ctx *ena_tx_ctx, struct mbuf *mbuf,
 	}
 
 	mbuf_next = m_getptr(mbuf, ehdrlen, &offset);
-	ip = (struct ip *)(mtodo(mbuf_next, offset));
-	iphlen = ip->ip_hl << 2;
+
+	switch (etype) {
+	case ETHERTYPE_IP:
+		ip = (struct ip *)(mtodo(mbuf_next, offset));
+		iphlen = ip->ip_hl << 2;
+		ipproto = ip->ip_p;
+		ena_tx_ctx->l3_proto = ENA_ETH_IO_L3_PROTO_IPV4;
+		if ((ip->ip_off & htons(IP_DF)) != 0)
+			ena_tx_ctx->df = 1;
+		break;
+	case ETHERTYPE_IPV6:
+		ena_tx_ctx->l3_proto = ENA_ETH_IO_L3_PROTO_IPV6;
+		iphlen = ip6_lasthdr(mbuf, ehdrlen, IPPROTO_IPV6, &ipproto);
+		iphlen -= ehdrlen;
+		ena_tx_ctx->df = 1;
+		break;
+	default:
+		iphlen = 0;
+		ipproto = 0;
+		break;
+	}
 
 	mbuf_next = m_getptr(mbuf, iphlen + ehdrlen, &offset);
 	th = (struct tcphdr *)(mtodo(mbuf_next, offset));
@@ -763,27 +788,14 @@ ena_tx_csum(struct ena_com_tx_ctx *ena_tx_ctx, struct mbuf *mbuf,
 		ena_meta->l4_hdr_len = (th->th_off);
 	}
 
-	switch (etype) {
-	case ETHERTYPE_IP:
-		ena_tx_ctx->l3_proto = ENA_ETH_IO_L3_PROTO_IPV4;
-		if ((ip->ip_off & htons(IP_DF)) != 0)
-			ena_tx_ctx->df = 1;
-		break;
-	case ETHERTYPE_IPV6:
-		ena_tx_ctx->l3_proto = ENA_ETH_IO_L3_PROTO_IPV6;
-
-	default:
-		break;
-	}
-
-	if (ip->ip_p == IPPROTO_TCP) {
+	if (ipproto == IPPROTO_TCP) {
 		ena_tx_ctx->l4_proto = ENA_ETH_IO_L4_PROTO_TCP;
 		if ((mbuf->m_pkthdr.csum_flags &
 		    (CSUM_IP_TCP | CSUM_IP6_TCP)) != 0)
 			ena_tx_ctx->l4_csum_enable = 1;
 		else
 			ena_tx_ctx->l4_csum_enable = 0;
-	} else if (ip->ip_p == IPPROTO_UDP) {
+	} else if (ipproto == IPPROTO_UDP) {
 		ena_tx_ctx->l4_proto = ENA_ETH_IO_L4_PROTO_UDP;
 		if ((mbuf->m_pkthdr.csum_flags &
 		    (CSUM_IP_UDP | CSUM_IP6_UDP)) != 0)

--- a/kernel/fbsd/ena/ena_datapath.h
+++ b/kernel/fbsd/ena/ena_datapath.h
@@ -39,4 +39,7 @@ void	ena_qflush(if_t ifp);
 int	ena_mq_start(if_t ifp, struct mbuf *m);
 void	ena_deferred_mq_start(void *arg, int pending);
 
+#define CSUM_OFFLOAD 	(CSUM_IP|CSUM_TCP|CSUM_UDP)
+#define CSUM6_OFFLOAD	(CSUM_IP6_UDP|CSUM_IP6_TCP)
+
 #endif /* ENA_TXRX_H */

--- a/kernel/fbsd/ena/ena_sysctl.c
+++ b/kernel/fbsd/ena/ena_sysctl.c
@@ -454,7 +454,7 @@ ena_sysctl_add_rss(struct ena_adapter *adapter)
 
 	/* RSS indirection table size */
 	SYSCTL_ADD_INT(ctx, child, OID_AUTO, "indir_table_size",
-	    CTLTYPE_INT | CTLFLAG_RD | CTLFLAG_MPSAFE, &ena_rss_table_size, 0,
+	    CTLFLAG_RD | CTLFLAG_MPSAFE, &ena_rss_table_size, 0,
 	    "RSS indirection table size.");
 }
 #endif /* RSS */

--- a/kernel/fbsd/ena/ena_sysctl.c
+++ b/kernel/fbsd/ena/ena_sysctl.c
@@ -206,6 +206,14 @@ ena_sysctl_add_stats(struct ena_adapter *adapter)
 
 		adapter->que[i].oid = queue_node;
 
+#ifdef RSS
+		/* Common stats */
+		SYSCTL_ADD_INT(ctx, queue_list, OID_AUTO, "cpu",
+		    CTLFLAG_RD, &adapter->que[i].cpu, 0, "CPU affinity");
+		SYSCTL_ADD_INT(ctx, queue_list, OID_AUTO, "domain",
+		    CTLFLAG_RD, &adapter->que[i].domain, 0, "NUMA domain");
+#endif
+
 		/* TX specific stats */
 		tx_node = SYSCTL_ADD_NODE(ctx, queue_list, OID_AUTO,
 		    "tx_ring", CTLFLAG_RD | CTLFLAG_MPSAFE, NULL, "TX ring");
@@ -916,4 +924,3 @@ unlock:
 	return (error);
 }
 #endif /* RSS */
-


### PR DESCRIPTION
*Description of changes:*

Some of the changes in this release:
- IPv6 L4 checksum offload fixes.
- Optimization of the Tx req_id validatio
- Timer service adjustments.
- NUMA awareness for the kernel RSS mode.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
