### PR TITLE
[ENA] RHEL 8.6 backported some kernel 5.15 networking features, causing the detection not to work on default RHEL 8.6 kernels

### DIFF
--- a/kernel/linux/ena/kcompat.h
+++ b/kernel/linux/ena/kcompat.h
@@ -884,18 +884,20 @@ xdp_prepare_buff(struct xdp_buff *xdp, unsigned char *hard_start,
 #define ENA_XDP_XMIT_FREES_FAILED_DESCS_INTERNALLY
 #endif
 
-#if LINUX_VERSION_CODE < KERNEL_VERSION(5, 15, 0)
+#if ((LINUX_VERSION_CODE < KERNEL_VERSION(5, 15, 0)) && \
+     !(RHEL_RELEASE_CODE && RHEL_RELEASE_CODE >= RHEL_RELEASE_VERSION(8, 6)))
 
 static inline void eth_hw_addr_set(struct net_device *dev, const u8 *addr)
 {
 	memcpy(dev->dev_addr, addr, ETH_ALEN);
 }
 
-#endif /* LINUX_VERSION_CODE < KERNEL_VERSION(5, 15, 0) */
+#endif /* LINUX_VERSION_CODE < KERNEL_VERSION(5, 15, 0) but not RHEL >= 8.6 */
 
-#if LINUX_VERSION_CODE >= KERNEL_VERSION(5, 15, 0)
+#if ((LINUX_VERSION_CODE >= KERNEL_VERSION(5, 15, 0)) || \
+     (RHEL_RELEASE_CODE && RHEL_RELEASE_CODE >= RHEL_RELEASE_VERSION(8, 6)))
 #define ENA_EXTENDED_COALESCE_UAPI_WITH_CQE_SUPPORTED
-#endif
+#endif /* LINUX_VERSION_CODE >= KERNEL_VERSION(5, 15, 0) or RHEL >= 8.6 */
 
 #if LINUX_VERSION_CODE >= KERNEL_VERSION(5, 17, 0)
 #define ENA_ETHTOOL_RX_BUFF_SIZE_CHANGE


### PR DESCRIPTION
*Description of changes:* Modified the kcompat.h detection in ENA 2.7 so that the kernel 5.15 features backported to the RHEL 8.6 kernel (4.18.0-372.9.1.el8) are properly detected. Otherwise, compilation fails with errors like this:

```
ena/kcompat.h:889:20: error: redefinition of ‘eth_hw_addr_set’
ena/ena_ethtool.c:1111:19: error: initialization of ‘int (*)(struct net_device *,
  struct ethtool_coalesce *, struct kernel_ethtool_coalesce *, struct netlink_ext_ack *)’ from incompatible
  pointer type ‘int (*)(struct net_device *, struct ethtool_coalesce *)’ [-Werror=incompatible-pointer-types]
```

I have tested this on Rocky Linux 8.6 aarch64 and x86_64, but it should apply to CentOS Stream and RHEL as well.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.