### PR TITLE
Include a patch for write-combining for kernel 6.12

### DIFF
--- a/userspace/dpdk/enav2-vfio-patch/patches/linux-6.12-vfio-wc.patch
+++ b/userspace/dpdk/enav2-vfio-patch/patches/linux-6.12-vfio-wc.patch
@@ -1,0 +1,30 @@
+diff --git a/drivers/vfio/pci/vfio_pci_core.c b/drivers/vfio/pci/vfio_pci_core.c
+index 1cbc990d4..5e8c3d07c 100644
+--- a/drivers/vfio/pci/vfio_pci_core.c
++++ b/drivers/vfio/pci/vfio_pci_core.c
+@@ -1762,7 +1762,12 @@ int vfio_pci_core_mmap(struct vfio_device *core_vdev, struct vm_area_struct *vma
+         if (ret)
+             return ret;
+ 
+-        vdev->barmap[index] = pci_iomap(pdev, index, 0);
++        if (pci_resource_flags(pdev, index) & IORESOURCE_PREFETCH)
++            vdev->barmap[index] = ioremap_wc(
++                pci_resource_start(pdev, index),
++                pci_resource_len(pdev, index));
++        else
++            vdev->barmap[index] = pci_iomap(pdev, index, 0);
+         if (!vdev->barmap[index]) {
+             pci_release_selected_regions(pdev, 1 << index);
+             return -ENOMEM;
+@@ -1770,7 +1775,10 @@ int vfio_pci_core_mmap(struct vfio_device *core_vdev, struct vm_area_struct *vma
+     }
+ 
+     vma->vm_private_data = vdev;
+-    vma->vm_page_prot = pgprot_noncached(vma->vm_page_prot);
++    if (pci_resource_flags(pdev, index) & IORESOURCE_PREFETCH)
++        vma->vm_page_prot = pgprot_writecombine(vma->vm_page_prot);
++    else
++        vma->vm_page_prot = pgprot_noncached(vma->vm_page_prot);
+     vma->vm_page_prot = pgprot_decrypted(vma->vm_page_prot);
+ 
+     /*


### PR DESCRIPTION
This commit includes a patch for the kernel version 6.12 which currently ships with AMI Al2023. Tested on c8gn.24xlarge instances with ARM AL2023 AMI.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
