### PR TITLE
dpdk/ena: Adjust vfio script to the apt behavior

### DIFF
--- a/userspace/dpdk/enav2-vfio-patch/get-vfio-with-wc.sh
+++ b/userspace/dpdk/enav2-vfio-patch/get-vfio-with-wc.sh
@@ -74,7 +74,7 @@ function download_kernel_src_apt {
 	green Done
 
 	bold "\nDownload Linux kernel source with vfio"
-	if ! apt-get -q -y source linux-image-$(uname -r); then
+	if ! apt-get -q -y source linux-image-unsigned-$(uname -r); then
 		err "Cannot download Linux kernel source.\nPlease uncomment appropriate 'deb-src' line in the /etc/apt/sources.list file"
 		exit 1
 	fi


### PR DESCRIPTION
The 'apt' application is no longer able to download the kernel sources using the old way. The repository provides the package with meta-data instead of the sources. To download the sources directly, the 'unsigned-' string needs to be added to the 'linux-image-' package name.

*Issue #, if available:* #243 