### PR TITLE
Move return value check of ena_com_get_feature before accessing response

### DIFF
--- a/kernel/linux/common/ena_com/ena_com.c
+++ b/kernel/linux/common/ena_com/ena_com.c
@@ -2243,13 +2243,13 @@ int ena_com_get_dev_attr_feat(struct ena_com_dev *ena_dev,
 	} else {
 		rc = ena_com_get_feature(ena_dev, &get_resp,
 					 ENA_ADMIN_MAX_QUEUES_NUM, 0);
+		if (rc)
+			return rc;
+
 		memcpy(&get_feat_ctx->max_queues, &get_resp.u.max_queue,
 		       sizeof(get_resp.u.max_queue));
 		ena_dev->tx_max_header_size =
 			get_resp.u.max_queue.max_header_size;
-
-		if (rc)
-			return rc;
 	}
 
 	rc = ena_com_get_feature(ena_dev, &get_resp,


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/amzn/amzn-drivers/issues/346

*Description of changes:*
Moved return value check to be before accessing the structure members of response.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
