### PR TITLE
dpdk: update WC patch for vfio for ubuntu lts

### DIFF
--- a/userspace/dpdk/enav2-vfio-patch/patches/linux-6.8-vfio-wc.patch
+++ b/userspace/dpdk/enav2-vfio-patch/patches/linux-6.8-vfio-wc.patch
@@ -2,7 +2,7 @@ diff --git a/drivers/vfio/pci/vfio_pci_core.c b/drivers/vfio/pci/vfio_pci_core.c
 index 1cbc990d42e0..0af050fa7ac2 100644
 --- a/drivers/vfio/pci/vfio_pci_core.c
 +++ b/drivers/vfio/pci/vfio_pci_core.c
-@@ -1745,7 +1745,12 @@ int vfio_pci_core_mmap(struct vfio_device *core_vdev, struct vm_area_struct *vma
++@@ -1765,7 +1765,12 @@ int vfio_pci_core_mmap(struct vfio_device *core_vdev, struct vm_area_struct *vma^
                 if (ret)
                         return ret;
 
@@ -16,7 +16,7 @@ index 1cbc990d42e0..0af050fa7ac2 100644
                 if (!vdev->barmap[index]) {
                         pci_release_selected_regions(pdev, 1 << index);
                         return -ENOMEM;
-@@ -1753,7 +1758,10 @@ int vfio_pci_core_mmap(struct vfio_device *core_vdev, struct vm_area_struct *vma
++@@ -1778,7 +1783,10 @@ int vfio_pci_core_mmap(struct vfio_device *core_vdev, struct vm_area_struct *vma
         }
 
         vma->vm_private_data = vdev;


### PR DESCRIPTION
VFIO-PCI driver does not support write combine.
To activate this feature, the patch that checks
if PCI BAR is prefetchable must be added.

ubuntu 24.04 LTS keeps getting kernel updates which caused problem when applying ENA vfio patch.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
