### PR TITLE
fbsd/ena: Update driver version to v2.6.0

### DIFF
--- a/kernel/fbsd/ena/Makefile
+++ b/kernel/fbsd/ena/Makefile
@@ -46,20 +46,67 @@ SRCS	+= ena.c ena_sysctl.c ena_datapath.c ena_netmap.c ena_rss.c
 CFLAGS  += -DSMP -O2
 CFLAGS  += -I${.CURDIR}/ena_com
 
+.if defined(DEBUG)
 # Enable debug messages and sysctls
-# CFLAGS  += -DENA_DEBUG
-
+CFLAGS  += -DENA_DEBUG
 # Enable logging on Tx/Rx data path.
 # When disabled, ena_log_io calls remain compiled out for performance purposes.
-# CFLAGS += -DENA_LOG_IO_ENABLE
+CFLAGS += -DENA_LOG_IO_ENABLE
+.endif
 
-# Add netmap support in the driver.
-# Uncomment this only if the netmap is enabled in the kernel.
-# CFLAGS += -DDEV_NETMAP
+# Try to determine if the driver should be built with the DEV_NETMAP option.
+# It will be enabled if:
+# - user doesn't define DEV_NETMAP variable and the current kernel has been
+#   built with the 'device netmap'
+# - user defines DEV_NETMAP variable and it's value is not 0.
+.if !make(clean) && ((!defined(DEV_NETMAP) && \
+    ${:!sysctl dev.netmap > /dev/null 2>&1; echo \$?!} == 0) || \
+    (defined(DEV_NETMAP) && ${DEV_NETMAP} != 0))
+.info Enabling DEV_NETMAP for the driver.
+CFLAGS += -DDEV_NETMAP
+.endif
 
-# Add kernel side RSS support in the driver.
-# Uncomment this only if RSS is enabled in the kernel.
-# CFLAGS += -DRSS
+# Try to determine if the driver should be built with the RSS option.
+# The requirements are similar as for the DEV_NETMAP option, except that the
+# script checks for the RSS option and variable instead.
+.if !make(clean) && ((!defined(RSS) && \
+    ${:!sysctl net.inet.rss > /dev/null 2>&1; echo \$?!} == 0) || \
+    (defined(RSS) && ${RSS} != 0))
+.info Enabling kernel RSS for the driver.
+CFLAGS += -DRSS
+.endif
+
+# Try to determine if the driver should be built with the extra debugging
+# facilities which also must be provided by the kernel.
+# As those options may affect driver's performance by adding extra sanity
+# checks, they must be explicitely enabled by passing the DEBUG variable to
+# the make command.
+# Please note that enabling those options in the kernel will affect the driver's
+# performance anyway.
+.if !make(clean) && defined(DEBUG) && ((!defined(INVARIANT_SUPPORT) && \
+    ${:!sysctl kern.features.invariant_support > /dev/null 2>&1; echo \$?!} == 0) || \
+    (defined(INVARIANT_SUPPORT) && ${INVARIANT_SUPPORT} != 0))
+.info Enabling INVARIANT_SUPPORT debug flag.
+CFLAGS += -DINVARIANT_SUPPORT
+.endif
+.if !make(clean) && defined(DEBUG) && ((!defined(INVARIANTS) && \
+    ${:!sysctl kern.features.invariants > /dev/null 2>&1; echo \$?!} == 0) || \
+    (defined(INVARIANTS) && ${INVARIANTS} != 0))
+.info Enabling INVARIANTS debug flag.
+CFLAGS += -DINVARIANTS
+.endif
+.if !make(clean) && defined(DEBUG) && ((!defined(WITNESS) && \
+    ${:!sysctl kern.features.witness > /dev/null 2>&1; echo \$?!} == 0) || \
+    (defined(WITNESS) && ${WITNESS} != 0))
+.info Enabling WITNESS debug flag.
+CFLAGS += -DWITNESS
+.endif
+.if !make(clean) && defined(DEBUG) && ((!defined(WITNESS_SKIPSPIN) && \
+    ${:!sysctl debug.witness.skipspin 2> /dev/null | grep '1' > /dev/null; echo \$?!} == 0) || \
+    (defined(WITNESS_SKIPSPIN) && ${WITNESS_SKIPSPIN} != 0))
+.info Enabling WITNESS_SKIPSPIN debug flag.
+CFLAGS += -DWITNESS_SKIPSPIN
+.endif
 
 clean:
 	rm -f opt_global.h opt_bdg.h device_if.h bus_if.h pci_if.h setdef* *_StripErr

--- a/kernel/fbsd/ena/README.rst
+++ b/kernel/fbsd/ena/README.rst
@@ -565,31 +565,38 @@ Compilation flags
 -----------------
 
 The supplied Makefile provides multiple optional compilation flags, allowing
-for customization of the driver operation. All of those flags are by default
-disabled and require the user to manually uncomment relevant lines. Those
-include:
+for customization of the driver operation.
 
-* ``ENA_LOG_IO_ENABLE``
+The Makefile will automatically attempt to detect the running kernel
+configuration and enable appropriate build flags if needed. This behavior can
+be overridden by passing variables to the make command, like below:
 
-  The driver provides an ability to control log verbosity at runtime, through
-  the sysctl interface. However, by default, the Tx/Rx data path logs remain
-  compiled out, even when matching log verbosity is set. This is dictated by
-  performance reasons. In order to enable logging on the data path,
-  the following line should be uncommented:
+.. code-block:: sh
 
-  .. code-block:: Makefile
+  make DEV_NETMAP=1 RSS=0
 
-    # CFLAGS += -DENA_LOG_IO_ENABLE
+This command will force-enable ``DEV_NETMAP`` flag and force-disable ``RSS``
+flag.
+
+Description of the available arguments and their meaning can be found below.
+
+* ``DEBUG``
+
+  This option turns on the flag ``ENA_LOG_IO_ENABLE``. The driver provides an
+  ability to control log verbosity at runtime, through the sysctl interface.
+  However, by default, the Tx/Rx data path logs remain compiled out, even when
+  matching log verbosity is set. This is dictated by performance reasons.
+
+  Also the ``DEBUG`` variable must be defined in order to use ``INVARIANTS``,
+  ``INVARIANT_SUPPORT``, ``WITNESS`` and ``WITNESS_SKIPSPIN`` flags, which will
+  be used if the kernel has been built with them or the user forces their usage
+  by passing them as a make variable.
 
 * ``DEV_NETMAP``
 
   The driver supports the `netmap <https://github.com/luigirizzo/netmap/>`_
-  framework. In order to use this feature, the following line should be
-  uncommented:
-
-  .. code-block:: Makefile
-
-    # CFLAGS += -DDEV_NETMAP
+  framework. If the ``device netmap`` has been enabled for the running kernel,
+  then it will be automatically added to the driver build configuration.
 
   The kernel must also be built with ``DEV_NETMAP`` option in order to be able
   to use the driver with the netmap support, which is default for ``amd64``, but
@@ -597,13 +604,7 @@ include:
 
 * ``RSS``
 
-  The driver is able to work with kernel side Receive Side Scaling support. In
-  order to use this feature, the following line should be uncommented:
-
-  .. code-block:: Makefile
-
-    # CFLAGS += -DRSS
-
+  The driver is able to work with kernel side Receive Side Scaling support.
   This flag should only be used if ``option RSS`` is enabled in the kernel.
 
 Management Interface

--- a/kernel/fbsd/ena/README.rst
+++ b/kernel/fbsd/ena/README.rst
@@ -49,11 +49,8 @@ When RSS is enabled, each Tx/Rx queue pair is bound to a corresponding
 CPU core and its NUMA domain. The order of those bindings is based on
 the RSS bucket mapping. For builds with RSS support disabled, the
 CPU and NUMA management is left to the kernel. CPU and NUMA management
-are only supported on FreeBSD 12 or newer.
-
-The ENA driver supports industry standard TCP/IP offload features such
-as checksum offload and TCP transmit segmentation offload (TSO).
-Receive-side scaling (RSS) is supported for multi-core scaling.
+are only supported on FreeBSD 12 or newer. Receive-side scaling (RSS) is
+supported for multi-core scaling.
 
 The ENA driver and its corresponding devices implement health
 monitoring mechanisms such as watchdog, enabling the device and driver
@@ -755,7 +752,6 @@ Stateless Offloads
 
 The ENA driver supports:
 
-* TSO over IPv4/IPv6
 * IPv4 header checksum offload
 * TCP/UDP over IPv4/IPv6 checksum offloads
 

--- a/kernel/fbsd/ena/README.rst
+++ b/kernel/fbsd/ena/README.rst
@@ -4,14 +4,14 @@ FreeBSD kernel driver for Elastic Network Adapter (ENA) family
 Version
 -------
 
-``2.5.0``
+``2.6.0``
 
 Supported FreeBSD Versions
 --------------------------
 
 **amd64**
 
-* *FreeBSD release/11.0* - and so on
+* *FreeBSD 11.0* - *FreeBSD 11.4*
 * *FreeBSD 12* - starting from ``rS3091111``
 * *FreeBSD 13*
 * *FreeBSD 14*

--- a/kernel/fbsd/ena/RELEASENOTES.md
+++ b/kernel/fbsd/ena/RELEASENOTES.md
@@ -9,16 +9,37 @@ The driver was verified on the following distributions:
 **Releases:**
 * FreeBSD 11.4
 * FreeBSD 12.3
-* FreeBSD 13.0
+* FreeBSD 13.1
 
 **Development:**
 +-----------+-------------+
 | Branch    | SHA         |
 +-----------+-------------+
-| stable/12 | dfe7186f287 |
-| stable/13 | cb4d27f48ef |
-| HEAD      | b406897911e |
+| stable/12 | dad7c072f48 |
+| stable/13 | 185159f77c9 |
+| HEAD      | 8020c05683f |
 +-----------+-------------+
+
+## r2.6.0 release notes
+**New Features**
+* Rework the Makefile to automatically detect the kernel options. This also
+  changes the supported compilation options.
+
+**Bug Fixes**
+* Fix invalid KASSERT in the netmap code.
+* Fix ENI metrics probing, by moving it to a separate task. That fixes the
+  issue with the sleep inside the callout.
+* Prevent LLQ initialization when membar isn't exposed.
+
+**Minor Changes**
+* Remove write-only variables.
+* Code style improvements.
+* Align the driver with the latest upstream kernel driver changes.
+* Use the generic function for setting the device description in probe.
+* Documentation update regarding the TSO.
+* Use atomic accessors for the first_interrupt variable.
+* Store last Tx cleanup ticks for easier device reset debugging.
+* Logging improvements.
 
 ## r2.5.0 release notes
 **New Features**

--- a/kernel/fbsd/ena/ena.c
+++ b/kernel/fbsd/ena/ena.c
@@ -296,7 +296,6 @@ static int
 ena_probe(device_t dev)
 {
 	ena_vendor_info_t *ent;
-	char		adapter_name[60];
 	uint16_t	pci_vendor_id = 0;
 	uint16_t	pci_device_id = 0;
 
@@ -310,8 +309,7 @@ ena_probe(device_t dev)
 			ena_log_raw(DBG, "vendor=%x device=%x\n",
 			    pci_vendor_id, pci_device_id);
 
-			sprintf(adapter_name, DEVICE_DESC);
-			device_set_desc_copy(dev, adapter_name);
+			device_set_desc(dev, DEVICE_DESC);
 			return (BUS_PROBE_DEFAULT);
 		}
 

