### PR TITLE
linux/ena: Remove weight parameter from napi context

### DIFF
--- a/kernel/linux/ena/ena_netdev.c
+++ b/kernel/linux/ena/ena_netdev.c
@@ -2036,10 +2036,16 @@ static void ena_init_napi_in_range(struct ena_adapter *adapter,
 			napi_handler = ena_xdp_io_poll;
 #endif /* ENA_XDP_SUPPORT */
 
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 1, 0)
+		netif_napi_add(adapter->netdev,
+			       &napi->napi,
+			       napi_handler);
+#else
 		netif_napi_add(adapter->netdev,
 			       &napi->napi,
 			       napi_handler,
 			       NAPI_POLL_WEIGHT);
+#endif
 
 #ifdef ENA_BUSY_POLL_SUPPORT
 		napi_hash_add(&adapter->ena_napi[i].napi);


### PR DESCRIPTION
Linux 6.1 completed the removal of the weight parameter from the creation of a napi context [1].

This commit adds support for this change present in kernels >= 6.1 while retaining the previous behavior for older kernels.

[1] https://lore.kernel.org/all/20220927132753.750069-1-kuba@kernel.org

Signed-off-by: Joshua Hoffer <jhoffer@sansorgan.es>

I've tested this change on Linux 6.0.12 on a t4g.medium instance and Linux 6.1.0 on a t3a.large instance (both running NixOS 22.11).

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.