### PR TITLE
dpdk/ena: add notice about LLQ and HW generations

### DIFF
--- a/userspace/dpdk/README.md
+++ b/userspace/dpdk/README.md
@@ -414,6 +414,16 @@ __*Notes:*__
 
 ## 6. vfio-pci and igb_uio
 
+__Important note - please read it first!__
+
+ENA on 5th generation instances and newer supports LLQ (Low Latency Queue) mode.
+While it's highly recommended to use the LLQ mode for the 5th generation
+platforms, it is specifically required on the 6th generation platforms and
+later. Failing to do so will result in a huge performance degradation.
+
+List of the all instance generation can be found
+[here](https://aws.amazon.com/ec2/instance-types/).
+
 ### 6.1. ENAv2 (>= v2.0.0) and Write Combining
 
 For ENA PMD of v2.0.0 and higher it's mandatory to map memory BAR of the ENA as


### PR DESCRIPTION
Disabling LLQ may have negative impact on the performance especially
starting from the 6th generation platforms.

The ENA DPDK documentation was updated with the appropriate notice,
which highlights the impact of disabling the LLQ depending on the
used platform.

Signed-off-by: Michal Krawczyk <mk@semihalf.com>

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
