### PR TITLE
linux/ena: Use napi_alloc_skb instead of __napi_alloc_skb

### DIFF
--- a/kernel/linux/ena/ena_xdp.c
+++ b/kernel/linux/ena/ena_xdp.c
@@ -813,7 +813,7 @@ static int ena_xdp_clean_rx_irq_zc(struct ena_ring *rx_ring,
 		xdp = rx_info->xdp;
 		xdp->data += ena_rx_ctx.pkt_offset;
 		xdp->data_end = xdp->data + ena_rx_ctx.ena_bufs[0].len;
-		xsk_buff_dma_sync_for_cpu(xdp, rx_ring->xsk_pool);
+		xsk_buff_dma_sync_for_cpu(xdp);
 
 		/* XDP multi-buffer packets not supported */
 		if (unlikely(ena_rx_ctx.descs > 1)) {

--- a/kernel/linux/ena/ena_xdp.c
+++ b/kernel/linux/ena/ena_xdp.c
@@ -746,9 +746,7 @@ static struct sk_buff *ena_xdp_rx_skb_zc(struct ena_ring *rx_ring, struct xdp_bu
 	data_addr = xdp->data;
 
 	/* allocate a skb to store the frags */
-	skb = __napi_alloc_skb(rx_ring->napi,
-			       headroom + data_len,
-			       GFP_ATOMIC | __GFP_NOWARN);
+	skb = napi_alloc_skb(rx_ring->napi, headroom + data_len);
 	if (unlikely(!skb)) {
 		ena_increase_stat(&rx_ring->rx_stats.skb_alloc_fail, 1,
 				  &rx_ring->syncp);


### PR DESCRIPTION

*Issue #, if available:*

Fixes https://github.com/amzn/amzn-drivers/issues/313

*Description of changes:*

See https://github.com/torvalds/linux/commit/6e9b01909a811555ff3326cf80a5847169c57806

for context.




By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