--- a/kernel/fbsd/ena/ena.c
+++ b/kernel/fbsd/ena/ena.c
@@ -2543,7 +2543,7 @@ ena_calc_max_io_queue_num(device_t pdev, struct ena_com_dev *ena_dev,
 	max_num_io_queues = min_t(uint32_t, max_num_io_queues, io_rx_num);
 	max_num_io_queues = min_t(uint32_t, max_num_io_queues, io_tx_sq_num);
 	max_num_io_queues = min_t(uint32_t, max_num_io_queues, io_tx_cq_num);
-	/* 1 IRQ for for mgmnt and 1 IRQ for each TX/RX pair */
+	/* 1 IRQ for mgmnt and 1 IRQ for each TX/RX pair */
 	max_num_io_queues = min_t(uint32_t, max_num_io_queues,
 	    pci_msix_count(pdev) - 1);
 #ifdef RSS
@@ -3961,8 +3961,7 @@ static driver_t ena_driver = {
     "ena", ena_methods, sizeof(struct ena_adapter),
 };
 
-devclass_t ena_devclass;
-DRIVER_MODULE(ena, pci, ena_driver, ena_devclass, 0, 0);
+DRIVER_MODULE(ena, pci, ena_driver, 0, 0);
 MODULE_PNP_INFO("U16:vendor;U16:device", pci, ena, ena_vendor_info_array,
 #if __FreeBSD_version > 1200084
     nitems(ena_vendor_info_array) - 1);

--- a/kernel/fbsd/ena/ena.c
+++ b/kernel/fbsd/ena/ena.c
@@ -439,6 +439,7 @@ ena_init_io_rings_advanced(struct ena_adapter *adapter)
 		/* Allocate Tx statistics. */
 		ena_alloc_counters((counter_u64_t *)&txr->tx_stats,
 		    sizeof(txr->tx_stats));
+		txr->tx_last_cleanup_ticks = ticks;
 
 		/* Allocate Rx statistics. */
 		ena_alloc_counters((counter_u64_t *)&rxr->rx_stats,
@@ -3039,6 +3040,8 @@ check_missing_comp_in_tx_queue(struct ena_adapter *adapter,
 	device_t pdev = adapter->pdev;
 	struct bintime curtime, time;
 	struct ena_tx_buffer *tx_buf;
+	int time_since_last_cleanup;
+	int missing_tx_comp_to;
 	sbintime_t time_offset;
 	uint32_t missed_tx = 0;
 	int i, rc = 0;
@@ -3072,10 +3075,23 @@ check_missing_comp_in_tx_queue(struct ena_adapter *adapter,
 		/* Check again if packet is still waiting */
 		if (unlikely(time_offset > adapter->missing_tx_timeout)) {
 
-			if (!tx_buf->print_once)
+			if (!tx_buf->print_once) {
+#if __FreeBSD_version > 1200066
+				time_since_last_cleanup = TICKS_2_USEC(ticks -
+				    tx_ring->tx_last_cleanup_ticks);
+#else
+				time_since_last_cleanup = 1000000 * (ticks -
+				    tx_ring->tx_last_cleanup_ticks) / hz;
+#endif
+				missing_tx_comp_to =
+				    sbttoms(adapter->missing_tx_timeout);
 				ena_log(pdev, WARN, "Found a Tx that wasn't "
-				    "completed on time, qid %d, index %d.\n",
-				    tx_ring->qid, i);
+				    "completed on time, qid %d, index %d."
+				    "%d usecs have passed since last cleanup."
+				    "Missing Tx timeout value %d msecs.\n",
+				    tx_ring->qid, i, time_since_last_cleanup,
+				    missing_tx_comp_to);
+			}
 
 			tx_buf->print_once = true;
 			missed_tx++;

--- a/kernel/fbsd/ena/ena.c
+++ b/kernel/fbsd/ena/ena.c
@@ -153,6 +153,7 @@ static int	ena_setup_ifnet(device_t, struct ena_adapter *,
 static int	ena_enable_wc(device_t, struct resource *);
 static int	ena_set_queues_placement_policy(device_t, struct ena_com_dev *,
     struct ena_admin_feature_llq_desc *, struct ena_llq_configurations *);
+static int	ena_map_llq_mem_bar(device_t, struct ena_com_dev *);
 static uint32_t	ena_calc_max_io_queue_num(device_t, struct ena_com_dev *,
     struct ena_com_dev_get_features_ctx *);
 static int	ena_calc_io_queue_size(struct ena_calc_queue_size_ctx *);
@@ -2603,8 +2604,7 @@ ena_set_queues_placement_policy(device_t pdev, struct ena_com_dev *ena_dev,
     struct ena_admin_feature_llq_desc *llq,
     struct ena_llq_configurations *llq_default_configurations)
 {
-	struct ena_adapter *adapter = device_get_softc(pdev);
-	int rc, rid;
+	int rc;
 	uint32_t llq_feature_mask;
 
 	llq_feature_mask = 1 << ENA_ADMIN_LLQ;
@@ -2615,17 +2615,28 @@ ena_set_queues_placement_policy(device_t pdev, struct ena_com_dev *ena_dev,
 		return (0);
 	}
 
+	if (ena_dev->mem_bar == NULL) {
+		ena_log(pdev, WARN,
+		    "LLQ is advertised as supported but device doesn't expose mem bar.\n");
+		ena_dev->tx_mem_queue_type = ENA_ADMIN_PLACEMENT_POLICY_HOST;
+		return (0);
+	}
+
 	rc = ena_com_config_dev_mode(ena_dev, llq, llq_default_configurations);
 	if (unlikely(rc != 0)) {
 		ena_log(pdev, WARN, "Failed to configure the device mode. "
 		    "Fallback to host mode policy.\n");
 		ena_dev->tx_mem_queue_type = ENA_ADMIN_PLACEMENT_POLICY_HOST;
-		return (0);
 	}
 
-	/* Nothing to config, exit */
-	if (ena_dev->tx_mem_queue_type == ENA_ADMIN_PLACEMENT_POLICY_HOST)
-		return (0);
+	return (0);
+}
+
+static int
+ena_map_llq_mem_bar(device_t pdev, struct ena_com_dev *ena_dev)
+{
+	struct ena_adapter *adapter = device_get_softc(pdev);
+	int rc, rid;
 
 	/* Try to allocate resources for LLQ bar */
 	rid = PCIR_BAR(ENA_MEM_BAR);
@@ -3626,6 +3637,12 @@ ena_attach(device_t pdev)
 	}
 
 	set_default_llq_configurations(&llq_config, &get_feat_ctx.llq);
+
+	rc = ena_map_llq_mem_bar(pdev, ena_dev);
+	if (unlikely(rc != 0)) {
+		ena_log(pdev, ERR, "failed to map ENA mem bar");
+		goto err_com_free;
+	}
 
 	rc = ena_set_queues_placement_policy(pdev, ena_dev, &get_feat_ctx.llq,
 	     &llq_config);

--- a/kernel/fbsd/ena/ena.c
+++ b/kernel/fbsd/ena/ena.c
@@ -3487,9 +3487,6 @@ ena_restore_device(struct ena_adapter *adapter)
 
 	ENA_FLAG_CLEAR_ATOMIC(ENA_FLAG_DEV_UP_BEFORE_RESET, adapter);
 
-	ena_log(dev, INFO,
-	    "Device reset completed successfully, Driver info: %s\n", ena_version);
-
 	return (rc);
 
 err_disable_msix:
@@ -3520,6 +3517,10 @@ ena_reset_task(void *arg, int pending)
 	if (likely(ENA_FLAG_ISSET(ENA_FLAG_TRIGGER_RESET, adapter))) {
 		ena_destroy_device(adapter, false);
 		ena_restore_device(adapter);
+
+		ena_log(adapter->pdev, INFO,
+		    "Device reset completed successfully, Driver info: %s\n",
+		    ena_version);
 	}
 	ENA_LOCK_UNLOCK();
 }

--- a/kernel/fbsd/ena/ena.c
+++ b/kernel/fbsd/ena/ena.c
@@ -3961,7 +3961,12 @@ static driver_t ena_driver = {
     "ena", ena_methods, sizeof(struct ena_adapter),
 };
 
+#if __FreeBSD_version > 1400057
 DRIVER_MODULE(ena, pci, ena_driver, 0, 0);
+#else
+devclass_t ena_devclass;
+DRIVER_MODULE(ena, pci, ena_driver, ena_devclass, 0, 0);
+#endif
 MODULE_PNP_INFO("U16:vendor;U16:device", pci, ena, ena_vendor_info_array,
 #if __FreeBSD_version > 1200084
     nitems(ena_vendor_info_array) - 1);

--- a/kernel/fbsd/ena/ena.c
+++ b/kernel/fbsd/ena/ena.c
@@ -168,7 +168,8 @@ static void unimplemented_aenq_handler(void *, struct ena_admin_aenq_entry *);
 static int ena_copy_eni_metrics(struct ena_adapter *);
 static void ena_timer_service(void *);
 
-static char ena_version[] = DEVICE_NAME DRV_MODULE_NAME " v" DRV_MODULE_VERSION;
+static char ena_version[] = ENA_DEVICE_NAME ENA_DRV_MODULE_NAME
+    " v" ENA_DRV_MODULE_VERSION;
 
 static ena_vendor_info_t ena_vendor_info_array[] = {
 	{ PCI_VENDOR_ID_AMAZON, PCI_DEV_ID_ENA_PF, 0 },
@@ -307,7 +308,7 @@ ena_probe(device_t dev)
 			ena_log_raw(DBG, "vendor=%x device=%x\n", pci_vendor_id,
 			    pci_device_id);
 
-			device_set_desc(dev, DEVICE_DESC);
+			device_set_desc(dev, ENA_DEVICE_DESC);
 			return (BUS_PROBE_DEFAULT);
 		}
 
@@ -2768,9 +2769,9 @@ ena_config_host_info(struct ena_com_dev *ena_dev, device_t dev)
 	strncpy(host_info->os_dist_str, osrelease,
 	    sizeof(host_info->os_dist_str) - 1);
 
-	host_info->driver_version = (DRV_MODULE_VER_MAJOR) |
-	    (DRV_MODULE_VER_MINOR << ENA_ADMIN_HOST_INFO_MINOR_SHIFT) |
-	    (DRV_MODULE_VER_SUBMINOR << ENA_ADMIN_HOST_INFO_SUB_MINOR_SHIFT);
+	host_info->driver_version = (ENA_DRV_MODULE_VER_MAJOR) |
+	    (ENA_DRV_MODULE_VER_MINOR << ENA_ADMIN_HOST_INFO_MINOR_SHIFT) |
+	    (ENA_DRV_MODULE_VER_SUBMINOR << ENA_ADMIN_HOST_INFO_SUB_MINOR_SHIFT);
 	host_info->num_cpus = mp_ncpus;
 	host_info->driver_supported_features =
 	    ENA_ADMIN_HOST_INFO_RX_OFFSET_MASK |
@@ -3541,10 +3542,10 @@ ena_attach(device_t pdev)
 	 * concurrency, as the callout won't be using any locking inside.
 	 */
 	ENA_TIMER_INIT(adapter);
-	adapter->keep_alive_timeout = DEFAULT_KEEP_ALIVE_TO;
-	adapter->missing_tx_timeout = DEFAULT_TX_CMP_TO;
-	adapter->missing_tx_max_queues = DEFAULT_TX_MONITORED_QUEUES;
-	adapter->missing_tx_threshold = DEFAULT_TX_CMP_THRESHOLD;
+	adapter->keep_alive_timeout = ENA_DEFAULT_KEEP_ALIVE_TO;
+	adapter->missing_tx_timeout = ENA_DEFAULT_TX_CMP_TO;
+	adapter->missing_tx_max_queues = ENA_DEFAULT_TX_MONITORED_QUEUES;
+	adapter->missing_tx_threshold = ENA_DEFAULT_TX_CMP_THRESHOLD;
 
 	if (version_printed++ == 0)
 		ena_log(pdev, INFO, "%s\n", ena_version);

--- a/kernel/fbsd/ena/ena.c
+++ b/kernel/fbsd/ena/ena.c
@@ -34,6 +34,7 @@ __FBSDID("$FreeBSD$");
 #include <sys/systm.h>
 #include <sys/bus.h>
 #include <sys/endian.h>
+#include <sys/eventhandler.h>
 #include <sys/kernel.h>
 #include <sys/kthread.h>
 #include <sys/malloc.h>
@@ -46,41 +47,39 @@ __FBSDID("$FreeBSD$");
 #include <sys/sysctl.h>
 #include <sys/taskqueue.h>
 #include <sys/time.h>
-#include <sys/eventhandler.h>
+
+#include <vm/vm.h>
+#include <vm/pmap.h>
 
 #include <machine/atomic.h>
 #include <machine/bus.h>
-#include <machine/resource.h>
 #include <machine/in_cksum.h>
+#include <machine/resource.h>
+
+#include <dev/pci/pcireg.h>
+#include <dev/pci/pcivar.h>
 
 #include <net/bpf.h>
 #include <net/ethernet.h>
 #include <net/if.h>
-#include <net/if_var.h>
 #include <net/if_arp.h>
 #include <net/if_dl.h>
 #include <net/if_media.h>
 #include <net/if_types.h>
+#include <net/if_var.h>
 #include <net/if_vlan_var.h>
-
-#include <netinet/in_systm.h>
 #include <netinet/in.h>
+#include <netinet/in_systm.h>
 #include <netinet/if_ether.h>
 #include <netinet/ip.h>
 #include <netinet/ip6.h>
 #include <netinet/tcp.h>
 #include <netinet/udp.h>
 
-#include <dev/pci/pcivar.h>
-#include <dev/pci/pcireg.h>
-
-#include <vm/vm.h>
-#include <vm/pmap.h>
-
-#include "ena_datapath.h"
 #include "ena.h"
-#include "ena_sysctl.h"
+#include "ena_datapath.h"
 #include "ena_rss.h"
+#include "ena_sysctl.h"
 
 #ifdef DEV_NETMAP
 #include "ena_netmap.h"
@@ -89,96 +88,95 @@ __FBSDID("$FreeBSD$");
 /*********************************************************
  *  Function prototypes
  *********************************************************/
-static int	ena_probe(device_t);
-static void	ena_intr_msix_mgmnt(void *);
-static void	ena_free_pci_resources(struct ena_adapter *);
-static int	ena_change_mtu(if_t, int);
+static int ena_probe(device_t);
+static void ena_intr_msix_mgmnt(void *);
+static void ena_free_pci_resources(struct ena_adapter *);
+static int ena_change_mtu(if_t, int);
 static inline void ena_alloc_counters(counter_u64_t *, int);
 static inline void ena_free_counters(counter_u64_t *, int);
 static inline void ena_reset_counters(counter_u64_t *, int);
-static void	ena_init_io_rings_common(struct ena_adapter *,
-    struct ena_ring *, uint16_t);
-static void	ena_init_io_rings_basic(struct ena_adapter *);
-static void	ena_init_io_rings_advanced(struct ena_adapter *);
-static void	ena_init_io_rings(struct ena_adapter *);
-static void	ena_free_io_ring_resources(struct ena_adapter *, unsigned int);
-static void	ena_free_all_io_rings_resources(struct ena_adapter *);
-static int	ena_setup_tx_dma_tag(struct ena_adapter *);
-static int	ena_free_tx_dma_tag(struct ena_adapter *);
-static int	ena_setup_rx_dma_tag(struct ena_adapter *);
-static int	ena_free_rx_dma_tag(struct ena_adapter *);
-static void	ena_release_all_tx_dmamap(struct ena_ring *);
-static int	ena_setup_tx_resources(struct ena_adapter *, int);
-static void	ena_free_tx_resources(struct ena_adapter *, int);
-static int	ena_setup_all_tx_resources(struct ena_adapter *);
-static void	ena_free_all_tx_resources(struct ena_adapter *);
-static int	ena_setup_rx_resources(struct ena_adapter *, unsigned int);
-static void	ena_free_rx_resources(struct ena_adapter *, unsigned int);
-static int	ena_setup_all_rx_resources(struct ena_adapter *);
-static void	ena_free_all_rx_resources(struct ena_adapter *);
+static void ena_init_io_rings_common(struct ena_adapter *, struct ena_ring *,
+    uint16_t);
+static void ena_init_io_rings_basic(struct ena_adapter *);
+static void ena_init_io_rings_advanced(struct ena_adapter *);
+static void ena_init_io_rings(struct ena_adapter *);
+static void ena_free_io_ring_resources(struct ena_adapter *, unsigned int);
+static void ena_free_all_io_rings_resources(struct ena_adapter *);
+static int ena_setup_tx_dma_tag(struct ena_adapter *);
+static int ena_free_tx_dma_tag(struct ena_adapter *);
+static int ena_setup_rx_dma_tag(struct ena_adapter *);
+static int ena_free_rx_dma_tag(struct ena_adapter *);
+static void ena_release_all_tx_dmamap(struct ena_ring *);
+static int ena_setup_tx_resources(struct ena_adapter *, int);
+static void ena_free_tx_resources(struct ena_adapter *, int);
+static int ena_setup_all_tx_resources(struct ena_adapter *);
+static void ena_free_all_tx_resources(struct ena_adapter *);
+static int ena_setup_rx_resources(struct ena_adapter *, unsigned int);
+static void ena_free_rx_resources(struct ena_adapter *, unsigned int);
+static int ena_setup_all_rx_resources(struct ena_adapter *);
+static void ena_free_all_rx_resources(struct ena_adapter *);
 static inline int ena_alloc_rx_mbuf(struct ena_adapter *, struct ena_ring *,
     struct ena_rx_buffer *);
-static void	ena_free_rx_mbuf(struct ena_adapter *, struct ena_ring *,
+static void ena_free_rx_mbuf(struct ena_adapter *, struct ena_ring *,
     struct ena_rx_buffer *);
-static void	ena_free_rx_bufs(struct ena_adapter *, unsigned int);
-static void	ena_refill_all_rx_bufs(struct ena_adapter *);
-static void	ena_free_all_rx_bufs(struct ena_adapter *);
-static void	ena_free_tx_bufs(struct ena_adapter *, unsigned int);
-static void	ena_free_all_tx_bufs(struct ena_adapter *);
-static void	ena_destroy_all_tx_queues(struct ena_adapter *);
-static void	ena_destroy_all_rx_queues(struct ena_adapter *);
-static void	ena_destroy_all_io_queues(struct ena_adapter *);
-static int	ena_create_io_queues(struct ena_adapter *);
-static int	ena_handle_msix(void *);
-static int	ena_enable_msix(struct ena_adapter *);
-static void	ena_setup_mgmnt_intr(struct ena_adapter *);
-static int	ena_setup_io_intr(struct ena_adapter *);
-static int	ena_request_mgmnt_irq(struct ena_adapter *);
-static int	ena_request_io_irq(struct ena_adapter *);
-static void	ena_free_mgmnt_irq(struct ena_adapter *);
-static void	ena_free_io_irq(struct ena_adapter *);
-static void	ena_free_irqs(struct ena_adapter*);
-static void	ena_disable_msix(struct ena_adapter *);
-static void	ena_unmask_all_io_irqs(struct ena_adapter *);
-static int	ena_up_complete(struct ena_adapter *);
-static uint64_t	ena_get_counter(if_t, ift_counter);
-static int	ena_media_change(if_t);
-static void	ena_media_status(if_t, struct ifmediareq *);
-static void	ena_init(void *);
-static int	ena_ioctl(if_t, u_long, caddr_t);
-static int	ena_get_dev_offloads(struct ena_com_dev_get_features_ctx *);
-static void	ena_update_host_info(struct ena_admin_host_info *, if_t);
-static void	ena_update_hwassist(struct ena_adapter *);
-static int	ena_setup_ifnet(device_t, struct ena_adapter *,
+static void ena_free_rx_bufs(struct ena_adapter *, unsigned int);
+static void ena_refill_all_rx_bufs(struct ena_adapter *);
+static void ena_free_all_rx_bufs(struct ena_adapter *);
+static void ena_free_tx_bufs(struct ena_adapter *, unsigned int);
+static void ena_free_all_tx_bufs(struct ena_adapter *);
+static void ena_destroy_all_tx_queues(struct ena_adapter *);
+static void ena_destroy_all_rx_queues(struct ena_adapter *);
+static void ena_destroy_all_io_queues(struct ena_adapter *);
+static int ena_create_io_queues(struct ena_adapter *);
+static int ena_handle_msix(void *);
+static int ena_enable_msix(struct ena_adapter *);
+static void ena_setup_mgmnt_intr(struct ena_adapter *);
+static int ena_setup_io_intr(struct ena_adapter *);
+static int ena_request_mgmnt_irq(struct ena_adapter *);
+static int ena_request_io_irq(struct ena_adapter *);
+static void ena_free_mgmnt_irq(struct ena_adapter *);
+static void ena_free_io_irq(struct ena_adapter *);
+static void ena_free_irqs(struct ena_adapter *);
+static void ena_disable_msix(struct ena_adapter *);
+static void ena_unmask_all_io_irqs(struct ena_adapter *);
+static int ena_up_complete(struct ena_adapter *);
+static uint64_t ena_get_counter(if_t, ift_counter);
+static int ena_media_change(if_t);
+static void ena_media_status(if_t, struct ifmediareq *);
+static void ena_init(void *);
+static int ena_ioctl(if_t, u_long, caddr_t);
+static int ena_get_dev_offloads(struct ena_com_dev_get_features_ctx *);
+static void ena_update_host_info(struct ena_admin_host_info *, if_t);
+static void ena_update_hwassist(struct ena_adapter *);
+static int ena_setup_ifnet(device_t, struct ena_adapter *,
     struct ena_com_dev_get_features_ctx *);
-static int	ena_enable_wc(device_t, struct resource *);
-static int	ena_set_queues_placement_policy(device_t, struct ena_com_dev *,
+static int ena_enable_wc(device_t, struct resource *);
+static int ena_set_queues_placement_policy(device_t, struct ena_com_dev *,
     struct ena_admin_feature_llq_desc *, struct ena_llq_configurations *);
-static int	ena_map_llq_mem_bar(device_t, struct ena_com_dev *);
-static uint32_t	ena_calc_max_io_queue_num(device_t, struct ena_com_dev *,
+static int ena_map_llq_mem_bar(device_t, struct ena_com_dev *);
+static uint32_t ena_calc_max_io_queue_num(device_t, struct ena_com_dev *,
     struct ena_com_dev_get_features_ctx *);
-static int	ena_calc_io_queue_size(struct ena_calc_queue_size_ctx *);
-static void	ena_config_host_info(struct ena_com_dev *, device_t);
-static int	ena_attach(device_t);
-static int	ena_detach(device_t);
-static int	ena_device_init(struct ena_adapter *, device_t,
+static int ena_calc_io_queue_size(struct ena_calc_queue_size_ctx *);
+static void ena_config_host_info(struct ena_com_dev *, device_t);
+static int ena_attach(device_t);
+static int ena_detach(device_t);
+static int ena_device_init(struct ena_adapter *, device_t,
     struct ena_com_dev_get_features_ctx *, int *);
-static int	ena_enable_msix_and_set_admin_interrupts(struct ena_adapter *);
+static int ena_enable_msix_and_set_admin_interrupts(struct ena_adapter *);
 static void ena_update_on_link_change(void *, struct ena_admin_aenq_entry *);
-static void	unimplemented_aenq_handler(void *,
-    struct ena_admin_aenq_entry *);
-static int	ena_copy_eni_metrics(struct ena_adapter *);
-static void	ena_timer_service(void *);
+static void unimplemented_aenq_handler(void *, struct ena_admin_aenq_entry *);
+static int ena_copy_eni_metrics(struct ena_adapter *);
+static void ena_timer_service(void *);
 
 static char ena_version[] = DEVICE_NAME DRV_MODULE_NAME " v" DRV_MODULE_VERSION;
 
 static ena_vendor_info_t ena_vendor_info_array[] = {
-    { PCI_VENDOR_ID_AMAZON, PCI_DEV_ID_ENA_PF, 0},
-    { PCI_VENDOR_ID_AMAZON, PCI_DEV_ID_ENA_PF_RSERV0, 0},
-    { PCI_VENDOR_ID_AMAZON, PCI_DEV_ID_ENA_VF, 0},
-    { PCI_VENDOR_ID_AMAZON, PCI_DEV_ID_ENA_VF_RSERV0, 0},
-    /* Last entry */
-    { 0, 0, 0 }
+	{ PCI_VENDOR_ID_AMAZON, PCI_DEV_ID_ENA_PF, 0 },
+	{ PCI_VENDOR_ID_AMAZON, PCI_DEV_ID_ENA_PF_RSERV0, 0 },
+	{ PCI_VENDOR_ID_AMAZON, PCI_DEV_ID_ENA_VF, 0 },
+	{ PCI_VENDOR_ID_AMAZON, PCI_DEV_ID_ENA_VF_RSERV0, 0 },
+	/* Last entry */
+	{ 0, 0, 0 }
 };
 
 struct sx ena_global_lock;
@@ -193,14 +191,14 @@ ena_dmamap_callback(void *arg, bus_dma_segment_t *segs, int nseg, int error)
 {
 	if (error != 0)
 		return;
-	*(bus_addr_t *) arg = segs[0].ds_addr;
+	*(bus_addr_t *)arg = segs[0].ds_addr;
 }
 
 int
-ena_dma_alloc(device_t dmadev, bus_size_t size,
-    ena_mem_handle_t *dma, int mapflags, bus_size_t alignment, int domain)
+ena_dma_alloc(device_t dmadev, bus_size_t size, ena_mem_handle_t *dma,
+    int mapflags, bus_size_t alignment, int domain)
 {
-	struct ena_adapter* adapter = device_get_softc(dmadev);
+	struct ena_adapter *adapter = device_get_softc(dmadev);
 	device_t pdev = adapter->pdev;
 	uint32_t maxsize;
 	uint64_t dma_space_addr;
@@ -213,16 +211,16 @@ ena_dma_alloc(device_t dmadev, bus_size_t size,
 		dma_space_addr = BUS_SPACE_MAXADDR;
 
 	error = bus_dma_tag_create(bus_get_dma_tag(dmadev), /* parent */
-	    alignment, 0,     /* alignment, bounds 		*/
-	    dma_space_addr,   /* lowaddr of exclusion window	*/
-	    BUS_SPACE_MAXADDR,/* highaddr of exclusion window	*/
-	    NULL, NULL,	      /* filter, filterarg 		*/
-	    maxsize,	      /* maxsize 			*/
-	    1,		      /* nsegments 			*/
-	    maxsize,	      /* maxsegsize 			*/
-	    BUS_DMA_ALLOCNOW, /* flags 				*/
-	    NULL,	      /* lockfunc 			*/
-	    NULL,	      /* lockarg 			*/
+	    alignment, 0,      /* alignment, bounds 		*/
+	    dma_space_addr,    /* lowaddr of exclusion window	*/
+	    BUS_SPACE_MAXADDR, /* highaddr of exclusion window	*/
+	    NULL, NULL,	       /* filter, filterarg 		*/
+	    maxsize,	       /* maxsize 			*/
+	    1,		       /* nsegments 			*/
+	    maxsize,	       /* maxsegsize 			*/
+	    BUS_DMA_ALLOCNOW,  /* flags 			*/
+	    NULL,	       /* lockfunc 			*/
+	    NULL,	       /* lockarg 			*/
 	    &dma->tag);
 	if (unlikely(error != 0)) {
 		ena_log(pdev, ERR, "bus_dma_tag_create failed: %d\n", error);
@@ -238,7 +236,7 @@ ena_dma_alloc(device_t dmadev, bus_size_t size,
 	}
 #endif
 
-	error = bus_dmamem_alloc(dma->tag, (void**) &dma->vaddr,
+	error = bus_dmamem_alloc(dma->tag, (void **)&dma->vaddr,
 	    BUS_DMA_COHERENT | BUS_DMA_ZERO, &dma->map);
 	if (unlikely(error != 0)) {
 		ena_log(pdev, ERR, "bus_dmamem_alloc(%ju) failed: %d\n",
@@ -247,8 +245,8 @@ ena_dma_alloc(device_t dmadev, bus_size_t size,
 	}
 
 	dma->paddr = 0;
-	error = bus_dmamap_load(dma->tag, dma->map, dma->vaddr,
-	    size, ena_dmamap_callback, &dma->paddr, mapflags);
+	error = bus_dmamap_load(dma->tag, dma->map, dma->vaddr, size,
+	    ena_dmamap_callback, &dma->paddr, mapflags);
 	if (unlikely((error != 0) || (dma->paddr == 0))) {
 		ena_log(pdev, ERR, "bus_dmamap_load failed: %d\n", error);
 		goto fail_map_load;
@@ -287,8 +285,8 @@ ena_free_pci_resources(struct ena_adapter *adapter)
 	}
 
 	if (adapter->msix != NULL) {
-		bus_release_resource(pdev, SYS_RES_MEMORY,
-		    adapter->msix_rid, adapter->msix);
+		bus_release_resource(pdev, SYS_RES_MEMORY, adapter->msix_rid,
+		    adapter->msix);
 	}
 }
 
@@ -296,8 +294,8 @@ static int
 ena_probe(device_t dev)
 {
 	ena_vendor_info_t *ent;
-	uint16_t	pci_vendor_id = 0;
-	uint16_t	pci_device_id = 0;
+	uint16_t pci_vendor_id = 0;
+	uint16_t pci_device_id = 0;
 
 	pci_vendor_id = pci_get_vendor(dev);
 	pci_device_id = pci_get_device(dev);
@@ -306,15 +304,14 @@ ena_probe(device_t dev)
 	while (ent->vendor_id != 0) {
 		if ((pci_vendor_id == ent->vendor_id) &&
 		    (pci_device_id == ent->device_id)) {
-			ena_log_raw(DBG, "vendor=%x device=%x\n",
-			    pci_vendor_id, pci_device_id);
+			ena_log_raw(DBG, "vendor=%x device=%x\n", pci_vendor_id,
+			    pci_device_id);
 
 			device_set_desc(dev, DEVICE_DESC);
 			return (BUS_PROBE_DEFAULT);
 		}
 
 		ent++;
-
 	}
 
 	return (ENXIO);
@@ -328,8 +325,7 @@ ena_change_mtu(if_t ifp, int new_mtu)
 	int rc;
 
 	if ((new_mtu > adapter->max_mtu) || (new_mtu < ENA_MIN_MTU)) {
-		ena_log(pdev, ERR, "Invalid MTU setting. "
-		    "new_mtu: %d max mtu: %d min mtu: %d\n",
+		ena_log(pdev, ERR, "Invalid MTU setting. new_mtu: %d max mtu: %d min mtu: %d\n",
 		    new_mtu, adapter->max_mtu, ENA_MIN_MTU);
 		return (EINVAL);
 	}
@@ -376,7 +372,6 @@ static void
 ena_init_io_rings_common(struct ena_adapter *adapter, struct ena_ring *ring,
     uint16_t qid)
 {
-
 	ring->qid = qid;
 	ring->adapter = adapter;
 	ring->ena_dev = adapter->ena_dev;
@@ -432,8 +427,8 @@ ena_init_io_rings_advanced(struct ena_adapter *adapter)
 
 		/* Allocate a buf ring */
 		txr->buf_ring_size = adapter->buf_ring_size;
-		txr->br = buf_ring_alloc(txr->buf_ring_size, M_DEVBUF,
-		    M_WAITOK, &txr->ring_mtx);
+		txr->br = buf_ring_alloc(txr->buf_ring_size, M_DEVBUF, M_WAITOK,
+		    &txr->ring_mtx);
 
 		/* Allocate Tx statistics. */
 		ena_alloc_counters((counter_u64_t *)&txr->tx_stats,
@@ -492,7 +487,6 @@ ena_free_all_io_rings_resources(struct ena_adapter *adapter)
 
 	for (i = 0; i < adapter->num_io_queues; i++)
 		ena_free_io_ring_resources(adapter, i);
-
 }
 
 static int
@@ -504,7 +498,7 @@ ena_setup_tx_dma_tag(struct ena_adapter *adapter)
 	ret = bus_dma_tag_create(bus_get_dma_tag(adapter->pdev),
 	    1, 0,				  /* alignment, bounds 	     */
 	    ENA_DMA_BIT_MASK(adapter->dma_width), /* lowaddr of excl window  */
-	    BUS_SPACE_MAXADDR, 			  /* highaddr of excl window */
+	    BUS_SPACE_MAXADDR,			  /* highaddr of excl window */
 	    NULL, NULL,				  /* filter, filterarg 	     */
 	    ENA_TSO_MAXSIZE,			  /* maxsize 		     */
 	    adapter->max_tx_sgl_size - 1,	  /* nsegments 		     */
@@ -539,7 +533,7 @@ ena_setup_rx_dma_tag(struct ena_adapter *adapter)
 	ret = bus_dma_tag_create(bus_get_dma_tag(adapter->pdev), /* parent   */
 	    1, 0,				  /* alignment, bounds 	     */
 	    ENA_DMA_BIT_MASK(adapter->dma_width), /* lowaddr of excl window  */
-	    BUS_SPACE_MAXADDR, 			  /* highaddr of excl window */
+	    BUS_SPACE_MAXADDR,			  /* highaddr of excl window */
 	    NULL, NULL,				  /* filter, filterarg 	     */
 	    ena_mbuf_sz,			  /* maxsize 		     */
 	    adapter->max_rx_sgl_size,		  /* nsegments 		     */
@@ -570,7 +564,7 @@ ena_release_all_tx_dmamap(struct ena_ring *tx_ring)
 {
 	struct ena_adapter *adapter = tx_ring->adapter;
 	struct ena_tx_buffer *tx_info;
-	bus_dma_tag_t tx_tag = adapter->tx_buf_tag;;
+	bus_dma_tag_t tx_tag = adapter->tx_buf_tag;
 	int i;
 #ifdef DEV_NETMAP
 	struct ena_netmap_tx_info *nm_info;
@@ -661,8 +655,7 @@ ena_setup_tx_resources(struct ena_adapter *adapter, int qid)
 		    &tx_ring->tx_buffer_info[i].dmamap);
 		if (unlikely(err != 0)) {
 			ena_log(pdev, ERR,
-			    "Unable to create Tx DMA map for buffer %d\n",
-			    i);
+			    "Unable to create Tx DMA map for buffer %d\n", i);
 			goto err_map_release;
 		}
 
@@ -674,8 +667,8 @@ ena_setup_tx_resources(struct ena_adapter *adapter, int qid)
 				    &map[j]);
 				if (unlikely(err != 0)) {
 					ena_log(pdev, ERR,
-					    "Unable to create "
-					    "Tx DMA for buffer %d %d\n", i, j);
+					    "Unable to create Tx DMA for buffer %d %d\n",
+					    i, j);
 					goto err_map_release;
 				}
 			}
@@ -737,8 +730,7 @@ ena_free_tx_resources(struct ena_adapter *adapter, int qid)
 	int j;
 #endif /* DEV_NETMAP */
 
-	while (taskqueue_cancel(tx_ring->enqueue_tq, &tx_ring->enqueue_task,
-	    NULL))
+	while (taskqueue_cancel(tx_ring->enqueue_tq, &tx_ring->enqueue_task, NULL))
 		taskqueue_drain(tx_ring->enqueue_tq, &tx_ring->enqueue_task);
 
 	taskqueue_free(tx_ring->enqueue_tq);
@@ -995,8 +987,8 @@ ena_free_all_rx_resources(struct ena_adapter *adapter)
 }
 
 static inline int
-ena_alloc_rx_mbuf(struct ena_adapter *adapter,
-    struct ena_ring *rx_ring, struct ena_rx_buffer *rx_info)
+ena_alloc_rx_mbuf(struct ena_adapter *adapter, struct ena_ring *rx_ring,
+    struct ena_rx_buffer *rx_info)
 {
 	device_t pdev = adapter->pdev;
 	struct ena_com_buf *ena_buf;
@@ -1027,8 +1019,9 @@ ena_alloc_rx_mbuf(struct ena_adapter *adapter,
 	rx_info->mbuf->m_pkthdr.len = rx_info->mbuf->m_len = mlen;
 
 	/* Map packets for DMA */
-	ena_log(pdev, DBG, "Using tag %p for buffers' DMA mapping, mbuf %p len: %d\n",
-	    adapter->rx_buf_tag,rx_info->mbuf, rx_info->mbuf->m_len);
+	ena_log(pdev, DBG,
+	    "Using tag %p for buffers' DMA mapping, mbuf %p len: %d\n",
+	    adapter->rx_buf_tag, rx_info->mbuf, rx_info->mbuf->m_len);
 	error = bus_dmamap_load_mbuf_sg(adapter->rx_buf_tag, rx_info->map,
 	    rx_info->mbuf, segs, &nsegs, BUS_DMA_NOWAIT);
 	if (unlikely((error != 0) || (nsegs != 1))) {
@@ -1036,7 +1029,6 @@ ena_alloc_rx_mbuf(struct ena_adapter *adapter,
 		    "failed to map mbuf, error: %d, nsegs: %d\n", error, nsegs);
 		counter_u64_add(rx_ring->rx_stats.dma_mapping_err, 1);
 		goto exit;
-
 	}
 
 	bus_dmamap_sync(adapter->rx_buf_tag, rx_info->map, BUS_DMASYNC_PREREAD);
@@ -1045,8 +1037,9 @@ ena_alloc_rx_mbuf(struct ena_adapter *adapter,
 	ena_buf->paddr = segs[0].ds_addr;
 	ena_buf->len = mlen;
 
-	ena_log(pdev, DBG, "ALLOC RX BUF: mbuf %p, rx_info %p, len %d, paddr %#jx\n",
-	    rx_info->mbuf, rx_info,ena_buf->len, (uintmax_t)ena_buf->paddr);
+	ena_log(pdev, DBG,
+	    "ALLOC RX BUF: mbuf %p, rx_info %p, len %d, paddr %#jx\n",
+	    rx_info->mbuf, rx_info, ena_buf->len, (uintmax_t)ena_buf->paddr);
 
 	return (0);
 
@@ -1060,7 +1053,6 @@ static void
 ena_free_rx_mbuf(struct ena_adapter *adapter, struct ena_ring *rx_ring,
     struct ena_rx_buffer *rx_info)
 {
-
 	if (rx_info->mbuf == NULL) {
 		ena_log(adapter->pdev, WARN,
 		    "Trying to free unallocated buffer\n");
@@ -1103,7 +1095,8 @@ ena_refill_rx_bufs(struct ena_ring *rx_ring, uint32_t num)
 		rx_info = &rx_ring->rx_buffer_info[req_id];
 #ifdef DEV_NETMAP
 		if (ena_rx_ring_in_netmap(adapter, rx_ring->qid))
-			rc = ena_netmap_alloc_rx_slot(adapter, rx_ring, rx_info);
+			rc = ena_netmap_alloc_rx_slot(adapter, rx_ring,
+			    rx_info);
 		else
 #endif /* DEV_NETMAP */
 			rc = ena_alloc_rx_mbuf(adapter, rx_ring, rx_info);
@@ -1128,8 +1121,8 @@ ena_refill_rx_bufs(struct ena_ring *rx_ring, uint32_t num)
 	if (unlikely(i < num)) {
 		counter_u64_add(rx_ring->rx_stats.refil_partial, 1);
 		ena_log_io(pdev, WARN,
-		     "refilled rx qid %d with only %d mbufs (from %d)\n",
-		     rx_ring->qid, i, num);
+		    "refilled rx qid %d with only %d mbufs (from %d)\n",
+		    rx_ring->qid, i, num);
 	}
 
 	if (likely(i != 0))
@@ -1177,7 +1170,6 @@ ena_update_buf_ring_size(struct ena_adapter *adapter,
 			ENA_FLAG_SET_ATOMIC(ENA_FLAG_DEV_UP_BEFORE_RESET,
 			    adapter);
 			ena_trigger_reset(adapter, ENA_REGS_RESET_OS_TRIGGER);
-
 		}
 	}
 
@@ -1326,7 +1318,8 @@ ena_refill_all_rx_bufs(struct ena_adapter *adapter)
 		if (unlikely(rc != bufs_num))
 			ena_log_io(adapter->pdev, WARN,
 			    "refilling Queue %d failed. "
-			    "Allocated %d buffers from: %d\n", i, rc, bufs_num);
+			    "Allocated %d buffers from: %d\n",
+			    i, rc, bufs_num);
 #ifdef DEV_NETMAP
 		rx_ring->initialized = true;
 #endif /* DEV_NETMAP */
@@ -1362,13 +1355,13 @@ ena_free_tx_bufs(struct ena_adapter *adapter, unsigned int qid)
 
 		if (print_once) {
 			ena_log(adapter->pdev, WARN,
-			    "free uncompleted tx mbuf qid %d idx 0x%x\n",
-			    qid, i);
+			    "free uncompleted tx mbuf qid %d idx 0x%x\n", qid,
+			    i);
 			print_once = false;
 		} else {
 			ena_log(adapter->pdev, DBG,
-			    "free uncompleted tx mbuf qid %d idx 0x%x\n",
-			     qid, i);
+			    "free uncompleted tx mbuf qid %d idx 0x%x\n", qid,
+			    i);
 		}
 
 		bus_dmamap_sync(adapter->tx_buf_tag, tx_info->dmamap,
@@ -1384,7 +1377,6 @@ ena_free_tx_bufs(struct ena_adapter *adapter, unsigned int qid)
 static void
 ena_free_all_tx_bufs(struct ena_adapter *adapter)
 {
-
 	for (int i = 0; i < adapter->num_io_queues; i++)
 		ena_free_tx_bufs(adapter, i);
 }
@@ -1421,10 +1413,8 @@ ena_destroy_all_io_queues(struct ena_adapter *adapter)
 
 	for (i = 0; i < adapter->num_io_queues; i++) {
 		queue = &adapter->que[i];
-		while (taskqueue_cancel(queue->cleanup_tq,
-		    &queue->cleanup_task, NULL))
-			taskqueue_drain(queue->cleanup_tq,
-			    &queue->cleanup_task);
+		while (taskqueue_cancel(queue->cleanup_tq, &queue->cleanup_task, NULL))
+			taskqueue_drain(queue->cleanup_tq, &queue->cleanup_task);
 		taskqueue_free(queue->cleanup_tq);
 	}
 
@@ -1463,12 +1453,12 @@ ena_create_io_queues(struct ena_adapter *adapter)
 		}
 		ring = &adapter->tx_ring[i];
 		rc = ena_com_get_io_handlers(ena_dev, ena_qid,
-		    &ring->ena_com_io_sq,
-		    &ring->ena_com_io_cq);
+		    &ring->ena_com_io_sq, &ring->ena_com_io_cq);
 		if (rc != 0) {
 			ena_log(adapter->pdev, ERR,
 			    "Failed to get TX queue handlers. TX queue num"
-			    " %d rc: %d\n", i, rc);
+			    " %d rc: %d\n",
+			    i, rc);
 			ena_com_destroy_io_queue(ena_dev, ena_qid);
 			goto err_tx;
 		}
@@ -1499,12 +1489,12 @@ ena_create_io_queues(struct ena_adapter *adapter)
 
 		ring = &adapter->rx_ring[i];
 		rc = ena_com_get_io_handlers(ena_dev, ena_qid,
-		    &ring->ena_com_io_sq,
-		    &ring->ena_com_io_cq);
+		    &ring->ena_com_io_sq, &ring->ena_com_io_cq);
 		if (unlikely(rc != 0)) {
 			ena_log(adapter->pdev, ERR,
 			    "Failed to get RX queue handlers. RX queue num"
-			    " %d rc: %d\n", i, rc);
+			    " %d rc: %d\n",
+			    i, rc);
 			ena_com_destroy_io_queue(ena_dev, ena_qid);
 			goto err_rx;
 		}
@@ -1530,8 +1520,7 @@ ena_create_io_queues(struct ena_adapter *adapter)
 		cpu_mask = &queue->cpu_mask;
 #endif
 		taskqueue_start_threads_cpuset(&queue->cleanup_tq, 1, PI_NET,
-		    cpu_mask,
-		    "%s queue %d cleanup",
+		    cpu_mask, "%s queue %d cleanup",
 		    device_get_nameunit(adapter->pdev), i);
 	}
 
@@ -1605,8 +1594,7 @@ ena_enable_msix(struct ena_adapter *adapter)
 	adapter->msix_entries = malloc(msix_vecs * sizeof(struct msix_entry),
 	    M_DEVBUF, M_WAITOK | M_ZERO);
 
-	ena_log(dev, DBG, "trying to enable MSI-X, vectors: %d\n",
-	    msix_vecs);
+	ena_log(dev, DBG, "trying to enable MSI-X, vectors: %d\n", msix_vecs);
 
 	for (i = 0; i < msix_vecs; i++) {
 		adapter->msix_entries[i].entry = i;
@@ -1617,8 +1605,8 @@ ena_enable_msix(struct ena_adapter *adapter)
 	msix_req = msix_vecs;
 	rc = pci_alloc_msix(dev, &msix_vecs);
 	if (unlikely(rc != 0)) {
-		ena_log(dev, ERR,
-		    "Failed to enable MSIX, vectors %d rc %d\n", msix_vecs, rc);
+		ena_log(dev, ERR, "Failed to enable MSIX, vectors %d rc %d\n",
+		    msix_vecs, rc);
 
 		rc = ENOSPC;
 		goto err_msix_free;
@@ -1633,8 +1621,10 @@ ena_enable_msix(struct ena_adapter *adapter)
 			rc = ENOSPC;
 			goto err_msix_free;
 		}
-		ena_log(dev, ERR, "Enable only %d MSI-x (out of %d), reduce "
-		    "the number of queues\n", msix_vecs, msix_req);
+		ena_log(dev, ERR,
+		    "Enable only %d MSI-x (out of %d), reduce "
+		    "the number of queues\n",
+		    msix_vecs, msix_req);
 	}
 
 	adapter->msix_vecs = msix_vecs;
@@ -1652,10 +1642,8 @@ err_msix_free:
 static void
 ena_setup_mgmnt_intr(struct ena_adapter *adapter)
 {
-
-	snprintf(adapter->irq_tbl[ENA_MGMNT_IRQ_IDX].name,
-	    ENA_IRQNAME_SIZE, "ena-mgmnt@pci:%s",
-	    device_get_nameunit(adapter->pdev));
+	snprintf(adapter->irq_tbl[ENA_MGMNT_IRQ_IDX].name, ENA_IRQNAME_SIZE,
+	    "ena-mgmnt@pci:%s", device_get_nameunit(adapter->pdev));
 	/*
 	 * Handler is NULL on purpose, it will be set
 	 * when mgmnt interrupt is acquired
@@ -1742,11 +1730,11 @@ ena_request_mgmnt_irq(struct ena_adapter *adapter)
 	}
 
 	rc = bus_setup_intr(adapter->pdev, irq->res,
-	    INTR_TYPE_NET | INTR_MPSAFE, NULL, ena_intr_msix_mgmnt,
-	    irq->data, &irq->cookie);
+	    INTR_TYPE_NET | INTR_MPSAFE, NULL, ena_intr_msix_mgmnt, irq->data,
+	    &irq->cookie);
 	if (unlikely(rc != 0)) {
-		ena_log(pdev, ERR, "failed to register "
-		    "interrupt handler for irq %ju: %d\n",
+		ena_log(pdev, ERR,
+		    "failed to register interrupt handler for irq %ju: %d\n",
 		    rman_get_start(irq->res), rc);
 		goto err_res_free;
 	}
@@ -1756,11 +1744,12 @@ ena_request_mgmnt_irq(struct ena_adapter *adapter)
 
 err_res_free:
 	ena_log(pdev, INFO, "releasing resource for irq %d\n", irq->vector);
-	rcc = bus_release_resource(adapter->pdev, SYS_RES_IRQ,
-	    irq->vector, irq->res);
+	rcc = bus_release_resource(adapter->pdev, SYS_RES_IRQ, irq->vector,
+	    irq->res);
 	if (unlikely(rcc != 0))
-		ena_log(pdev, ERR, "dev has no parent while "
-		    "releasing res for irq: %d\n", irq->vector);
+		ena_log(pdev, ERR,
+		    "dev has no parent while releasing res for irq: %d\n",
+		    irq->vector);
 	irq->res = NULL;
 
 	return (rc);
@@ -1792,17 +1781,17 @@ ena_request_io_irq(struct ena_adapter *adapter)
 		    &irq->vector, flags);
 		if (unlikely(irq->res == NULL)) {
 			rc = ENOMEM;
-			ena_log(pdev, ERR, "could not allocate irq vector: %d\n",
-			    irq->vector);
+			ena_log(pdev, ERR,
+			    "could not allocate irq vector: %d\n", irq->vector);
 			goto err;
 		}
 
 		rc = bus_setup_intr(adapter->pdev, irq->res,
-		    INTR_TYPE_NET | INTR_MPSAFE, irq->handler, NULL,
-		    irq->data, &irq->cookie);
-		 if (unlikely(rc != 0)) {
-			ena_log(pdev, ERR, "failed to register "
-			    "interrupt handler for irq %ju: %d\n",
+		    INTR_TYPE_NET | INTR_MPSAFE, irq->handler, NULL, irq->data,
+		    &irq->cookie);
+		if (unlikely(rc != 0)) {
+			ena_log(pdev, ERR,
+			    "failed to register interrupt handler for irq %ju: %d\n",
 			    rman_get_start(irq->res), rc);
 			goto err;
 		}
@@ -1811,8 +1800,8 @@ ena_request_io_irq(struct ena_adapter *adapter)
 #ifdef RSS
 		rc = bus_bind_intr(adapter->pdev, irq->res, irq->cpu);
 		if (unlikely(rc != 0)) {
-			ena_log(pdev, ERR, "failed to bind "
-			    "interrupt handler for irq %ju to cpu %d: %d\n",
+			ena_log(pdev, ERR,
+			    "failed to bind interrupt handler for irq %ju to cpu %d: %d\n",
 			    rman_get_start(irq->res), irq->cpu, rc);
 			goto err;
 		}
@@ -1833,9 +1822,11 @@ err:
 		/* Once we entered err: section and irq->requested is true we
 		   free both intr and resources */
 		if (irq->requested)
-			rcc = bus_teardown_intr(adapter->pdev, irq->res, irq->cookie);
+			rcc = bus_teardown_intr(adapter->pdev, irq->res,
+			    irq->cookie);
 		if (unlikely(rcc != 0))
-			ena_log(pdev, ERR, "could not release irq: %d, error: %d\n",
+			ena_log(pdev, ERR,
+			    "could not release irq: %d, error: %d\n",
 			    irq->vector, rcc);
 
 		/* If we entred err: section without irq->requested set we know
@@ -1848,8 +1839,9 @@ err:
 			    irq->vector, irq->res);
 		}
 		if (unlikely(rcc != 0))
-			ena_log(pdev, ERR, "dev has no parent while "
-			    "releasing res for irq: %d\n", irq->vector);
+			ena_log(pdev, ERR,
+			    "dev has no parent while releasing res for irq: %d\n",
+			    irq->vector);
 		irq->requested = false;
 		irq->res = NULL;
 	}
@@ -1880,8 +1872,9 @@ ena_free_mgmnt_irq(struct ena_adapter *adapter)
 		    irq->vector, irq->res);
 		irq->res = NULL;
 		if (unlikely(rc != 0))
-			ena_log(pdev, ERR, "dev has no parent while "
-			    "releasing res for irq: %d\n", irq->vector);
+			ena_log(pdev, ERR,
+			    "dev has no parent while releasing res for irq: %d\n",
+			    irq->vector);
 	}
 }
 
@@ -1899,7 +1892,8 @@ ena_free_io_irq(struct ena_adapter *adapter)
 			rc = bus_teardown_intr(adapter->pdev, irq->res,
 			    irq->cookie);
 			if (unlikely(rc != 0)) {
-				ena_log(pdev, ERR, "failed to tear down irq: %d\n",
+				ena_log(pdev, ERR,
+				    "failed to tear down irq: %d\n",
 				    irq->vector);
 			}
 			irq->requested = 0;
@@ -1912,8 +1906,8 @@ ena_free_io_irq(struct ena_adapter *adapter)
 			    irq->vector, irq->res);
 			irq->res = NULL;
 			if (unlikely(rc != 0)) {
-				ena_log(pdev, ERR, "dev has no parent"
-				    " while releasing res for irq: %d\n",
+				ena_log(pdev, ERR,
+				    "dev has no parent while releasing res for irq: %d\n",
 				    irq->vector);
 			}
 		}
@@ -1921,9 +1915,8 @@ ena_free_io_irq(struct ena_adapter *adapter)
 }
 
 static void
-ena_free_irqs(struct ena_adapter* adapter)
+ena_free_irqs(struct ena_adapter *adapter)
 {
-
 	ena_free_io_irq(adapter);
 	ena_free_mgmnt_irq(adapter);
 	ena_disable_msix(adapter);
@@ -1932,7 +1925,6 @@ ena_free_irqs(struct ena_adapter* adapter)
 static void
 ena_disable_msix(struct ena_adapter *adapter)
 {
-
 	if (ENA_FLAG_ISSET(ENA_FLAG_MSIX_ENABLED, adapter)) {
 		ENA_FLAG_CLEAR_ATOMIC(ENA_FLAG_MSIX_ENABLED, adapter);
 		pci_release_msi(adapter->pdev);
@@ -1946,7 +1938,7 @@ ena_disable_msix(struct ena_adapter *adapter)
 static void
 ena_unmask_all_io_irqs(struct ena_adapter *adapter)
 {
-	struct ena_com_io_cq* io_cq;
+	struct ena_com_io_cq *io_cq;
 	struct ena_eth_io_intr_reg intr_reg;
 	struct ena_ring *tx_ring;
 	uint16_t ena_qid;
@@ -1989,8 +1981,7 @@ ena_up_complete(struct ena_adapter *adapter)
 }
 
 static void
-set_io_rings_size(struct ena_adapter *adapter, int new_tx_size,
-    int new_rx_size)
+set_io_rings_size(struct ena_adapter *adapter, int new_tx_size, int new_rx_size)
 {
 	int i;
 
@@ -2033,8 +2024,7 @@ create_queues_with_size_backoff(struct ena_adapter *adapter)
 		/* Create IO queues for Rx & Tx */
 		rc = ena_create_io_queues(adapter);
 		if (unlikely(rc != 0)) {
-			ena_log(pdev, ERR,
-			    "create IO queues failed\n");
+			ena_log(pdev, ERR, "create IO queues failed\n");
 			goto err_io_que;
 		}
 
@@ -2066,8 +2056,8 @@ err_setup_tx:
 		new_rx_ring_size = cur_rx_ring_size;
 
 		/*
-		 * Decrease the size of a larger queue, or decrease both if they are
-		 * the same size.
+		 * Decrease the size of a larger queue, or decrease both if they
+		 * are the same size.
 		 */
 		if (cur_rx_ring_size <= cur_tx_ring_size)
 			new_tx_ring_size = cur_tx_ring_size / 2;
@@ -2121,13 +2111,12 @@ ena_up(struct ena_adapter *adapter)
 	}
 
 	ena_log(adapter->pdev, INFO,
-	    "Creating %u IO queues. Rx queue size: %d, Tx queue size: %d, "
-	    "LLQ is %s\n",
+	    "Creating %u IO queues. Rx queue size: %d, Tx queue size: %d, LLQ is %s\n",
 	    adapter->num_io_queues,
 	    adapter->requested_rx_ring_size,
 	    adapter->requested_tx_ring_size,
 	    (adapter->ena_dev->tx_mem_queue_type ==
-	        ENA_ADMIN_PLACEMENT_POLICY_DEV) ?  "ENABLED" : "DISABLED");
+		ENA_ADMIN_PLACEMENT_POLICY_DEV) ? "ENABLED" : "DISABLED");
 
 	rc = create_queues_with_size_backoff(adapter);
 	if (unlikely(rc != 0)) {
@@ -2147,8 +2136,7 @@ ena_up(struct ena_adapter *adapter)
 
 	ena_update_hwassist(adapter);
 
-	if_setdrvflagbits(adapter->ifp, IFF_DRV_RUNNING,
-		IFF_DRV_OACTIVE);
+	if_setdrvflagbits(adapter->ifp, IFF_DRV_RUNNING, IFF_DRV_OACTIVE);
 
 	ENA_FLAG_SET_ATOMIC(ENA_FLAG_DEV_UP, adapter);
 
@@ -2265,8 +2253,8 @@ ena_ioctl(if_t ifp, u_long command, caddr_t data)
 	case SIOCSIFFLAGS:
 		if ((ifp->if_flags & IFF_UP) != 0) {
 			if ((if_getdrvflags(ifp) & IFF_DRV_RUNNING) != 0) {
-				if ((ifp->if_flags & (IFF_PROMISC |
-				    IFF_ALLMULTI)) != 0) {
+				if ((ifp->if_flags &
+				    (IFF_PROMISC | IFF_ALLMULTI)) != 0) {
 					ena_log(adapter->pdev, INFO,
 					    "ioctl promisc/allmulti\n");
 				}
@@ -2336,12 +2324,10 @@ ena_get_dev_offloads(struct ena_com_dev_get_features_ctx *feat)
 	    ENA_ADMIN_FEATURE_OFFLOAD_DESC_TX_L4_IPV6_CSUM_PART_MASK)) != 0)
 		caps |= IFCAP_TXCSUM_IPV6;
 
-	if ((feat->offload.tx &
-	    ENA_ADMIN_FEATURE_OFFLOAD_DESC_TSO_IPV4_MASK) != 0)
+	if ((feat->offload.tx & ENA_ADMIN_FEATURE_OFFLOAD_DESC_TSO_IPV4_MASK) != 0)
 		caps |= IFCAP_TSO4;
 
-	if ((feat->offload.tx &
-	    ENA_ADMIN_FEATURE_OFFLOAD_DESC_TSO_IPV6_MASK) != 0)
+	if ((feat->offload.tx & ENA_ADMIN_FEATURE_OFFLOAD_DESC_TSO_IPV6_MASK) != 0)
 		caps |= IFCAP_TSO6;
 
 	if ((feat->offload.rx_supported &
@@ -2361,9 +2347,7 @@ ena_get_dev_offloads(struct ena_com_dev_get_features_ctx *feat)
 static void
 ena_update_host_info(struct ena_admin_host_info *host_info, if_t ifp)
 {
-
-	host_info->supported_network_features[0] =
-	    (uint32_t)if_getcapabilities(ifp);
+	host_info->supported_network_features[0] = (uint32_t)if_getcapabilities(ifp);
 }
 
 static void
@@ -2415,8 +2399,8 @@ ena_setup_ifnet(device_t pdev, struct ena_adapter *adapter,
 	if_setsoftc(ifp, adapter);
 
 #if __FreeBSD_version > 1300081
-	if_setflags(ifp, IFF_BROADCAST | IFF_SIMPLEX | IFF_MULTICAST |
-	    IFF_KNOWSEPOCH);
+	if_setflags(ifp,
+	    IFF_BROADCAST | IFF_SIMPLEX | IFF_MULTICAST | IFF_KNOWSEPOCH);
 #else
 	if_setflags(ifp, IFF_BROADCAST | IFF_SIMPLEX | IFF_MULTICAST);
 #endif
@@ -2451,8 +2435,8 @@ ena_setup_ifnet(device_t pdev, struct ena_adapter *adapter,
 	 * Specify the media types supported by this adapter and register
 	 * callbacks to update media and link information
 	 */
-	ifmedia_init(&adapter->media, IFM_IMASK,
-	    ena_media_change, ena_media_status);
+	ifmedia_init(&adapter->media, IFM_IMASK, ena_media_change,
+	    ena_media_status);
 	ifmedia_add(&adapter->media, IFM_ETHER | IFM_AUTO, 0, NULL);
 	ifmedia_set(&adapter->media, IFM_ETHER | IFM_AUTO);
 
@@ -2474,17 +2458,14 @@ ena_down(struct ena_adapter *adapter)
 	ena_log(adapter->pdev, INFO, "device is going DOWN\n");
 
 	ENA_FLAG_CLEAR_ATOMIC(ENA_FLAG_DEV_UP, adapter);
-	if_setdrvflagbits(adapter->ifp, IFF_DRV_OACTIVE,
-		IFF_DRV_RUNNING);
+	if_setdrvflagbits(adapter->ifp, IFF_DRV_OACTIVE, IFF_DRV_RUNNING);
 
 	ena_free_io_irq(adapter);
 
 	if (ENA_FLAG_ISSET(ENA_FLAG_TRIGGER_RESET, adapter)) {
-		rc = ena_com_dev_reset(adapter->ena_dev,
-			adapter->reset_reason);
+		rc = ena_com_dev_reset(adapter->ena_dev, adapter->reset_reason);
 		if (unlikely(rc != 0))
-			ena_log(adapter->pdev, ERR,
-				"Device reset failed\n");
+			ena_log(adapter->pdev, ERR, "Device reset failed\n");
 	}
 
 	ena_destroy_all_io_queues(adapter);
@@ -2508,7 +2489,7 @@ ena_calc_max_io_queue_num(device_t pdev, struct ena_com_dev *ena_dev,
 		struct ena_admin_queue_ext_feature_fields *max_queue_ext =
 		    &get_feat_ctx->max_queue_ext.max_queue_ext;
 		io_rx_num = min_t(int, max_queue_ext->max_rx_sq_num,
-			max_queue_ext->max_rx_cq_num);
+		    max_queue_ext->max_rx_cq_num);
 
 		io_tx_sq_num = max_queue_ext->max_tx_sq_num;
 		io_tx_cq_num = max_queue_ext->max_tx_cq_num;
@@ -2571,7 +2552,7 @@ ena_enable_wc(device_t pdev, struct resource *res)
 		ena_log(pdev, ERR, "pmap_change_attr failed, %d\n", rc);
 
 	return (rc);
-#else /* defined(__aarch64__) */
+#else  /* defined(__aarch64__) */
 	vm_paddr_t pa;
 	pa = rman_get_start(res);
 	pmap_kenter(va, len, pa, VM_MEMATTR_WRITE_COMBINING);
@@ -2608,7 +2589,8 @@ ena_set_queues_placement_policy(device_t pdev, struct ena_com_dev *ena_dev,
 
 	rc = ena_com_config_dev_mode(ena_dev, llq, llq_default_configurations);
 	if (unlikely(rc != 0)) {
-		ena_log(pdev, WARN, "Failed to configure the device mode. "
+		ena_log(pdev, WARN,
+		    "Failed to configure the device mode. "
 		    "Fallback to host mode policy.\n");
 		ena_dev->tx_mem_queue_type = ENA_ADMIN_PLACEMENT_POLICY_HOST;
 	}
@@ -2624,11 +2606,11 @@ ena_map_llq_mem_bar(device_t pdev, struct ena_com_dev *ena_dev)
 
 	/* Try to allocate resources for LLQ bar */
 	rid = PCIR_BAR(ENA_MEM_BAR);
-	adapter->memory = bus_alloc_resource_any(pdev, SYS_RES_MEMORY,
-	    &rid, RF_ACTIVE);
+	adapter->memory = bus_alloc_resource_any(pdev, SYS_RES_MEMORY, &rid,
+	    RF_ACTIVE);
 	if (unlikely(adapter->memory == NULL)) {
-		ena_log(pdev, WARN, "unable to allocate LLQ bar resource. "
-		    "Fallback to host mode policy.\n");
+		ena_log(pdev, WARN,
+		    "unable to allocate LLQ bar resource. Fallback to host mode policy.\n");
 		ena_dev->tx_mem_queue_type = ENA_ADMIN_PLACEMENT_POLICY_HOST;
 		return (0);
 	}
@@ -2649,18 +2631,16 @@ ena_map_llq_mem_bar(device_t pdev, struct ena_com_dev *ena_dev)
 	return (0);
 }
 
-static inline
-void set_default_llq_configurations(struct ena_llq_configurations *llq_config,
-	struct ena_admin_feature_llq_desc *llq)
+static inline void
+set_default_llq_configurations(struct ena_llq_configurations *llq_config,
+    struct ena_admin_feature_llq_desc *llq)
 {
-
 	llq_config->llq_header_location = ENA_ADMIN_INLINE_HEADER;
 	llq_config->llq_stride_ctrl = ENA_ADMIN_MULTIPLE_DESCS_PER_ENTRY;
 	llq_config->llq_num_decs_before_header =
 	    ENA_ADMIN_LLQ_NUM_DESCS_BEFORE_HEADER_2;
-	if ((llq->entry_size_ctrl_supported &
-	     ENA_ADMIN_LIST_ENTRY_SIZE_256B) != 0 &&
-	    ena_force_large_llq_header) {
+	if ((llq->entry_size_ctrl_supported & ENA_ADMIN_LIST_ENTRY_SIZE_256B) !=
+	    0 && ena_force_large_llq_header) {
 		llq_config->llq_ring_entry_size =
 		    ENA_ADMIN_LIST_ENTRY_SIZE_256B;
 		llq_config->llq_ring_entry_size_value = 256;
@@ -2704,8 +2684,7 @@ ena_calc_io_queue_size(struct ena_calc_queue_size_ctx *ctx)
 	} else {
 		struct ena_admin_queue_feature_desc *max_queues =
 		    &ctx->get_feat_ctx->max_queues;
-		max_rx_queue_size = min_t(uint32_t,
-		    max_queues->max_cq_depth,
+		max_rx_queue_size = min_t(uint32_t, max_queues->max_cq_depth,
 		    max_queues->max_sq_depth);
 		max_tx_queue_size = max_queues->max_cq_depth;
 
@@ -2734,9 +2713,9 @@ ena_calc_io_queue_size(struct ena_calc_queue_size_ctx *ctx)
 	 */
 	if (ena_force_large_llq_header) {
 		if ((llq->entry_size_ctrl_supported &
-		     ENA_ADMIN_LIST_ENTRY_SIZE_256B) != 0 &&
+		    ENA_ADMIN_LIST_ENTRY_SIZE_256B) != 0 &&
 		    ena_dev->tx_mem_queue_type ==
-		     ENA_ADMIN_PLACEMENT_POLICY_DEV) {
+		    ENA_ADMIN_PLACEMENT_POLICY_DEV) {
 			max_tx_queue_size /= 2;
 			ena_log(ctx->pdev, INFO,
 			    "Forcing large headers and decreasing maximum Tx queue size to %d\n",
@@ -2789,10 +2768,9 @@ ena_config_host_info(struct ena_com_dev *ena_dev, device_t dev)
 	strncpy(host_info->os_dist_str, osrelease,
 	    sizeof(host_info->os_dist_str) - 1);
 
-	host_info->driver_version =
-		(DRV_MODULE_VER_MAJOR) |
-		(DRV_MODULE_VER_MINOR << ENA_ADMIN_HOST_INFO_MINOR_SHIFT) |
-		(DRV_MODULE_VER_SUBMINOR << ENA_ADMIN_HOST_INFO_SUB_MINOR_SHIFT);
+	host_info->driver_version = (DRV_MODULE_VER_MAJOR) |
+	    (DRV_MODULE_VER_MINOR << ENA_ADMIN_HOST_INFO_MINOR_SHIFT) |
+	    (DRV_MODULE_VER_SUBMINOR << ENA_ADMIN_HOST_INFO_SUB_MINOR_SHIFT);
 	host_info->num_cpus = mp_ncpus;
 	host_info->driver_supported_features =
 	    ENA_ADMIN_HOST_INFO_RX_OFFSET_MASK |
@@ -2818,7 +2796,7 @@ static int
 ena_device_init(struct ena_adapter *adapter, device_t pdev,
     struct ena_com_dev_get_features_ctx *get_feat_ctx, int *wd_active)
 {
-	struct ena_com_dev* ena_dev = adapter->ena_dev;
+	struct ena_com_dev *ena_dev = adapter->ena_dev;
 	bool readless_supported;
 	uint32_t aenq_groups;
 	int dma_width;
@@ -2908,7 +2886,8 @@ err_mmio_read_less:
 	return (rc);
 }
 
-static int ena_enable_msix_and_set_admin_interrupts(struct ena_adapter *adapter)
+static int
+ena_enable_msix_and_set_admin_interrupts(struct ena_adapter *adapter)
 {
 	struct ena_com_dev *ena_dev = adapter->ena_dev;
 	int rc;
@@ -2940,8 +2919,8 @@ err_disable_msix:
 }
 
 /* Function called on ENA_ADMIN_KEEP_ALIVE event */
-static void ena_keep_alive_wd(void *adapter_data,
-    struct ena_admin_aenq_entry *aenq_e)
+static void
+ena_keep_alive_wd(void *adapter_data, struct ena_admin_aenq_entry *aenq_e)
 {
 	struct ena_adapter *adapter = (struct ena_adapter *)adapter_data;
 	struct ena_admin_aenq_keep_alive_desc *desc;
@@ -2963,7 +2942,8 @@ static void ena_keep_alive_wd(void *adapter_data,
 }
 
 /* Check for keep alive expiration */
-static void check_for_missing_keep_alive(struct ena_adapter *adapter)
+static void
+check_for_missing_keep_alive(struct ena_adapter *adapter)
 {
 	sbintime_t timestamp, time;
 
@@ -2983,10 +2963,10 @@ static void check_for_missing_keep_alive(struct ena_adapter *adapter)
 }
 
 /* Check if admin queue is enabled */
-static void check_for_admin_com_state(struct ena_adapter *adapter)
+static void
+check_for_admin_com_state(struct ena_adapter *adapter)
 {
-	if (unlikely(ena_com_get_admin_running_state(adapter->ena_dev) ==
-	    false)) {
+	if (unlikely(ena_com_get_admin_running_state(adapter->ena_dev) == false)) {
 		ena_log(adapter->pdev, ERR,
 		    "ENA admin queue is not in running state!\n");
 		counter_u64_add(adapter->dev_stats.admin_q_pause, 1);
@@ -3006,9 +2986,11 @@ check_for_rx_interrupt_queue(struct ena_adapter *adapter,
 
 	rx_ring->no_interrupt_event_cnt++;
 
-	if (rx_ring->no_interrupt_event_cnt == ENA_MAX_NO_INTERRUPT_ITERATIONS) {
-		ena_log(adapter->pdev, ERR, "Potential MSIX issue on Rx side "
-		    "Queue = %d. Reset the device\n", rx_ring->qid);
+	if (rx_ring->no_interrupt_event_cnt ==
+	    ENA_MAX_NO_INTERRUPT_ITERATIONS) {
+		ena_log(adapter->pdev, ERR,
+		    "Potential MSIX issue on Rx side Queue = %d. Reset the device\n",
+		    rx_ring->qid);
 		ena_trigger_reset(adapter, ENA_REGS_RESET_MISS_INTERRUPT);
 		return (EIO);
 	}
@@ -3049,7 +3031,8 @@ check_missing_comp_in_tx_queue(struct ena_adapter *adapter,
 			 */
 			ena_log(pdev, ERR,
 			    "Potential MSIX issue on Tx side Queue = %d. "
-			    "Reset the device\n", tx_ring->qid);
+			    "Reset the device\n",
+			    tx_ring->qid);
 			ena_trigger_reset(adapter,
 			    ENA_REGS_RESET_MISS_INTERRUPT);
 			return (EIO);
@@ -3066,12 +3049,11 @@ check_missing_comp_in_tx_queue(struct ena_adapter *adapter,
 				time_since_last_cleanup = 1000000 * (ticks -
 				    tx_ring->tx_last_cleanup_ticks) / hz;
 #endif
-				missing_tx_comp_to =
-				    sbttoms(adapter->missing_tx_timeout);
-				ena_log(pdev, WARN, "Found a Tx that wasn't "
-				    "completed on time, qid %d, index %d."
-				    "%d usecs have passed since last cleanup."
-				    "Missing Tx timeout value %d msecs.\n",
+				missing_tx_comp_to = sbttoms(
+				    adapter->missing_tx_timeout);
+				ena_log(pdev, WARN,
+				    "Found a Tx that wasn't completed on time, qid %d, index %d."
+				    "%d usecs have passed since last cleanup. Missing Tx timeout value %d msecs.\n",
 				    tx_ring->qid, i, time_since_last_cleanup,
 				    missing_tx_comp_to);
 			}
@@ -3171,11 +3153,12 @@ check_for_empty_rx_ring(struct ena_adapter *adapter)
 	for (i = 0; i < adapter->num_io_queues; i++) {
 		rx_ring = &adapter->rx_ring[i];
 
-		refill_required = ena_com_free_q_entries(rx_ring->ena_com_io_sq);
+		refill_required = ena_com_free_q_entries(
+		    rx_ring->ena_com_io_sq);
 		if (unlikely(refill_required == (rx_ring->ring_size - 1))) {
 			rx_ring->empty_rx_queue++;
 
-			if (rx_ring->empty_rx_queue >= EMPTY_RX_REFILL)	{
+			if (rx_ring->empty_rx_queue >= EMPTY_RX_REFILL) {
 				counter_u64_add(rx_ring->rx_stats.empty_rx_ring,
 				    1);
 
@@ -3193,8 +3176,9 @@ check_for_empty_rx_ring(struct ena_adapter *adapter)
 	}
 }
 
-static void ena_update_hints(struct ena_adapter *adapter,
-			     struct ena_admin_ena_hw_hints *hints)
+static void
+ena_update_hints(struct ena_adapter *adapter,
+    struct ena_admin_ena_hw_hints *hints)
 {
 	struct ena_com_dev *ena_dev = adapter->ena_dev;
 
@@ -3204,8 +3188,7 @@ static void ena_update_hints(struct ena_adapter *adapter,
 
 	if (hints->mmio_read_timeout)
 		/* convert to usec */
-		ena_dev->mmio_read.reg_read_to =
-		    hints->mmio_read_timeout * 1000;
+		ena_dev->mmio_read.reg_read_to = hints->mmio_read_timeout * 1000;
 
 	if (hints->missed_tx_completion_count_threshold_to_reset)
 		adapter->missing_tx_threshold =
@@ -3213,19 +3196,19 @@ static void ena_update_hints(struct ena_adapter *adapter,
 
 	if (hints->missing_tx_completion_timeout) {
 		if (hints->missing_tx_completion_timeout ==
-		     ENA_HW_HINTS_NO_TIMEOUT)
+		    ENA_HW_HINTS_NO_TIMEOUT)
 			adapter->missing_tx_timeout = ENA_HW_HINTS_NO_TIMEOUT;
 		else
-			adapter->missing_tx_timeout =
-			    SBT_1MS * hints->missing_tx_completion_timeout;
+			adapter->missing_tx_timeout = SBT_1MS *
+			    hints->missing_tx_completion_timeout;
 	}
 
 	if (hints->driver_watchdog_timeout) {
 		if (hints->driver_watchdog_timeout == ENA_HW_HINTS_NO_TIMEOUT)
 			adapter->keep_alive_timeout = ENA_HW_HINTS_NO_TIMEOUT;
 		else
-			adapter->keep_alive_timeout =
-			    SBT_1MS * hints->driver_watchdog_timeout;
+			adapter->keep_alive_timeout = SBT_1MS *
+			    hints->driver_watchdog_timeout;
 	}
 }
 
@@ -3388,7 +3371,6 @@ static int
 ena_device_validate_params(struct ena_adapter *adapter,
     struct ena_com_dev_get_features_ctx *get_feat_ctx)
 {
-
 	if (memcmp(get_feat_ctx->dev_attr.mac_addr, adapter->mac_addr,
 	    ETHER_ADDR_LEN) != 0) {
 		ena_log(adapter->pdev, ERR, "Error, mac addresses differ\n");
@@ -3451,8 +3433,7 @@ ena_restore_device(struct ena_adapter *adapter)
 	 * are available.
 	 */
 	if ((adapter->msix_vecs - ENA_ADMIN_MSIX_VEC) < adapter->num_io_queues)
-		adapter->num_io_queues =
-		    adapter->msix_vecs - ENA_ADMIN_MSIX_VEC;
+		adapter->num_io_queues = adapter->msix_vecs - ENA_ADMIN_MSIX_VEC;
 
 	/* Re-initialize rings basic information */
 	ena_init_io_rings(adapter);
@@ -3577,8 +3558,8 @@ ena_attach(device_t pdev)
 
 	rid = PCIR_BAR(ENA_REG_BAR);
 	adapter->memory = NULL;
-	adapter->registers = bus_alloc_resource_any(pdev, SYS_RES_MEMORY,
-	    &rid, RF_ACTIVE);
+	adapter->registers = bus_alloc_resource_any(pdev, SYS_RES_MEMORY, &rid,
+	    RF_ACTIVE);
 	if (unlikely(adapter->registers == NULL)) {
 		ena_log(pdev, ERR,
 		    "unable to allocate bus resource: registers!\n");
@@ -3604,12 +3585,12 @@ ena_attach(device_t pdev)
 	    M_WAITOK | M_ZERO);
 
 	/* Store register resources */
-	((struct ena_bus*)(ena_dev->bus))->reg_bar_t =
-	    rman_get_bustag(adapter->registers);
-	((struct ena_bus*)(ena_dev->bus))->reg_bar_h =
-	    rman_get_bushandle(adapter->registers);
+	((struct ena_bus *)(ena_dev->bus))->reg_bar_t = rman_get_bustag(
+	    adapter->registers);
+	((struct ena_bus *)(ena_dev->bus))->reg_bar_h = rman_get_bushandle(
+	    adapter->registers);
 
-	if (unlikely(((struct ena_bus*)(ena_dev->bus))->reg_bar_h == 0)) {
+	if (unlikely(((struct ena_bus *)(ena_dev->bus))->reg_bar_h == 0)) {
 		ena_log(pdev, ERR, "failed to pmap registers bar\n");
 		rc = ENXIO;
 		goto err_bus_free;
@@ -3637,15 +3618,15 @@ ena_attach(device_t pdev)
 	}
 
 	rc = ena_set_queues_placement_policy(pdev, ena_dev, &get_feat_ctx.llq,
-	     &llq_config);
+	    &llq_config);
 	if (unlikely(rc != 0)) {
 		ena_log(pdev, ERR, "failed to set placement policy\n");
 		goto err_com_free;
 	}
 
 	if (ena_dev->tx_mem_queue_type == ENA_ADMIN_PLACEMENT_POLICY_DEV)
-		adapter->disable_meta_caching =
-		    !!(get_feat_ctx.llq.accel_mode.u.get.supported_flags &
+		adapter->disable_meta_caching = !!(
+		    get_feat_ctx.llq.accel_mode.u.get.supported_flags &
 		    BIT(ENA_ADMIN_DISABLE_META_CACHING));
 
 	adapter->keep_alive_timestamp = getsbinuptime();
@@ -3728,15 +3709,15 @@ ena_attach(device_t pdev)
 	TASK_INIT(&adapter->reset_task, 0, ena_reset_task, adapter);
 	adapter->reset_tq = taskqueue_create("ena_reset_enqueue",
 	    M_WAITOK | M_ZERO, taskqueue_thread_enqueue, &adapter->reset_tq);
-	taskqueue_start_threads(&adapter->reset_tq, 1, PI_NET,
-	    "%s rstq", device_get_nameunit(adapter->pdev));
+	taskqueue_start_threads(&adapter->reset_tq, 1, PI_NET, "%s rstq",
+	    device_get_nameunit(adapter->pdev));
 
 	/* Initialize metrics task queue */
 	TASK_INIT(&adapter->metrics_task, 0, ena_metrics_task, adapter);
 	adapter->metrics_tq = taskqueue_create("ena_metrics_enqueue",
 	    M_WAITOK | M_ZERO, taskqueue_thread_enqueue, &adapter->metrics_tq);
-	taskqueue_start_threads(&adapter->metrics_tq, 1, PI_NET,
-	    "%s metricsq", device_get_nameunit(adapter->pdev));
+	taskqueue_start_threads(&adapter->metrics_tq, 1, PI_NET, "%s metricsq",
+	    device_get_nameunit(adapter->pdev));
 
 	/* Initialize statistics */
 	ena_alloc_counters((counter_u64_t *)&adapter->dev_stats,
@@ -3908,15 +3889,15 @@ ena_update_on_link_change(void *adapter_data,
 	}
 }
 
-static void ena_notification(void *adapter_data,
-    struct ena_admin_aenq_entry *aenq_e)
+static void
+ena_notification(void *adapter_data, struct ena_admin_aenq_entry *aenq_e)
 {
 	struct ena_adapter *adapter = (struct ena_adapter *)adapter_data;
 	struct ena_admin_ena_hw_hints *hints;
 
-	ENA_WARN(aenq_e->aenq_common_desc.group != ENA_ADMIN_NOTIFICATION, adapter->ena_dev,
-	    "Invalid group(%x) expected %x\n",	aenq_e->aenq_common_desc.group,
-	    ENA_ADMIN_NOTIFICATION);
+	ENA_WARN(aenq_e->aenq_common_desc.group != ENA_ADMIN_NOTIFICATION,
+	    adapter->ena_dev, "Invalid group(%x) expected %x\n",
+	    aenq_e->aenq_common_desc.group, ENA_ADMIN_NOTIFICATION);
 
 	switch (aenq_e->aenq_common_desc.syndrome) {
 	case ENA_ADMIN_UPDATE_HINTS:
@@ -3971,16 +3952,16 @@ static struct ena_aenq_handlers aenq_handlers = {
  *  FreeBSD Device Interface Entry Points
  *********************************************************************/
 
-static device_method_t ena_methods[] = {
-    /* Device interface */
-    DEVMETHOD(device_probe, ena_probe),
-    DEVMETHOD(device_attach, ena_attach),
-    DEVMETHOD(device_detach, ena_detach),
-    DEVMETHOD_END
+static device_method_t ena_methods[] = { /* Device interface */
+	DEVMETHOD(device_probe, ena_probe),
+	DEVMETHOD(device_attach, ena_attach),
+	DEVMETHOD(device_detach, ena_detach), DEVMETHOD_END
 };
 
 static driver_t ena_driver = {
-    "ena", ena_methods, sizeof(struct ena_adapter),
+	"ena",
+	ena_methods,
+	sizeof(struct ena_adapter),
 };
 
 #if __FreeBSD_version > 1400057

--- a/kernel/fbsd/ena/ena.c
+++ b/kernel/fbsd/ena/ena.c
@@ -48,6 +48,7 @@ __FBSDID("$FreeBSD$");
 #include <sys/time.h>
 #include <sys/eventhandler.h>
 
+#include <machine/atomic.h>
 #include <machine/bus.h>
 #include <machine/resource.h>
 #include <machine/in_cksum.h>
@@ -381,7 +382,7 @@ ena_init_io_rings_common(struct ena_adapter *adapter, struct ena_ring *ring,
 	ring->qid = qid;
 	ring->adapter = adapter;
 	ring->ena_dev = adapter->ena_dev;
-	ring->first_interrupt = false;
+	atomic_store_8(&ring->first_interrupt, false);
 	ring->no_interrupt_event_cnt = 0;
 }
 
@@ -3015,7 +3016,7 @@ static int
 check_for_rx_interrupt_queue(struct ena_adapter *adapter,
     struct ena_ring *rx_ring)
 {
-	if (likely(rx_ring->first_interrupt))
+	if (likely(atomic_load_8(&rx_ring->first_interrupt)))
 		return (0);
 
 	if (ena_com_cq_empty(rx_ring->ena_com_io_cq))
@@ -3058,7 +3059,7 @@ check_missing_comp_in_tx_queue(struct ena_adapter *adapter,
 		bintime_sub(&time, &tx_buf->timestamp);
 		time_offset = bttosbt(time);
 
-		if (unlikely(!tx_ring->first_interrupt &&
+		if (unlikely(!atomic_load_8(&tx_ring->first_interrupt) &&
 		    time_offset > 2 * adapter->missing_tx_timeout)) {
 			/*
 			 * If after graceful period interrupt is still not

--- a/kernel/fbsd/ena/ena.c
+++ b/kernel/fbsd/ena/ena.c
@@ -2110,13 +2110,6 @@ ena_up(struct ena_adapter *adapter)
 
 	ena_log(adapter->pdev, INFO, "device is going UP\n");
 
-	/*
-	 * ena_timer_service can use functions, which write to the admin queue.
-	 * Those calls are not protected by ENA_LOCK, and because of that, the
-	 * timer should be stopped when bringing the device up or down.
-	 */
-	ENA_TIMER_DRAIN(adapter);
-
 	/* setup interrupts for IO queues */
 	rc = ena_setup_io_intr(adapter);
 	if (unlikely(rc != 0)) {
@@ -2163,8 +2156,6 @@ ena_up(struct ena_adapter *adapter)
 
 	ena_unmask_all_io_irqs(adapter);
 
-	ENA_TIMER_RESET(adapter);
-
 	return (0);
 
 err_up_complete:
@@ -2174,8 +2165,6 @@ err_up_complete:
 err_create_queues_with_backoff:
 	ena_free_io_irq(adapter);
 error:
-	ENA_TIMER_RESET(adapter);
-
 	return (rc);
 }
 
@@ -2484,9 +2473,6 @@ ena_down(struct ena_adapter *adapter)
 	if (!ENA_FLAG_ISSET(ENA_FLAG_DEV_UP, adapter))
 		return;
 
-	/* Drain timer service to avoid admin queue race condition. */
-	ENA_TIMER_DRAIN(adapter);
-
 	ena_log(adapter->pdev, INFO, "device is going DOWN\n");
 
 	ENA_FLAG_CLEAR_ATOMIC(ENA_FLAG_DEV_UP, adapter);
@@ -2511,8 +2497,6 @@ ena_down(struct ena_adapter *adapter)
 	ena_free_all_rx_resources(adapter);
 
 	counter_u64_add(adapter->dev_stats.interface_down, 1);
-
-	ENA_TIMER_RESET(adapter);
 }
 
 static uint32_t
@@ -3312,24 +3296,7 @@ ena_timer_service(void *data)
 	if ((adapter->eni_metrics_sample_interval != 0) &&
 	    (++adapter->eni_metrics_sample_interval_cnt >=
 	     adapter->eni_metrics_sample_interval)) {
-		/*
-		 * There is no race with other admin queue calls, as:
-		 *   - Timer service runs after attach function ends, so all
-		 *     configuration calls to the admin queue are finished.
-		 *   - Timer service is temporarily stopped when bringing
-		 *     the interface up or down.
-		 *   - After interface is up, the driver doesn't use (at least
-		 *     for now) other functions writing to the admin queue.
-		 *
-		 * It may change in the future, so in that situation, the lock
-		 * will be needed. ENA_LOCK_*() cannot be used for that purpose,
-		 * as callout ena_timer_service is protected by them. It could
-		 * lead to the deadlock if callout_drain() would hold the lock
-		 * before ena_copy_eni_metrics() was executed. It's advised to
-		 * use separate lock in that situation which will be used only
-		 * for the admin queue.
-		 */
-		(void)ena_copy_eni_metrics(adapter);
+		taskqueue_enqueue(adapter->metrics_tq, &adapter->metrics_task);
 		adapter->eni_metrics_sample_interval_cnt = 0;
 	}
 
@@ -3534,6 +3501,16 @@ err:
 	ENA_TIMER_RESET(adapter);
 
 	return (rc);
+}
+
+static void
+ena_metrics_task(void *arg, int pending)
+{
+	struct ena_adapter *adapter = (struct ena_adapter *)arg;
+
+	ENA_LOCK_LOCK();
+	(void)ena_copy_eni_metrics(adapter);
+	ENA_LOCK_UNLOCK();
 }
 
 static void
@@ -3756,6 +3733,13 @@ ena_attach(device_t pdev)
 	taskqueue_start_threads(&adapter->reset_tq, 1, PI_NET,
 	    "%s rstq", device_get_nameunit(adapter->pdev));
 
+	/* Initialize metrics task queue */
+	TASK_INIT(&adapter->metrics_task, 0, ena_metrics_task, adapter);
+	adapter->metrics_tq = taskqueue_create("ena_metrics_enqueue",
+	    M_WAITOK | M_ZERO, taskqueue_thread_enqueue, &adapter->metrics_tq);
+	taskqueue_start_threads(&adapter->metrics_tq, 1, PI_NET,
+	    "%s metricsq", device_get_nameunit(adapter->pdev));
+
 	/* Initialize statistics */
 	ena_alloc_counters((counter_u64_t *)&adapter->dev_stats,
 	    sizeof(struct ena_stats_dev));
@@ -3833,6 +3817,11 @@ ena_detach(device_t pdev)
 	ENA_LOCK_LOCK();
 	ENA_TIMER_DRAIN(adapter);
 	ENA_LOCK_UNLOCK();
+
+	/* Release metrics task */
+	while (taskqueue_cancel(adapter->metrics_tq, &adapter->metrics_task, NULL))
+		taskqueue_drain(adapter->metrics_tq, &adapter->metrics_task);
+	taskqueue_free(adapter->metrics_tq);
 
 	/* Release reset task */
 	while (taskqueue_cancel(adapter->reset_tq, &adapter->reset_task, NULL))

--- a/kernel/fbsd/ena/ena.h
+++ b/kernel/fbsd/ena/ena.h
@@ -469,6 +469,8 @@ struct ena_adapter {
 	uint32_t next_monitored_tx_qid;
 	struct task reset_task;
 	struct taskqueue *reset_tq;
+	struct task metrics_task;
+	struct taskqueue *metrics_tq;
 	int wd_active;
 	sbintime_t keep_alive_timeout;
 	sbintime_t missing_tx_timeout;

--- a/kernel/fbsd/ena/ena.h
+++ b/kernel/fbsd/ena/ena.h
@@ -542,4 +542,12 @@ ena_trigger_reset(struct ena_adapter *adapter,
 	}
 }
 
+static inline void
+ena_ring_tx_doorbell(struct ena_ring *tx_ring)
+{
+	ena_com_write_sq_doorbell(tx_ring->ena_com_io_sq);
+	counter_u64_add(tx_ring->tx_stats.doorbells, 1);
+	tx_ring->acum_pkts = 0;
+}
+
 #endif /* !(ENA_H) */

--- a/kernel/fbsd/ena/ena.h
+++ b/kernel/fbsd/ena/ena.h
@@ -373,6 +373,8 @@ struct ena_ring {
 	/* Used for LLQ */
 	uint8_t *push_buf_intermediate_buf;
 
+	int tx_last_cleanup_ticks;
+
 #ifdef DEV_NETMAP
 	bool initialized;
 #endif /* DEV_NETMAP */

--- a/kernel/fbsd/ena/ena.h
+++ b/kernel/fbsd/ena/ena.h
@@ -500,7 +500,7 @@ struct ena_adapter {
 
 #define	ENA_TIMER_INIT(_adapter)					\
 	callout_init(&(_adapter)->timer_service, true)
-#define ENA_TIMER_DRAIN(_adapter)					\
+#define	ENA_TIMER_DRAIN(_adapter)					\
 	callout_drain(&(_adapter)->timer_service)
 #define	ENA_TIMER_RESET(_adapter)					\
 	callout_reset_sbt(&(_adapter)->timer_service, SBT_1S, SBT_1S,	\

--- a/kernel/fbsd/ena/ena.h
+++ b/kernel/fbsd/ena/ena.h
@@ -38,20 +38,20 @@
 #include "ena_com/ena_com.h"
 #include "ena_com/ena_eth_com.h"
 
-#define DRV_MODULE_VER_MAJOR	2
-#define DRV_MODULE_VER_MINOR	5
-#define DRV_MODULE_VER_SUBMINOR 0
+#define ENA_DRV_MODULE_VER_MAJOR	2
+#define ENA_DRV_MODULE_VER_MINOR	5
+#define ENA_DRV_MODULE_VER_SUBMINOR	0
 
-#define DRV_MODULE_NAME		"ena"
+#define ENA_DRV_MODULE_NAME		"ena"
 
-#ifndef DRV_MODULE_VERSION
-#define DRV_MODULE_VERSION				\
-	__XSTRING(DRV_MODULE_VER_MAJOR) "."		\
-	__XSTRING(DRV_MODULE_VER_MINOR) "."		\
-	__XSTRING(DRV_MODULE_VER_SUBMINOR)
+#ifndef ENA_DRV_MODULE_VERSION
+#define ENA_DRV_MODULE_VERSION				\
+	__XSTRING(ENA_DRV_MODULE_VER_MAJOR) "."		\
+	__XSTRING(ENA_DRV_MODULE_VER_MINOR) "."		\
+	__XSTRING(ENA_DRV_MODULE_VER_SUBMINOR)
 #endif
-#define DEVICE_NAME	"Elastic Network Adapter (ENA)"
-#define DEVICE_DESC	"ENA adapter"
+#define ENA_DEVICE_NAME	"Elastic Network Adapter (ENA)"
+#define ENA_DEVICE_DESC	"ENA adapter"
 
 /* Calculate DMA mask - width for ena cannot exceed 48, so it is safe */
 #define ENA_DMA_BIT_MASK(x)		((1ULL << (x)) - 1ULL)
@@ -91,24 +91,24 @@
 
 #define ENA_TX_RESUME_THRESH		(ENA_PKT_MAX_BUFS + 2)
 
-#define DB_THRESHOLD	64
+#define ENA_DB_THRESHOLD	64
 
-#define TX_COMMIT	32
+#define ENA_TX_COMMIT	32
  /*
  * TX budget for cleaning. It should be half of the RX budget to reduce amount
  *  of TCP retransmissions.
  */
-#define TX_BUDGET	128
+#define ENA_TX_BUDGET	128
 /* RX cleanup budget. -1 stands for infinity. */
-#define RX_BUDGET	256
+#define ENA_RX_BUDGET	256
 /*
  * How many times we can repeat cleanup in the io irq handling routine if the
  * RX or TX budget was depleted.
  */
-#define CLEAN_BUDGET	8
+#define ENA_CLEAN_BUDGET	8
 
-#define RX_IRQ_INTERVAL 20
-#define TX_IRQ_INTERVAL 50
+#define ENA_RX_IRQ_INTERVAL	20
+#define ENA_TX_IRQ_INTERVAL	50
 
 #define ENA_MIN_MTU		128
 
@@ -135,16 +135,16 @@
  * ENA device should send keep alive msg every 1 sec.
  * We wait for 6 sec just to be on the safe side.
  */
-#define DEFAULT_KEEP_ALIVE_TO		(SBT_1S * 6)
+#define ENA_DEFAULT_KEEP_ALIVE_TO	(SBT_1S * 6)
 
 /* Time in jiffies before concluding the transmitter is hung. */
-#define DEFAULT_TX_CMP_TO		(SBT_1S * 5)
+#define ENA_DEFAULT_TX_CMP_TO		(SBT_1S * 5)
 
 /* Number of queues to check for missing queues per timer tick */
-#define DEFAULT_TX_MONITORED_QUEUES	(4)
+#define ENA_DEFAULT_TX_MONITORED_QUEUES	(4)
 
 /* Max number of timeouted packets before device reset */
-#define DEFAULT_TX_CMP_THRESHOLD	(128)
+#define ENA_DEFAULT_TX_CMP_THRESHOLD	(128)
 
 /*
  * Supported PCI vendor and devices IDs

--- a/kernel/fbsd/ena/ena.h
+++ b/kernel/fbsd/ena/ena.h
@@ -39,7 +39,7 @@
 #include "ena_com/ena_eth_com.h"
 
 #define ENA_DRV_MODULE_VER_MAJOR	2
-#define ENA_DRV_MODULE_VER_MINOR	5
+#define ENA_DRV_MODULE_VER_MINOR	6
 #define ENA_DRV_MODULE_VER_SUBMINOR	0
 
 #define ENA_DRV_MODULE_NAME		"ena"

--- a/kernel/fbsd/ena/ena.h
+++ b/kernel/fbsd/ena/ena.h
@@ -57,37 +57,37 @@
 #define ENA_DMA_BIT_MASK(x)		((1ULL << (x)) - 1ULL)
 
 /* 1 for AENQ + ADMIN */
-#define	ENA_ADMIN_MSIX_VEC		1
-#define	ENA_MAX_MSIX_VEC(io_queues)	(ENA_ADMIN_MSIX_VEC + (io_queues))
+#define ENA_ADMIN_MSIX_VEC		1
+#define ENA_MAX_MSIX_VEC(io_queues)	(ENA_ADMIN_MSIX_VEC + (io_queues))
 
-#define	ENA_REG_BAR			0
-#define	ENA_MEM_BAR			2
+#define ENA_REG_BAR			0
+#define ENA_MEM_BAR			2
 
-#define	ENA_BUS_DMA_SEGS		32
+#define ENA_BUS_DMA_SEGS		32
 
-#define	ENA_DEFAULT_BUF_RING_SIZE	4096
+#define ENA_DEFAULT_BUF_RING_SIZE	4096
 
-#define	ENA_DEFAULT_RING_SIZE		1024
-#define	ENA_MIN_RING_SIZE		256
+#define ENA_DEFAULT_RING_SIZE		1024
+#define ENA_MIN_RING_SIZE		256
 
 /*
  * Refill Rx queue when number of required descriptors is above
  * QUEUE_SIZE / ENA_RX_REFILL_THRESH_DIVIDER or ENA_RX_REFILL_THRESH_PACKET
  */
-#define	ENA_RX_REFILL_THRESH_DIVIDER	8
-#define	ENA_RX_REFILL_THRESH_PACKET	256
+#define ENA_RX_REFILL_THRESH_DIVIDER	8
+#define ENA_RX_REFILL_THRESH_PACKET	256
 
-#define	ENA_IRQNAME_SIZE		40
+#define ENA_IRQNAME_SIZE		40
 
-#define	ENA_PKT_MAX_BUFS 		19
+#define ENA_PKT_MAX_BUFS 		19
 
-#define	ENA_RX_RSS_TABLE_LOG_SIZE	7
-#define	ENA_RX_RSS_TABLE_SIZE		(1 << ENA_RX_RSS_TABLE_LOG_SIZE)
+#define ENA_RX_RSS_TABLE_LOG_SIZE	7
+#define ENA_RX_RSS_TABLE_SIZE		(1 << ENA_RX_RSS_TABLE_LOG_SIZE)
 
-#define	ENA_HASH_KEY_SIZE		40
+#define ENA_HASH_KEY_SIZE		40
 
-#define	ENA_MAX_FRAME_LEN		10000
-#define	ENA_MIN_FRAME_LEN 		60
+#define ENA_MAX_FRAME_LEN		10000
+#define ENA_MIN_FRAME_LEN 		60
 
 #define ENA_TX_RESUME_THRESH		(ENA_PKT_MAX_BUFS + 2)
 
@@ -110,26 +110,26 @@
 #define RX_IRQ_INTERVAL 20
 #define TX_IRQ_INTERVAL 50
 
-#define	ENA_MIN_MTU		128
+#define ENA_MIN_MTU		128
 
-#define	ENA_TSO_MAXSIZE		65536
+#define ENA_TSO_MAXSIZE		65536
 
-#define	ENA_MMIO_DISABLE_REG_READ	BIT(0)
+#define ENA_MMIO_DISABLE_REG_READ	BIT(0)
 
-#define	ENA_TX_RING_IDX_NEXT(idx, ring_size) (((idx) + 1) & ((ring_size) - 1))
+#define ENA_TX_RING_IDX_NEXT(idx, ring_size) (((idx) + 1) & ((ring_size) - 1))
 
-#define	ENA_RX_RING_IDX_NEXT(idx, ring_size) (((idx) + 1) & ((ring_size) - 1))
+#define ENA_RX_RING_IDX_NEXT(idx, ring_size) (((idx) + 1) & ((ring_size) - 1))
 
-#define	ENA_IO_TXQ_IDX(q)		(2 * (q))
-#define	ENA_IO_RXQ_IDX(q)		(2 * (q) + 1)
-#define	ENA_IO_TXQ_IDX_TO_COMBINED_IDX(q)	((q) / 2)
-#define	ENA_IO_RXQ_IDX_TO_COMBINED_IDX(q)	(((q) - 1) / 2)
+#define ENA_IO_TXQ_IDX(q)		(2 * (q))
+#define ENA_IO_RXQ_IDX(q)		(2 * (q) + 1)
+#define ENA_IO_TXQ_IDX_TO_COMBINED_IDX(q)	((q) / 2)
+#define ENA_IO_RXQ_IDX_TO_COMBINED_IDX(q)	(((q) - 1) / 2)
 
-#define	ENA_MGMNT_IRQ_IDX		0
-#define	ENA_IO_IRQ_FIRST_IDX		1
-#define	ENA_IO_IRQ_IDX(q)		(ENA_IO_IRQ_FIRST_IDX + (q))
+#define ENA_MGMNT_IRQ_IDX		0
+#define ENA_IO_IRQ_FIRST_IDX		1
+#define ENA_IO_IRQ_IDX(q)		(ENA_IO_IRQ_FIRST_IDX + (q))
 
-#define	ENA_MAX_NO_INTERRUPT_ITERATIONS	3
+#define ENA_MAX_NO_INTERRUPT_ITERATIONS	3
 
 /*
  * ENA device should send keep alive msg every 1 sec.
@@ -149,12 +149,12 @@
 /*
  * Supported PCI vendor and devices IDs
  */
-#define	PCI_VENDOR_ID_AMAZON	0x1d0f
+#define PCI_VENDOR_ID_AMAZON	0x1d0f
 
-#define	PCI_DEV_ID_ENA_PF		0x0ec2
-#define	PCI_DEV_ID_ENA_PF_RSERV0	0x1ec2
-#define	PCI_DEV_ID_ENA_VF		0xec20
-#define	PCI_DEV_ID_ENA_VF_RSERV0	0xec21
+#define PCI_DEV_ID_ENA_PF		0x0ec2
+#define PCI_DEV_ID_ENA_PF_RSERV0	0x1ec2
+#define PCI_DEV_ID_ENA_VF		0xec20
+#define PCI_DEV_ID_ENA_VF_RSERV0	0xec21
 
 /*
  * Flags indicating current ENA driver state
@@ -489,9 +489,9 @@ struct ena_adapter {
 	enum ena_regs_reset_reason_types reset_reason;
 };
 
-#define	ENA_RING_MTX_LOCK(_ring)		mtx_lock(&(_ring)->ring_mtx)
-#define	ENA_RING_MTX_TRYLOCK(_ring)		mtx_trylock(&(_ring)->ring_mtx)
-#define	ENA_RING_MTX_UNLOCK(_ring)		mtx_unlock(&(_ring)->ring_mtx)
+#define ENA_RING_MTX_LOCK(_ring)		mtx_lock(&(_ring)->ring_mtx)
+#define ENA_RING_MTX_TRYLOCK(_ring)		mtx_trylock(&(_ring)->ring_mtx)
+#define ENA_RING_MTX_UNLOCK(_ring)		mtx_unlock(&(_ring)->ring_mtx)
 #define ENA_RING_MTX_ASSERT(_ring)		\
 	mtx_assert(&(_ring)->ring_mtx, MA_OWNED)
 
@@ -502,11 +502,11 @@ struct ena_adapter {
 #define ENA_LOCK_UNLOCK()		sx_unlock(&ena_global_lock)
 #define ENA_LOCK_ASSERT()		sx_assert(&ena_global_lock, SA_XLOCKED)
 
-#define	ENA_TIMER_INIT(_adapter)					\
+#define ENA_TIMER_INIT(_adapter)					\
 	callout_init(&(_adapter)->timer_service, true)
-#define	ENA_TIMER_DRAIN(_adapter)					\
+#define ENA_TIMER_DRAIN(_adapter)					\
 	callout_drain(&(_adapter)->timer_service)
-#define	ENA_TIMER_RESET(_adapter)					\
+#define ENA_TIMER_RESET(_adapter)					\
 	callout_reset_sbt(&(_adapter)->timer_service, SBT_1S, SBT_1S,	\
 			ena_timer_service, (void*)(_adapter), 0)
 
@@ -514,16 +514,6 @@ struct ena_adapter {
 #define clamp_val(val, lo, hi)		clamp_t(__typeof(val), val, lo, hi)
 
 extern struct sx ena_global_lock;
-
-static inline int ena_mbuf_count(struct mbuf *mbuf)
-{
-	int count = 1;
-
-	while ((mbuf = mbuf->m_next) != NULL)
-		++count;
-
-	return count;
-}
 
 int	ena_up(struct ena_adapter *adapter);
 void	ena_down(struct ena_adapter *adapter);
@@ -535,6 +525,17 @@ int	ena_update_buf_ring_size(struct ena_adapter *adapter,
 int	ena_update_queue_size(struct ena_adapter *adapter, uint32_t new_tx_size,
     uint32_t new_rx_size);
 int	ena_update_io_queue_nb(struct ena_adapter *adapter, uint32_t new_num);
+
+static inline int
+ena_mbuf_count(struct mbuf *mbuf)
+{
+	int count = 1;
+
+	while ((mbuf = mbuf->m_next) != NULL)
+		++count;
+
+	return count;
+}
 
 static inline void
 ena_trigger_reset(struct ena_adapter *adapter,

--- a/kernel/fbsd/ena/ena_datapath.c
+++ b/kernel/fbsd/ena/ena_datapath.c
@@ -211,7 +211,8 @@ ena_get_tx_req_id(struct ena_ring *tx_ring, struct ena_com_io_cq *io_cq,
 		return (EAGAIN);
 
 	if (unlikely(rc != 0)) {
-		ena_log(adapter->pdev, ERR, "Invalid req_id: %hu\n", *req_id);
+		ena_log(adapter->pdev, ERR, "Invalid req_id %hu in qid %hu\n",
+		    *req_id, tx_ring->qid);
 		counter_u64_add(tx_ring->tx_stats.bad_req_id, 1);
 		goto err;
 	}
@@ -219,7 +220,9 @@ ena_get_tx_req_id(struct ena_ring *tx_ring, struct ena_com_io_cq *io_cq,
 	if (tx_ring->tx_buffer_info[*req_id].mbuf != NULL)
 		return (0);
 
-	ena_log(adapter->pdev, ERR, "tx_info doesn't have valid mbuf\n");
+	ena_log(adapter->pdev, ERR,
+	    "tx_info doesn't have valid mbuf. qid %hu req_id %hu\n",
+	    tx_ring->qid, *req_id);
 err:
 	ena_trigger_reset(adapter, ENA_REGS_RESET_INV_TX_REQ_ID);
 

--- a/kernel/fbsd/ena/ena_datapath.c
+++ b/kernel/fbsd/ena/ena_datapath.c
@@ -92,20 +92,20 @@ ena_cleanup(void *arg, int pending)
 	atomic_store_8(&tx_ring->first_interrupt, true);
 	atomic_store_8(&rx_ring->first_interrupt, true);
 
-	for (i = 0; i < CLEAN_BUDGET; ++i) {
+	for (i = 0; i < ENA_CLEAN_BUDGET; ++i) {
 		rxc = ena_rx_cleanup(rx_ring);
 		txc = ena_tx_cleanup(tx_ring);
 
 		if (unlikely((if_getdrvflags(ifp) & IFF_DRV_RUNNING) == 0))
 			return;
 
-		if ((txc != TX_BUDGET) && (rxc != RX_BUDGET))
+		if ((txc != ENA_TX_BUDGET) && (rxc != ENA_RX_BUDGET))
 			break;
 	}
 
 	/* Signal that work is done and unmask interrupt */
-	ena_com_update_intr_reg(&intr_reg, RX_IRQ_INTERVAL, TX_IRQ_INTERVAL,
-	    true);
+	ena_com_update_intr_reg(&intr_reg, ENA_RX_IRQ_INTERVAL,
+	    ENA_TX_IRQ_INTERVAL, true);
 	counter_u64_add(tx_ring->tx_stats.unmask_interrupt_num, 1);
 	ena_com_unmask_intr(io_cq, &intr_reg);
 }
@@ -247,8 +247,8 @@ ena_tx_cleanup(struct ena_ring *tx_ring)
 	uint16_t ena_qid;
 	unsigned int total_done = 0;
 	int rc;
-	int commit = TX_COMMIT;
-	int budget = TX_BUDGET;
+	int commit = ENA_TX_COMMIT;
+	int budget = ENA_TX_BUDGET;
 	int work_done;
 	bool above_thresh;
 
@@ -293,8 +293,8 @@ ena_tx_cleanup(struct ena_ring *tx_ring)
 		    tx_ring->ring_size);
 
 		if (unlikely(--commit == 0)) {
-			commit = TX_COMMIT;
-			/* update ring state every TX_COMMIT descriptor */
+			commit = ENA_TX_COMMIT;
+			/* update ring state every ENA_TX_COMMIT descriptor */
 			tx_ring->next_to_clean = next_to_clean;
 			ena_com_comp_ack(
 			    &adapter->ena_dev->io_sq_queues[ena_qid],
@@ -304,13 +304,13 @@ ena_tx_cleanup(struct ena_ring *tx_ring)
 		}
 	} while (likely(--budget));
 
-	work_done = TX_BUDGET - budget;
+	work_done = ENA_TX_BUDGET - budget;
 
 	ena_log_io(adapter->pdev, DBG, "tx: q %d done. total pkts: %d\n",
 	    tx_ring->qid, work_done);
 
 	/* If there is still something to commit update ring state */
-	if (likely(commit != TX_COMMIT)) {
+	if (likely(commit != ENA_TX_COMMIT)) {
 		tx_ring->next_to_clean = next_to_clean;
 		ena_com_comp_ack(&adapter->ena_dev->io_sq_queues[ena_qid],
 		    total_done);
@@ -574,7 +574,7 @@ ena_rx_cleanup(struct ena_ring *rx_ring)
 	uint32_t do_if_input = 0;
 	unsigned int qid;
 	int rc, i;
-	int budget = RX_BUDGET;
+	int budget = ENA_RX_BUDGET;
 #ifdef DEV_NETMAP
 	int done;
 #endif /* DEV_NETMAP */
@@ -697,7 +697,7 @@ ena_rx_cleanup(struct ena_ring *rx_ring)
 
 	tcp_lro_flush_all(&rx_ring->lro);
 
-	return (RX_BUDGET - budget);
+	return (ENA_RX_BUDGET - budget);
 }
 
 static void
@@ -1015,7 +1015,7 @@ ena_xmit_mbuf(struct ena_ring *tx_ring, struct mbuf **mbuf)
 	/* Set flags and meta data */
 	ena_tx_csum(&ena_tx_ctx, *mbuf, adapter->disable_meta_caching);
 
-	if (tx_ring->acum_pkts == DB_THRESHOLD ||
+	if (tx_ring->acum_pkts == ENA_DB_THRESHOLD ||
 	    ena_com_is_doorbell_needed(tx_ring->ena_com_io_sq, &ena_tx_ctx)) {
 		ena_log_io(pdev, DBG,
 		    "llq tx max burst size of queue %d achieved, writing doorbell to send burst\n",

--- a/kernel/fbsd/ena/ena_datapath.c
+++ b/kernel/fbsd/ena/ena_datapath.c
@@ -343,6 +343,8 @@ ena_tx_cleanup(struct ena_ring *tx_ring)
 		ENA_RING_MTX_UNLOCK(tx_ring);
 	}
 
+	tx_ring->tx_last_cleanup_ticks = ticks;
+
 	return (work_done);
 }
 

--- a/kernel/fbsd/ena/ena_datapath.c
+++ b/kernel/fbsd/ena/ena_datapath.c
@@ -1099,7 +1099,6 @@ ena_start_xmit(struct ena_ring *tx_ring)
 {
 	struct mbuf *mbuf;
 	struct ena_adapter *adapter = tx_ring->adapter;
-	int ena_qid;
 	int ret = 0;
 
 	ENA_RING_MTX_ASSERT(tx_ring);
@@ -1109,8 +1108,6 @@ ena_start_xmit(struct ena_ring *tx_ring)
 
 	if (unlikely(!ENA_FLAG_ISSET(ENA_FLAG_LINK_UP, adapter)))
 		return;
-
-	ena_qid = ENA_IO_TXQ_IDX(tx_ring->que->id);
 
 	while ((mbuf = drbr_peek(adapter->ifp, tx_ring->br)) != NULL) {
 		ena_log_io(adapter->pdev, DBG,

--- a/kernel/fbsd/ena/ena_datapath.c
+++ b/kernel/fbsd/ena/ena_datapath.c
@@ -45,21 +45,21 @@ __FBSDID("$FreeBSD$");
  *  Static functions prototypes
  *********************************************************************/
 
-static int	ena_tx_cleanup(struct ena_ring *);
-static int	ena_rx_cleanup(struct ena_ring *);
+static int ena_tx_cleanup(struct ena_ring *);
+static int ena_rx_cleanup(struct ena_ring *);
 static inline int ena_get_tx_req_id(struct ena_ring *tx_ring,
     struct ena_com_io_cq *io_cq, uint16_t *req_id);
-static void	ena_rx_hash_mbuf(struct ena_ring *, struct ena_com_rx_ctx *,
+static void ena_rx_hash_mbuf(struct ena_ring *, struct ena_com_rx_ctx *,
     struct mbuf *);
-static struct mbuf* ena_rx_mbuf(struct ena_ring *, struct ena_com_rx_buf_info *,
+static struct mbuf *ena_rx_mbuf(struct ena_ring *, struct ena_com_rx_buf_info *,
     struct ena_com_rx_ctx *, uint16_t *);
 static inline void ena_rx_checksum(struct ena_ring *, struct ena_com_rx_ctx *,
     struct mbuf *);
-static void	ena_tx_csum(struct ena_com_tx_ctx *, struct mbuf *, bool);
-static int	ena_check_and_collapse_mbuf(struct ena_ring *tx_ring,
+static void ena_tx_csum(struct ena_com_tx_ctx *, struct mbuf *, bool);
+static int ena_check_and_collapse_mbuf(struct ena_ring *tx_ring,
     struct mbuf **mbuf);
-static int	ena_xmit_mbuf(struct ena_ring *, struct mbuf **);
-static void	ena_start_xmit(struct ena_ring *);
+static int ena_xmit_mbuf(struct ena_ring *, struct mbuf **);
+static void ena_start_xmit(struct ena_ring *);
 
 /*********************************************************************
  *  Global functions
@@ -68,12 +68,12 @@ static void	ena_start_xmit(struct ena_ring *);
 void
 ena_cleanup(void *arg, int pending)
 {
-	struct ena_que	*que = arg;
+	struct ena_que *que = arg;
 	struct ena_adapter *adapter = que->adapter;
 	if_t ifp = adapter->ifp;
 	struct ena_ring *tx_ring;
 	struct ena_ring *rx_ring;
-	struct ena_com_io_cq* io_cq;
+	struct ena_com_io_cq *io_cq;
 	struct ena_eth_io_intr_reg intr_reg;
 	int qid, ena_qid;
 	int txc, rxc, i;
@@ -100,13 +100,11 @@ ena_cleanup(void *arg, int pending)
 			return;
 
 		if ((txc != TX_BUDGET) && (rxc != RX_BUDGET))
-		       break;
+			break;
 	}
 
 	/* Signal that work is done and unmask interrupt */
-	ena_com_update_intr_reg(&intr_reg,
-	    RX_IRQ_INTERVAL,
-	    TX_IRQ_INTERVAL,
+	ena_com_update_intr_reg(&intr_reg, RX_IRQ_INTERVAL, TX_IRQ_INTERVAL,
 	    true);
 	counter_u64_add(tx_ring->tx_stats.unmask_interrupt_num, 1);
 	ena_com_unmask_intr(io_cq, &intr_reg);
@@ -118,8 +116,7 @@ ena_deferred_mq_start(void *arg, int pending)
 	struct ena_ring *tx_ring = (struct ena_ring *)arg;
 	struct ifnet *ifp = tx_ring->adapter->ifp;
 
-	while (!drbr_empty(ifp, tx_ring->br) &&
-	    tx_ring->running &&
+	while (!drbr_empty(ifp, tx_ring->br) && tx_ring->running &&
 	    (if_getdrvflags(ifp) & IFF_DRV_RUNNING) != 0) {
 		ENA_RING_MTX_LOCK(tx_ring);
 		ena_start_xmit(tx_ring);
@@ -185,7 +182,7 @@ ena_qflush(if_t ifp)
 	struct ena_ring *tx_ring = adapter->tx_ring;
 	int i;
 
-	for(i = 0; i < adapter->num_io_queues; ++i, ++tx_ring)
+	for (i = 0; i < adapter->num_io_queues; ++i, ++tx_ring)
 		if (!drbr_empty(ifp, tx_ring->br)) {
 			ENA_RING_MTX_LOCK(tx_ring);
 			drbr_flush(ifp, tx_ring->br);
@@ -244,7 +241,7 @@ static int
 ena_tx_cleanup(struct ena_ring *tx_ring)
 {
 	struct ena_adapter *adapter;
-	struct ena_com_io_cq* io_cq;
+	struct ena_com_io_cq *io_cq;
 	uint16_t next_to_clean;
 	uint16_t req_id;
 	uint16_t ena_qid;
@@ -282,8 +279,7 @@ ena_tx_cleanup(struct ena_ring *tx_ring)
 
 		bus_dmamap_sync(adapter->tx_buf_tag, tx_info->dmamap,
 		    BUS_DMASYNC_POSTWRITE);
-		bus_dmamap_unload(adapter->tx_buf_tag,
-		    tx_info->dmamap);
+		bus_dmamap_unload(adapter->tx_buf_tag, tx_info->dmamap);
 
 		ena_log_io(adapter->pdev, DBG, "tx: q %d mbuf %p completed\n",
 		    tx_ring->qid, mbuf);
@@ -331,9 +327,8 @@ ena_tx_cleanup(struct ena_ring *tx_ring)
 	    ENA_TX_RESUME_THRESH);
 	if (unlikely(!tx_ring->running && above_thresh)) {
 		ENA_RING_MTX_LOCK(tx_ring);
-		above_thresh =
-		    ena_com_sq_have_enough_space(tx_ring->ena_com_io_sq,
-		    ENA_TX_RESUME_THRESH);
+		above_thresh = ena_com_sq_have_enough_space(
+		    tx_ring->ena_com_io_sq, ENA_TX_RESUME_THRESH);
 		if (!tx_ring->running && above_thresh) {
 			tx_ring->running = true;
 			counter_u64_add(tx_ring->tx_stats.queue_wakeup, 1);
@@ -421,7 +416,7 @@ ena_rx_hash_mbuf(struct ena_ring *rx_ring, struct ena_com_rx_ctx *ena_rx_ctx,
  * @next_to_clean: ring pointer, will be updated only upon success
  *
  **/
-static struct mbuf*
+static struct mbuf *
 ena_rx_mbuf(struct ena_ring *rx_ring, struct ena_com_rx_buf_info *ena_bufs,
     struct ena_com_rx_ctx *ena_rx_ctx, uint16_t *next_to_clean)
 {
@@ -568,8 +563,8 @@ ena_rx_cleanup(struct ena_ring *rx_ring)
 	device_t pdev;
 	struct mbuf *mbuf;
 	struct ena_com_rx_ctx ena_rx_ctx;
-	struct ena_com_io_cq* io_cq;
-	struct ena_com_io_sq* io_sq;
+	struct ena_com_io_cq *io_cq;
+	struct ena_com_io_sq *io_sq;
 	enum ena_regs_reset_reason_types reset_reason;
 	if_t ifp;
 	uint16_t ena_qid;
@@ -626,14 +621,14 @@ ena_rx_cleanup(struct ena_ring *rx_ring)
 		if (unlikely(ena_rx_ctx.descs == 0))
 			break;
 
-		ena_log_io(pdev, DBG, "rx: q %d got packet from ena. "
-		    "descs #: %d l3 proto %d l4 proto %d hash: %x\n",
+		ena_log_io(pdev, DBG,
+		    "rx: q %d got packet from ena. descs #: %d l3 proto %d l4 proto %d hash: %x\n",
 		    rx_ring->qid, ena_rx_ctx.descs, ena_rx_ctx.l3_proto,
 		    ena_rx_ctx.l4_proto, ena_rx_ctx.hash);
 
 		/* Receive mbuf from the ring */
-		mbuf = ena_rx_mbuf(rx_ring, rx_ring->ena_bufs,
-		    &ena_rx_ctx, &next_to_clean);
+		mbuf = ena_rx_mbuf(rx_ring, rx_ring->ena_bufs, &ena_rx_ctx,
+		    &next_to_clean);
 		bus_dmamap_sync(io_cq->cdesc_addr.mem_handle.tag,
 		    io_cq->cdesc_addr.mem_handle.map, BUS_DMASYNC_PREREAD);
 		/* Exit if we failed to retrieve a buffer */
@@ -641,10 +636,8 @@ ena_rx_cleanup(struct ena_ring *rx_ring)
 			for (i = 0; i < ena_rx_ctx.descs; ++i) {
 				rx_ring->free_rx_ids[next_to_clean] =
 				    rx_ring->ena_bufs[i].req_id;
-				next_to_clean =
-				    ENA_RX_RING_IDX_NEXT(next_to_clean,
-				    rx_ring->ring_size);
-
+				next_to_clean = ENA_RX_RING_IDX_NEXT(
+				    next_to_clean, rx_ring->ring_size);
 			}
 			break;
 		}
@@ -665,7 +658,7 @@ ena_rx_cleanup(struct ena_ring *rx_ring)
 		 * should be computed by hardware.
 		 */
 		do_if_input = 1;
-		if (((ifp->if_capenable & IFCAP_LRO) != 0)  &&
+		if (((ifp->if_capenable & IFCAP_LRO) != 0) &&
 		    ((mbuf->m_pkthdr.csum_flags & CSUM_IP_VALID) != 0) &&
 		    (ena_rx_ctx.l4_proto == ENA_ETH_IO_L4_PROTO_TCP)) {
 			/*
@@ -676,11 +669,11 @@ ena_rx_cleanup(struct ena_ring *rx_ring)
 			 */
 			if ((rx_ring->lro.lro_cnt != 0) &&
 			    (tcp_lro_rx(&rx_ring->lro, mbuf, 0) == 0))
-					do_if_input = 0;
+				do_if_input = 0;
 		}
 		if (do_if_input != 0) {
-			ena_log_io(pdev, DBG, "calling if_input() with mbuf %p\n",
-			    mbuf);
+			ena_log_io(pdev, DBG,
+			    "calling if_input() with mbuf %p\n", mbuf);
 			(*ifp->if_input)(ifp, mbuf);
 		}
 
@@ -872,8 +865,8 @@ ena_tx_map_mbuf(struct ena_ring *tx_ring, struct ena_tx_buffer *tx_info,
 	 * For easier maintaining of the DMA map, map the whole mbuf even if
 	 * the LLQ is used. The descriptors will be filled using the segments.
 	 */
-	rc = bus_dmamap_load_mbuf_sg(adapter->tx_buf_tag, tx_info->dmamap, mbuf,
-	    segs, &nsegs, BUS_DMA_NOWAIT);
+	rc = bus_dmamap_load_mbuf_sg(adapter->tx_buf_tag,
+	    tx_info->dmamap, mbuf, segs, &nsegs, BUS_DMA_NOWAIT);
 	if (unlikely((rc != 0) || (nsegs == 0))) {
 		ena_log_io(adapter->pdev, WARN,
 		    "dmamap load failed! err: %d nsegs: %d\n", rc, nsegs);
@@ -891,24 +884,27 @@ ena_tx_map_mbuf(struct ena_ring *tx_ring, struct ena_tx_buffer *tx_info,
 		 * First check if header fits in the mbuf. If not, copy it to
 		 * separate buffer that will be holding linearized data.
 		 */
-		*header_len = min_t(uint32_t, mbuf->m_pkthdr.len, tx_ring->tx_max_header_size);
+		*header_len = min_t(uint32_t, mbuf->m_pkthdr.len,
+		    tx_ring->tx_max_header_size);
 
 		/* If header is in linear space, just point into mbuf's data. */
 		if (likely(*header_len <= mbuf_head_len)) {
 			*push_hdr = mbuf->m_data;
 		/*
-		 * Otherwise, copy whole portion of header from multiple mbufs
-		 * to intermediate buffer.
+		 * Otherwise, copy whole portion of header from multiple
+		 * mbufs to intermediate buffer.
 		 */
 		} else {
-			m_copydata(mbuf, 0, *header_len, tx_ring->push_buf_intermediate_buf);
+			m_copydata(mbuf, 0, *header_len,
+			    tx_ring->push_buf_intermediate_buf);
 			*push_hdr = tx_ring->push_buf_intermediate_buf;
 
 			counter_u64_add(tx_ring->tx_stats.llq_buffer_copy, 1);
 		}
 
-		ena_log_io(adapter->pdev, DBG, "mbuf: %p ""header_buf->vaddr: %p "
-		    "push_len: %d\n", mbuf, *push_hdr, *header_len);
+		ena_log_io(adapter->pdev, DBG,
+		    "mbuf: %p header_buf->vaddr: %p push_len: %d\n",
+		    mbuf, *push_hdr, *header_len);
 
 		/* If packet is fitted in LLQ header, no need for DMA segments. */
 		if (mbuf->m_pkthdr.len <= tx_ring->tx_max_header_size) {
@@ -916,15 +912,18 @@ ena_tx_map_mbuf(struct ena_ring *tx_ring, struct ena_tx_buffer *tx_info,
 		} else {
 			offset = tx_ring->tx_max_header_size;
 			/*
-			 * As Header part is mapped to LLQ header, we can skip it and just
-			 * map the residuum of the mbuf to DMA Segments.
+			 * As Header part is mapped to LLQ header, we can skip
+			 * it and just map the residuum of the mbuf to DMA
+			 * Segments.
 			 */
 			while (offset > 0) {
 				if (offset >= segs[iseg].ds_len) {
 					offset -= segs[iseg].ds_len;
 				} else {
-					ena_buf->paddr = segs[iseg].ds_addr + offset;
-					ena_buf->len = segs[iseg].ds_len - offset;
+					ena_buf->paddr = segs[iseg].ds_addr +
+					    offset;
+					ena_buf->len = segs[iseg].ds_len -
+					    offset;
 					ena_buf++;
 					tx_info->num_of_bufs++;
 					offset = 0;
@@ -935,12 +934,12 @@ ena_tx_map_mbuf(struct ena_ring *tx_ring, struct ena_tx_buffer *tx_info,
 	} else {
 		*push_hdr = NULL;
 		/*
-		* header_len is just a hint for the device. Because FreeBSD is not
-		* giving us information about packet header length and it is not
-		* guaranteed that all packet headers will be in the 1st mbuf, setting
-		* header_len to 0 is making the device ignore this value and resolve
-		* header on it's own.
-		*/
+		 * header_len is just a hint for the device. Because FreeBSD is
+		 * not giving us information about packet header length and it
+		 * is not guaranteed that all packet headers will be in the 1st
+		 * mbuf, setting header_len to 0 is making the device ignore
+		 * this value and resolve header on it's own.
+		 */
 		*header_len = 0;
 	}
 
@@ -969,7 +968,7 @@ ena_xmit_mbuf(struct ena_ring *tx_ring, struct mbuf **mbuf)
 	struct ena_tx_buffer *tx_info;
 	struct ena_com_tx_ctx ena_tx_ctx;
 	struct ena_com_dev *ena_dev;
-	struct ena_com_io_sq* io_sq;
+	struct ena_com_io_sq *io_sq;
 	void *push_hdr;
 	uint16_t next_to_use;
 	uint16_t req_id;
@@ -1138,8 +1137,7 @@ ena_start_xmit(struct ena_ring *tx_ring)
 
 		drbr_advance(adapter->ifp, tx_ring->br);
 
-		if (unlikely((if_getdrvflags(adapter->ifp) &
-		    IFF_DRV_RUNNING) == 0))
+		if (unlikely((if_getdrvflags(adapter->ifp) & IFF_DRV_RUNNING) == 0))
 			return;
 
 		tx_ring->acum_pkts++;

--- a/kernel/fbsd/ena/ena_datapath.c
+++ b/kernel/fbsd/ena/ena_datapath.c
@@ -1016,9 +1016,7 @@ ena_xmit_mbuf(struct ena_ring *tx_ring, struct mbuf **mbuf)
 		ena_log_io(pdev, DBG,
 		    "llq tx max burst size of queue %d achieved, writing doorbell to send burst\n",
 		    tx_ring->que->id);
-		ena_com_write_sq_doorbell(tx_ring->ena_com_io_sq);
-		counter_u64_add(tx_ring->tx_stats.doorbells, 1);
-		tx_ring->acum_pkts = 0;
+		ena_ring_tx_doorbell(tx_ring);
 	}
 
 	/* Prepare the packet's descriptors and send them to device */
@@ -1097,7 +1095,6 @@ ena_start_xmit(struct ena_ring *tx_ring)
 {
 	struct mbuf *mbuf;
 	struct ena_adapter *adapter = tx_ring->adapter;
-	struct ena_com_io_sq* io_sq;
 	int ena_qid;
 	int ret = 0;
 
@@ -1110,7 +1107,6 @@ ena_start_xmit(struct ena_ring *tx_ring)
 		return;
 
 	ena_qid = ENA_IO_TXQ_IDX(tx_ring->que->id);
-	io_sq = &adapter->ena_dev->io_sq_queues[ena_qid];
 
 	while ((mbuf = drbr_peek(adapter->ifp, tx_ring->br)) != NULL) {
 		ena_log_io(adapter->pdev, DBG,
@@ -1148,9 +1144,7 @@ ena_start_xmit(struct ena_ring *tx_ring)
 
 	if (likely(tx_ring->acum_pkts != 0)) {
 		/* Trigger the dma engine */
-		ena_com_write_sq_doorbell(io_sq);
-		counter_u64_add(tx_ring->tx_stats.doorbells, 1);
-		tx_ring->acum_pkts = 0;
+		ena_ring_tx_doorbell(tx_ring);
 	}
 
 	if (unlikely(!tx_ring->running))

--- a/kernel/fbsd/ena/ena_datapath.c
+++ b/kernel/fbsd/ena/ena_datapath.c
@@ -89,8 +89,8 @@ ena_cleanup(void *arg, int pending)
 	ena_qid = ENA_IO_TXQ_IDX(qid);
 	io_cq = &adapter->ena_dev->io_cq_queues[ena_qid];
 
-	tx_ring->first_interrupt = true;
-	rx_ring->first_interrupt = true;
+	atomic_store_8(&tx_ring->first_interrupt, true);
+	atomic_store_8(&rx_ring->first_interrupt, true);
 
 	for (i = 0; i < CLEAN_BUDGET; ++i) {
 		rxc = ena_rx_cleanup(rx_ring);

--- a/kernel/fbsd/ena/ena_datapath.h
+++ b/kernel/fbsd/ena/ena_datapath.h
@@ -34,12 +34,12 @@
 #ifndef ENA_TXRX_H
 #define ENA_TXRX_H
 
-void	ena_cleanup(void *arg, int pending);
-void	ena_qflush(if_t ifp);
-int	ena_mq_start(if_t ifp, struct mbuf *m);
-void	ena_deferred_mq_start(void *arg, int pending);
+void ena_cleanup(void *arg, int pending);
+void ena_qflush(if_t ifp);
+int ena_mq_start(if_t ifp, struct mbuf *m);
+void ena_deferred_mq_start(void *arg, int pending);
 
-#define CSUM_OFFLOAD 	(CSUM_IP|CSUM_TCP|CSUM_UDP)
-#define CSUM6_OFFLOAD	(CSUM_IP6_UDP|CSUM_IP6_TCP)
+#define CSUM_OFFLOAD (CSUM_IP | CSUM_TCP | CSUM_UDP)
+#define CSUM6_OFFLOAD (CSUM_IP6_UDP | CSUM_IP6_TCP)
 
 #endif /* ENA_TXRX_H */

--- a/kernel/fbsd/ena/ena_netmap.c
+++ b/kernel/fbsd/ena/ena_netmap.c
@@ -428,7 +428,7 @@ ena_netmap_tx_frame(struct ena_netmap_ctx *ctx)
 
 	/* There are no any offloads, as the netmap doesn't support them */
 
-	if (tx_ring->acum_pkts == DB_THRESHOLD ||
+	if (tx_ring->acum_pkts == ENA_DB_THRESHOLD ||
 	    ena_com_is_doorbell_needed(ctx->io_sq, &ena_tx_ctx))
 		ena_ring_tx_doorbell(tx_ring);
 

--- a/kernel/fbsd/ena/ena_netmap.c
+++ b/kernel/fbsd/ena/ena_netmap.c
@@ -882,7 +882,8 @@ validate_tx_req_id(struct ena_ring *tx_ring, uint16_t req_id)
 	if (likely(req_id < tx_ring->ring_size))
 		return (0);
 
-	ena_log_nm(adapter->pdev, WARN, "Invalid req_id: %hu\n", req_id);
+	ena_log_nm(adapter->pdev, WARN, "Invalid req_id %hu in qid %hu\n",
+	    req_id, tx_ring->qid);
 	counter_u64_add(tx_ring->tx_stats.bad_req_id, 1);
 
 	ena_trigger_reset(adapter, ENA_REGS_RESET_INV_TX_REQ_ID);

--- a/kernel/fbsd/ena/ena_netmap.c
+++ b/kernel/fbsd/ena/ena_netmap.c
@@ -206,7 +206,7 @@ ena_netmap_free_rx_slot(struct ena_adapter *adapter, struct ena_ring *rx_ring,
 	    BUS_DMASYNC_POSTREAD);
 	netmap_unload_map(na, adapter->rx_buf_tag, rx_info->map);
 
-	KASSERT(kring->ring == NULL, ("Netmap Rx ring is NULL\n"));
+	KASSERT(kring->ring != NULL, ("Netmap Rx ring is NULL\n"));
 
 	slot = &kring->ring->slot[nm_i];
 

--- a/kernel/fbsd/ena/ena_netmap.c
+++ b/kernel/fbsd/ena/ena_netmap.c
@@ -508,10 +508,8 @@ ena_netmap_copy_data(struct netmap_adapter *na, struct netmap_slot *slots,
 {
 	struct netmap_slot *nm_slot;
 	void *slot_vaddr;
-	uint16_t packet_size;
 	uint16_t data_amount;
 
-	packet_size = 0;
 	do {
 		nm_slot = &slots[slot_index];
 		slot_vaddr = NMB(na, nm_slot);

--- a/kernel/fbsd/ena/ena_netmap.h
+++ b/kernel/fbsd/ena/ena_netmap.h
@@ -42,19 +42,21 @@
 #undef unlikely
 #endif /* unlikely */
 
-#include <net/netmap.h>
 #include <sys/selinfo.h>
+
+#include <net/netmap.h>
+
 #include <dev/netmap/netmap_kern.h>
 
-int	ena_netmap_attach(struct ena_adapter *adapter);
-int	ena_netmap_alloc_rx_slot(struct ena_adapter *adapter,
+int ena_netmap_attach(struct ena_adapter *adapter);
+int ena_netmap_alloc_rx_slot(struct ena_adapter *adapter,
     struct ena_ring *rx_ring, struct ena_rx_buffer *rx_info);
-void	ena_netmap_free_rx_slot(struct ena_adapter *adapter,
+void ena_netmap_free_rx_slot(struct ena_adapter *adapter,
     struct ena_ring *rx_ring, struct ena_rx_buffer *rx_info);
-bool	ena_rx_ring_in_netmap(struct ena_adapter *adapter, int qid);
-bool	ena_tx_ring_in_netmap(struct ena_adapter *adapter, int qid);
-void	ena_netmap_reset_rx_ring(struct ena_adapter *adapter, int qid);
-void	ena_netmap_reset_tx_ring(struct ena_adapter *adapter, int qid);
-void	ena_netmap_unload(struct ena_adapter *adapter, bus_dmamap_t map);
+bool ena_rx_ring_in_netmap(struct ena_adapter *adapter, int qid);
+bool ena_tx_ring_in_netmap(struct ena_adapter *adapter, int qid);
+void ena_netmap_reset_rx_ring(struct ena_adapter *adapter, int qid);
+void ena_netmap_reset_tx_ring(struct ena_adapter *adapter, int qid);
+void ena_netmap_unload(struct ena_adapter *adapter, bus_dmamap_t map);
 
 #endif /* _ENA_NETMAP_H_ */

--- a/kernel/fbsd/ena/ena_rss.c
+++ b/kernel/fbsd/ena/ena_rss.c
@@ -47,7 +47,8 @@ ena_rss_key_fill(void *key, size_t size)
 	static bool key_generated;
 	static uint8_t default_key[ENA_HASH_KEY_SIZE];
 
-	KASSERT(size <= ENA_HASH_KEY_SIZE, ("Requested more bytes than ENA RSS key can hold"));
+	KASSERT(size <= ENA_HASH_KEY_SIZE,
+	    ("Requested more bytes than ENA RSS key can hold"));
 
 	if (!key_generated) {
 #if __FreeBSD_version > 1200028
@@ -75,7 +76,8 @@ ena_rss_reorder_hash_key(u8 *reordered_key, const u8 *key, size_t key_size)
 		*reordered_key++ = *key--;
 }
 
-int ena_rss_set_hash(struct ena_com_dev *ena_dev, const u8 *key)
+int
+ena_rss_set_hash(struct ena_com_dev *ena_dev, const u8 *key)
 {
 	enum ena_admin_hash_functions ena_func = ENA_ADMIN_TOEPLITZ;
 	u8 hw_key[ENA_HASH_KEY_SIZE];
@@ -86,7 +88,8 @@ int ena_rss_set_hash(struct ena_com_dev *ena_dev, const u8 *key)
 	    ENA_HASH_KEY_SIZE, 0x0));
 }
 
-int ena_rss_get_hash_key(struct ena_com_dev *ena_dev, u8 *key)
+int
+ena_rss_get_hash_key(struct ena_com_dev *ena_dev, u8 *key)
 {
 	u8 hw_key[ENA_HASH_KEY_SIZE];
 	int rc;
@@ -137,8 +140,8 @@ ena_rss_init_default(struct ena_adapter *adapter)
 		rc = ena_rss_set_hash(ena_dev, hash_key);
 	} else
 #endif
-	rc = ena_com_fill_hash_function(ena_dev, ENA_ADMIN_TOEPLITZ, NULL,
-	    ENA_HASH_KEY_SIZE, 0x0);
+		rc = ena_com_fill_hash_function(ena_dev, ENA_ADMIN_TOEPLITZ,
+		    NULL, ENA_HASH_KEY_SIZE, 0x0);
 	if (unlikely((rc != 0) && (rc != EOPNOTSUPP))) {
 		ena_log(dev, ERR, "Cannot fill hash function\n");
 		goto err_rss_destroy;
@@ -220,12 +223,14 @@ ena_rss_init_default_deferred(void *arg)
 				ena_log(adapter->pdev, WARN,
 				    "WARNING: RSS was not properly initialized,"
 				    " it will affect bandwidth\n");
-				ENA_FLAG_CLEAR_ATOMIC(ENA_FLAG_RSS_ACTIVE, adapter);
+				ENA_FLAG_CLEAR_ATOMIC(ENA_FLAG_RSS_ACTIVE,
+				    adapter);
 			}
 		}
 	}
 }
-SYSINIT(ena_rss_init, SI_SUB_KICK_SCHEDULER, SI_ORDER_SECOND, ena_rss_init_default_deferred, NULL);
+SYSINIT(ena_rss_init, SI_SUB_KICK_SCHEDULER, SI_ORDER_SECOND,
+    ena_rss_init_default_deferred, NULL);
 
 int
 ena_rss_indir_get(struct ena_adapter *adapter, uint32_t *table)
@@ -269,8 +274,7 @@ ena_rss_indir_set(struct ena_adapter *adapter, uint32_t *table)
 		device_printf(adapter->pdev,
 		    "Writing to indirection table not supported\n");
 	else if (rc != 0)
-		device_printf(adapter->pdev,
-		    "Cannot set indirection table\n");
+		device_printf(adapter->pdev, "Cannot set indirection table\n");
 
 	return (rc);
 }

--- a/kernel/fbsd/ena/ena_rss.h
+++ b/kernel/fbsd/ena/ena_rss.h
@@ -42,7 +42,7 @@
 
 #include "ena.h"
 
-#define ENA_RX_RSS_MSG_RECORD_SZ	8
+#define ENA_RX_RSS_MSG_RECORD_SZ 8
 
 struct ena_indir {
 	uint32_t table[ENA_RX_RSS_TABLE_SIZE];
@@ -50,12 +50,12 @@ struct ena_indir {
 	char sysctl_buf[ENA_RX_RSS_TABLE_SIZE * ENA_RX_RSS_MSG_RECORD_SZ];
 };
 
-int	ena_rss_set_hash(struct ena_com_dev *ena_dev, const u8 *key);
-int	ena_rss_get_hash_key(struct ena_com_dev *ena_dev, u8 *key);
-int	ena_rss_configure(struct ena_adapter *);
-int	ena_rss_indir_get(struct ena_adapter *adapter, uint32_t *table);
-int	ena_rss_indir_set(struct ena_adapter *adapter, uint32_t *table);
-int	ena_rss_indir_init(struct ena_adapter *adapter);
+int ena_rss_set_hash(struct ena_com_dev *ena_dev, const u8 *key);
+int ena_rss_get_hash_key(struct ena_com_dev *ena_dev, u8 *key);
+int ena_rss_configure(struct ena_adapter *);
+int ena_rss_indir_get(struct ena_adapter *adapter, uint32_t *table);
+int ena_rss_indir_set(struct ena_adapter *adapter, uint32_t *table);
+int ena_rss_indir_init(struct ena_adapter *adapter);
 
 static inline void
 ena_rss_copy_indir_buf(char *buf, uint32_t *table)
@@ -63,8 +63,8 @@ ena_rss_copy_indir_buf(char *buf, uint32_t *table)
 	int i;
 
 	for (i = 0; i < ENA_RX_RSS_TABLE_SIZE; ++i) {
-		buf += snprintf(buf, ENA_RX_RSS_MSG_RECORD_SZ + 1,
-		    "%s%d:%d", i == 0 ? "" : " ", i, table[i]);
+		buf += snprintf(buf, ENA_RX_RSS_MSG_RECORD_SZ + 1, "%s%d:%d",
+		    i == 0 ? "" : " ", i, table[i]);
 	}
 }
 

--- a/kernel/fbsd/ena/ena_sysctl.c
+++ b/kernel/fbsd/ena/ena_sysctl.c
@@ -66,7 +66,7 @@ SYSCTL_INT(_hw_ena, OID_AUTO, log_level, CTLFLAG_RWTUN, &ena_log_level, 0,
     "Logging level indicating verbosity of the logs");
 
 SYSCTL_CONST_STRING(_hw_ena, OID_AUTO, driver_version, CTLFLAG_RD,
-    DRV_MODULE_VERSION, "ENA driver version");
+    ENA_DRV_MODULE_VERSION, "ENA driver version");
 
 /*
  * Use 9k mbufs for the Rx buffers. Default to 0 (use page size mbufs instead).

--- a/kernel/fbsd/ena/ena_sysctl.c
+++ b/kernel/fbsd/ena/ena_sysctl.c
@@ -484,11 +484,9 @@ ena_sysctl_add_rss(struct ena_adapter *adapter)
 void
 ena_sysctl_update_queue_node_nb(struct ena_adapter *adapter, int old, int new)
 {
-	device_t dev;
 	struct sysctl_oid *oid;
 	int min, max, i;
 
-	dev = adapter->pdev;
 	min = MIN(old, new);
 	max = MIN(MAX(old, new), adapter->max_num_io_queues);
 
@@ -830,7 +828,6 @@ ena_sysctl_rss_indir_table(SYSCTL_HANDLER_ARGS)
 {
 	int num_queues, error;
 	struct ena_adapter *adapter = arg1;
-	struct ena_com_dev *ena_dev;
 	struct ena_indir *indir;
 	char *msg, *buf, *endp;
 	uint32_t idx, value;
@@ -846,7 +843,6 @@ ena_sysctl_rss_indir_table(SYSCTL_HANDLER_ARGS)
 		goto unlock;
 	}
 
-	ena_dev = adapter->ena_dev;
 	indir = adapter->rss_indir;
 	msg = indir->sysctl_buf;
 

--- a/kernel/fbsd/ena/ena_sysctl.c
+++ b/kernel/fbsd/ena/ena_sysctl.c
@@ -31,29 +31,29 @@
 #include <sys/param.h>
 __FBSDID("$FreeBSD$");
 
-#include "ena_sysctl.h"
 #include "ena_rss.h"
+#include "ena_sysctl.h"
 
-static void	ena_sysctl_add_wd(struct ena_adapter *);
-static void	ena_sysctl_add_stats(struct ena_adapter *);
-static void	ena_sysctl_add_eni_metrics(struct ena_adapter *);
-static void	ena_sysctl_add_tuneables(struct ena_adapter *);
+static void ena_sysctl_add_wd(struct ena_adapter *);
+static void ena_sysctl_add_stats(struct ena_adapter *);
+static void ena_sysctl_add_eni_metrics(struct ena_adapter *);
+static void ena_sysctl_add_tuneables(struct ena_adapter *);
 /* Kernel option RSS prevents manipulation of key hash and indirection table. */
 #ifndef RSS
-static void	ena_sysctl_add_rss(struct ena_adapter *);
+static void ena_sysctl_add_rss(struct ena_adapter *);
 #endif
-static int	ena_sysctl_buf_ring_size(SYSCTL_HANDLER_ARGS);
-static int	ena_sysctl_rx_queue_size(SYSCTL_HANDLER_ARGS);
-static int	ena_sysctl_io_queues_nb(SYSCTL_HANDLER_ARGS);
-static int	ena_sysctl_eni_metrics_interval(SYSCTL_HANDLER_ARGS);
+static int ena_sysctl_buf_ring_size(SYSCTL_HANDLER_ARGS);
+static int ena_sysctl_rx_queue_size(SYSCTL_HANDLER_ARGS);
+static int ena_sysctl_io_queues_nb(SYSCTL_HANDLER_ARGS);
+static int ena_sysctl_eni_metrics_interval(SYSCTL_HANDLER_ARGS);
 #ifndef RSS
-static int	ena_sysctl_rss_key(SYSCTL_HANDLER_ARGS);
-static int	ena_sysctl_rss_indir_table(SYSCTL_HANDLER_ARGS);
+static int ena_sysctl_rss_key(SYSCTL_HANDLER_ARGS);
+static int ena_sysctl_rss_indir_table(SYSCTL_HANDLER_ARGS);
 #endif
 
 /* Limit max ENI sample rate to be an hour. */
 #define ENI_METRICS_MAX_SAMPLE_INTERVAL 3600
-#define ENA_HASH_KEY_MSG_SIZE		(ENA_HASH_KEY_SIZE * 2 + 1)
+#define ENA_HASH_KEY_MSG_SIZE (ENA_HASH_KEY_SIZE * 2 + 1)
 
 static SYSCTL_NODE(_hw, OID_AUTO, ena, CTLFLAG_RD | CTLFLAG_MPSAFE, 0,
     "ENA driver parameters");
@@ -62,8 +62,8 @@ static SYSCTL_NODE(_hw, OID_AUTO, ena, CTLFLAG_RD | CTLFLAG_MPSAFE, 0,
  * Logging level for changing verbosity of the output
  */
 int ena_log_level = ENA_INFO;
-SYSCTL_INT(_hw_ena, OID_AUTO, log_level, CTLFLAG_RWTUN,
-    &ena_log_level, 0, "Logging level indicating verbosity of the logs");
+SYSCTL_INT(_hw_ena, OID_AUTO, log_level, CTLFLAG_RWTUN, &ena_log_level, 0,
+    "Logging level indicating verbosity of the logs");
 
 SYSCTL_CONST_STRING(_hw_ena, OID_AUTO, driver_version, CTLFLAG_RD,
     DRV_MODULE_VERSION, "ENA driver version");
@@ -123,9 +123,8 @@ ena_sysctl_add_wd(struct ena_adapter *adapter)
 	child = SYSCTL_CHILDREN(tree);
 
 	/* Sysctl calls for Watchdog service */
-	SYSCTL_ADD_INT(ctx, child, OID_AUTO, "wd_active",
-	    CTLFLAG_RWTUN, &adapter->wd_active, 0,
-	    "Watchdog is active");
+	SYSCTL_ADD_INT(ctx, child, OID_AUTO, "wd_active", CTLFLAG_RWTUN,
+	    &adapter->wd_active, 0, "Watchdog is active");
 
 	SYSCTL_ADD_QUAD(ctx, child, OID_AUTO, "keep_alive_timeout",
 	    CTLFLAG_RWTUN, &adapter->keep_alive_timeout,
@@ -184,82 +183,68 @@ ena_sysctl_add_stats(struct ena_adapter *adapter)
 	dev_stats = &adapter->dev_stats;
 	admin_stats = &adapter->ena_dev->admin_queue.stats;
 
-	SYSCTL_ADD_COUNTER_U64(ctx, child, OID_AUTO, "wd_expired",
-	    CTLFLAG_RD, &dev_stats->wd_expired,
-	    "Watchdog expiry count");
-	SYSCTL_ADD_COUNTER_U64(ctx, child, OID_AUTO, "interface_up",
-	    CTLFLAG_RD, &dev_stats->interface_up,
-	    "Network interface up count");
+	SYSCTL_ADD_COUNTER_U64(ctx, child, OID_AUTO, "wd_expired", CTLFLAG_RD,
+	    &dev_stats->wd_expired, "Watchdog expiry count");
+	SYSCTL_ADD_COUNTER_U64(ctx, child, OID_AUTO, "interface_up", CTLFLAG_RD,
+	    &dev_stats->interface_up, "Network interface up count");
 	SYSCTL_ADD_COUNTER_U64(ctx, child, OID_AUTO, "interface_down",
 	    CTLFLAG_RD, &dev_stats->interface_down,
 	    "Network interface down count");
 	SYSCTL_ADD_COUNTER_U64(ctx, child, OID_AUTO, "admin_q_pause",
-	    CTLFLAG_RD, &dev_stats->admin_q_pause,
-	    "Admin queue pauses");
+	    CTLFLAG_RD, &dev_stats->admin_q_pause, "Admin queue pauses");
 
 	for (i = 0; i < adapter->num_io_queues; ++i, ++tx_ring, ++rx_ring) {
 		snprintf(namebuf, QUEUE_NAME_LEN, "queue%d", i);
 
-		queue_node = SYSCTL_ADD_NODE(ctx, child, OID_AUTO,
-		    namebuf, CTLFLAG_RD | CTLFLAG_MPSAFE, NULL, "Queue Name");
+		queue_node = SYSCTL_ADD_NODE(ctx, child, OID_AUTO, namebuf,
+		    CTLFLAG_RD | CTLFLAG_MPSAFE, NULL, "Queue Name");
 		queue_list = SYSCTL_CHILDREN(queue_node);
 
 		adapter->que[i].oid = queue_node;
 
 #ifdef RSS
 		/* Common stats */
-		SYSCTL_ADD_INT(ctx, queue_list, OID_AUTO, "cpu",
-		    CTLFLAG_RD, &adapter->que[i].cpu, 0, "CPU affinity");
-		SYSCTL_ADD_INT(ctx, queue_list, OID_AUTO, "domain",
-		    CTLFLAG_RD, &adapter->que[i].domain, 0, "NUMA domain");
+		SYSCTL_ADD_INT(ctx, queue_list, OID_AUTO, "cpu", CTLFLAG_RD,
+		    &adapter->que[i].cpu, 0, "CPU affinity");
+		SYSCTL_ADD_INT(ctx, queue_list, OID_AUTO, "domain", CTLFLAG_RD,
+		    &adapter->que[i].domain, 0, "NUMA domain");
 #endif
 
 		/* TX specific stats */
-		tx_node = SYSCTL_ADD_NODE(ctx, queue_list, OID_AUTO,
-		    "tx_ring", CTLFLAG_RD | CTLFLAG_MPSAFE, NULL, "TX ring");
+		tx_node = SYSCTL_ADD_NODE(ctx, queue_list, OID_AUTO, "tx_ring",
+		    CTLFLAG_RD | CTLFLAG_MPSAFE, NULL, "TX ring");
 		tx_list = SYSCTL_CHILDREN(tx_node);
 
 		tx_stats = &tx_ring->tx_stats;
 
+		SYSCTL_ADD_COUNTER_U64(ctx, tx_list, OID_AUTO, "count",
+		    CTLFLAG_RD, &tx_stats->cnt, "Packets sent");
+		SYSCTL_ADD_COUNTER_U64(ctx, tx_list, OID_AUTO, "bytes",
+		    CTLFLAG_RD, &tx_stats->bytes, "Bytes sent");
 		SYSCTL_ADD_COUNTER_U64(ctx, tx_list, OID_AUTO,
-		    "count", CTLFLAG_RD,
-		    &tx_stats->cnt, "Packets sent");
-		SYSCTL_ADD_COUNTER_U64(ctx, tx_list, OID_AUTO,
-		    "bytes", CTLFLAG_RD,
-		    &tx_stats->bytes, "Bytes sent");
-		SYSCTL_ADD_COUNTER_U64(ctx, tx_list, OID_AUTO,
-		    "prepare_ctx_err", CTLFLAG_RD,
-		    &tx_stats->prepare_ctx_err,
+		    "prepare_ctx_err", CTLFLAG_RD, &tx_stats->prepare_ctx_err,
 		    "TX buffer preparation failures");
 		SYSCTL_ADD_COUNTER_U64(ctx, tx_list, OID_AUTO,
-		    "dma_mapping_err", CTLFLAG_RD,
-		    &tx_stats->dma_mapping_err, "DMA mapping failures");
+		    "dma_mapping_err", CTLFLAG_RD, &tx_stats->dma_mapping_err,
+		    "DMA mapping failures");
+		SYSCTL_ADD_COUNTER_U64(ctx, tx_list, OID_AUTO, "doorbells",
+		    CTLFLAG_RD, &tx_stats->doorbells, "Queue doorbells");
 		SYSCTL_ADD_COUNTER_U64(ctx, tx_list, OID_AUTO,
-		    "doorbells", CTLFLAG_RD,
-		    &tx_stats->doorbells, "Queue doorbells");
+		    "missing_tx_comp", CTLFLAG_RD, &tx_stats->missing_tx_comp,
+		    "TX completions missed");
+		SYSCTL_ADD_COUNTER_U64(ctx, tx_list, OID_AUTO, "bad_req_id",
+		    CTLFLAG_RD, &tx_stats->bad_req_id, "Bad request id count");
+		SYSCTL_ADD_COUNTER_U64(ctx, tx_list, OID_AUTO, "mbuf_collapses",
+		    CTLFLAG_RD, &tx_stats->collapse, "Mbuf collapse count");
 		SYSCTL_ADD_COUNTER_U64(ctx, tx_list, OID_AUTO,
-		    "missing_tx_comp", CTLFLAG_RD,
-		    &tx_stats->missing_tx_comp, "TX completions missed");
+		    "mbuf_collapse_err", CTLFLAG_RD, &tx_stats->collapse_err,
+		    "Mbuf collapse failures");
+		SYSCTL_ADD_COUNTER_U64(ctx, tx_list, OID_AUTO, "queue_wakeups",
+		    CTLFLAG_RD, &tx_stats->queue_wakeup, "Queue wakeups");
+		SYSCTL_ADD_COUNTER_U64(ctx, tx_list, OID_AUTO, "queue_stops",
+		    CTLFLAG_RD, &tx_stats->queue_stop, "Queue stops");
 		SYSCTL_ADD_COUNTER_U64(ctx, tx_list, OID_AUTO,
-		    "bad_req_id", CTLFLAG_RD,
-		    &tx_stats->bad_req_id, "Bad request id count");
-		SYSCTL_ADD_COUNTER_U64(ctx, tx_list, OID_AUTO,
-		        "mbuf_collapses", CTLFLAG_RD,
-		        &tx_stats->collapse,
-		        "Mbuf collapse count");
-		SYSCTL_ADD_COUNTER_U64(ctx, tx_list, OID_AUTO,
-		        "mbuf_collapse_err", CTLFLAG_RD,
-		        &tx_stats->collapse_err,
-		        "Mbuf collapse failures");
-		SYSCTL_ADD_COUNTER_U64(ctx, tx_list, OID_AUTO,
-		    "queue_wakeups", CTLFLAG_RD,
-		    &tx_stats->queue_wakeup, "Queue wakeups");
-		SYSCTL_ADD_COUNTER_U64(ctx, tx_list, OID_AUTO,
-		    "queue_stops", CTLFLAG_RD,
-		    &tx_stats->queue_stop, "Queue stops");
-		SYSCTL_ADD_COUNTER_U64(ctx, tx_list, OID_AUTO,
-		    "llq_buffer_copy", CTLFLAG_RD,
-		    &tx_stats->llq_buffer_copy,
+		    "llq_buffer_copy", CTLFLAG_RD, &tx_stats->llq_buffer_copy,
 		    "Header copies for llq transaction");
 		SYSCTL_ADD_COUNTER_U64(ctx, tx_list, OID_AUTO,
 		    "unmask_interrupt_num", CTLFLAG_RD,
@@ -267,45 +252,41 @@ ena_sysctl_add_stats(struct ena_adapter *adapter)
 		    "Unmasked interrupt count");
 
 		/* RX specific stats */
-		rx_node = SYSCTL_ADD_NODE(ctx, queue_list, OID_AUTO,
-		    "rx_ring", CTLFLAG_RD | CTLFLAG_MPSAFE, NULL, "RX ring");
+		rx_node = SYSCTL_ADD_NODE(ctx, queue_list, OID_AUTO, "rx_ring",
+		    CTLFLAG_RD | CTLFLAG_MPSAFE, NULL, "RX ring");
 		rx_list = SYSCTL_CHILDREN(rx_node);
 
 		rx_stats = &rx_ring->rx_stats;
 
+		SYSCTL_ADD_COUNTER_U64(ctx, rx_list, OID_AUTO, "count",
+		    CTLFLAG_RD, &rx_stats->cnt, "Packets received");
+		SYSCTL_ADD_COUNTER_U64(ctx, rx_list, OID_AUTO, "bytes",
+		    CTLFLAG_RD, &rx_stats->bytes, "Bytes received");
+		SYSCTL_ADD_COUNTER_U64(ctx, rx_list, OID_AUTO, "refil_partial",
+		    CTLFLAG_RD, &rx_stats->refil_partial,
+		    "Partial refilled mbufs");
+		SYSCTL_ADD_COUNTER_U64(ctx, rx_list, OID_AUTO, "csum_bad",
+		    CTLFLAG_RD, &rx_stats->csum_bad, "Bad RX checksum");
 		SYSCTL_ADD_COUNTER_U64(ctx, rx_list, OID_AUTO,
-		    "count", CTLFLAG_RD,
-		    &rx_stats->cnt, "Packets received");
+		    "mbuf_alloc_fail", CTLFLAG_RD, &rx_stats->mbuf_alloc_fail,
+		    "Failed mbuf allocs");
 		SYSCTL_ADD_COUNTER_U64(ctx, rx_list, OID_AUTO,
-		    "bytes", CTLFLAG_RD,
-		    &rx_stats->bytes, "Bytes received");
+		    "mjum_alloc_fail", CTLFLAG_RD, &rx_stats->mjum_alloc_fail,
+		    "Failed jumbo mbuf allocs");
 		SYSCTL_ADD_COUNTER_U64(ctx, rx_list, OID_AUTO,
-		    "refil_partial", CTLFLAG_RD,
-		    &rx_stats->refil_partial, "Partial refilled mbufs");
-		SYSCTL_ADD_COUNTER_U64(ctx, rx_list, OID_AUTO,
-		    "csum_bad", CTLFLAG_RD,
-		    &rx_stats->csum_bad, "Bad RX checksum");
-		SYSCTL_ADD_COUNTER_U64(ctx, rx_list, OID_AUTO,
-		    "mbuf_alloc_fail", CTLFLAG_RD,
-		    &rx_stats->mbuf_alloc_fail, "Failed mbuf allocs");
-		SYSCTL_ADD_COUNTER_U64(ctx, rx_list, OID_AUTO,
-		    "mjum_alloc_fail", CTLFLAG_RD,
-		    &rx_stats->mjum_alloc_fail, "Failed jumbo mbuf allocs");
-		SYSCTL_ADD_COUNTER_U64(ctx, rx_list, OID_AUTO,
-		    "dma_mapping_err", CTLFLAG_RD,
-		    &rx_stats->dma_mapping_err, "DMA mapping errors");
-		SYSCTL_ADD_COUNTER_U64(ctx, rx_list, OID_AUTO,
-		    "bad_desc_num", CTLFLAG_RD,
-		    &rx_stats->bad_desc_num, "Bad descriptor count");
-		SYSCTL_ADD_COUNTER_U64(ctx, rx_list, OID_AUTO,
-		    "bad_req_id", CTLFLAG_RD,
-		    &rx_stats->bad_req_id, "Bad request id count");
-		SYSCTL_ADD_COUNTER_U64(ctx, rx_list, OID_AUTO,
-		    "empty_rx_ring", CTLFLAG_RD,
-		    &rx_stats->empty_rx_ring, "RX descriptors depletion count");
-		SYSCTL_ADD_COUNTER_U64(ctx, rx_list, OID_AUTO,
-		    "csum_good", CTLFLAG_RD,
-		    &rx_stats->csum_good, "Valid RX checksum calculations");
+		    "dma_mapping_err", CTLFLAG_RD, &rx_stats->dma_mapping_err,
+		    "DMA mapping errors");
+		SYSCTL_ADD_COUNTER_U64(ctx, rx_list, OID_AUTO, "bad_desc_num",
+		    CTLFLAG_RD, &rx_stats->bad_desc_num,
+		    "Bad descriptor count");
+		SYSCTL_ADD_COUNTER_U64(ctx, rx_list, OID_AUTO, "bad_req_id",
+		    CTLFLAG_RD, &rx_stats->bad_req_id, "Bad request id count");
+		SYSCTL_ADD_COUNTER_U64(ctx, rx_list, OID_AUTO, "empty_rx_ring",
+		    CTLFLAG_RD, &rx_stats->empty_rx_ring,
+		    "RX descriptors depletion count");
+		SYSCTL_ADD_COUNTER_U64(ctx, rx_list, OID_AUTO, "csum_good",
+		    CTLFLAG_RD, &rx_stats->csum_good,
+		    "Valid RX checksum calculations");
 	}
 
 	/* Stats read from device */
@@ -572,7 +553,7 @@ ena_sysctl_rx_queue_size(SYSCTL_HANDLER_ARGS)
 	if (error != 0 || req->newptr == NULL)
 		goto unlock;
 
-	if  (val < ENA_MIN_RING_SIZE || val > adapter->max_rx_ring_size) {
+	if (val < ENA_MIN_RING_SIZE || val > adapter->max_rx_ring_size) {
 		ena_log(adapter->pdev, ERR,
 		    "Requested new Rx queue size (%u) is out of range: [%u, %u]\n",
 		    val, ENA_MIN_RING_SIZE, adapter->max_rx_ring_size);
@@ -591,8 +572,8 @@ ena_sysctl_rx_queue_size(SYSCTL_HANDLER_ARGS)
 
 	if (val != adapter->requested_rx_ring_size) {
 		ena_log(adapter->pdev, INFO,
-		    "Requested new Rx queue size: %u. Old size: %u\n",
-		    val, adapter->requested_rx_ring_size);
+		    "Requested new Rx queue size: %u. Old size: %u\n", val,
+		    adapter->requested_rx_ring_size);
 
 		error = ena_update_queue_size(adapter,
 		    adapter->requested_tx_ring_size, val);
@@ -648,19 +629,21 @@ ena_sysctl_io_queues_nb(SYSCTL_HANDLER_ARGS)
 	 */
 	if (tmp > (adapter->msix_vecs - ENA_ADMIN_MSIX_VEC)) {
 		ena_log(adapter->pdev, ERR,
-		    "Requested number of IO queues is higher than maximum "
-		    "allowed (%u)\n", adapter->msix_vecs - ENA_ADMIN_MSIX_VEC);
+		    "Requested number of IO queues is higher than maximum allowed (%u)\n",
+		    adapter->msix_vecs - ENA_ADMIN_MSIX_VEC);
 		error = EINVAL;
 		goto unlock;
 	}
 	if (tmp == adapter->num_io_queues) {
 		ena_log(adapter->pdev, ERR,
 		    "Requested number of IO queues is equal to current value "
-		    "(%u)\n", adapter->num_io_queues);
+		    "(%u)\n",
+		    adapter->num_io_queues);
 	} else {
 		ena_log(adapter->pdev, INFO,
 		    "Requested new number of IO queues: %u, current value: "
-		    "%u\n", tmp, adapter->num_io_queues);
+		    "%u\n",
+		    tmp, adapter->num_io_queues);
 
 		old_num_queues = adapter->num_io_queues;
 		error = ena_update_io_queue_nb(adapter, tmp);
@@ -711,7 +694,8 @@ ena_sysctl_eni_metrics_interval(SYSCTL_HANDLER_ARGS)
 		bzero(&adapter->eni_metrics, sizeof(adapter->eni_metrics));
 	} else {
 		ena_log(adapter->pdev, INFO,
-		    "ENI metrics update interval is set to: %"PRIu16" seconds\n",
+		    "ENI metrics update interval is set to: %" PRIu16
+		    " seconds\n",
 		    interval);
 	}
 

--- a/kernel/fbsd/ena/ena_sysctl.h
+++ b/kernel/fbsd/ena/ena_sysctl.h
@@ -39,8 +39,8 @@
 
 #include "ena.h"
 
-void	ena_sysctl_add_nodes(struct ena_adapter *adapter);
-void	ena_sysctl_update_queue_node_nb(struct ena_adapter *adapter, int old,
+void ena_sysctl_add_nodes(struct ena_adapter *adapter);
+void ena_sysctl_update_queue_node_nb(struct ena_adapter *adapter, int old,
     int new);
 
 extern int ena_enable_9k_mbufs;


### PR DESCRIPTION
Some of the changes in this release:
* Style fixes
* Fix ENI stats probing
* Add trace for the last Tx cleanup call
* Prevent LLQ initialization if member isn't exposed
* Improve logging
* Build system improvements

Signed-off-by: Michal Krawczyk <mk@semihalf.com>
