### PR TITLE
Fix the missing code block

### DIFF
--- a/kernel/linux/ena/ENA_Linux_Best_Practices.rst
+++ b/kernel/linux/ena/ENA_Linux_Best_Practices.rst
@@ -186,7 +186,7 @@ type. On some instance types Rx moderation is disabled by default, on others it
 is enabled in adaptive mode.
 Please use
 
-.. code-block::bash
+.. code-block:: bash
 
     $ ethtool -c DEVNAME
 


### PR DESCRIPTION
*Description of changes:*

There was a missing whitespace that cause the code block missing. 

Original:
`.. code-block::bash`

Modified:
`.. code-block:: bash`

Add a whitespace to fix this issue.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
