### PR TITLE
linux/efa: Add support for building with Clang/LLVM

### DIFF
--- a/kernel/linux/efa/config/Makefile
+++ b/kernel/linux/efa/config/Makefile
@@ -2,7 +2,7 @@
 # Copyright 2020 Amazon.com, Inc. or its affiliates. All rights reserved.
 
 DRIVER_NAME = conftest
-KBUILD_CPPFLAGS += -Werror -Wno-unused-variable -Wno-uninitialized -Wno-maybe-uninitialized
+ccflags-y += -Werror -Wno-unused-variable -Wno-uninitialized -Wno-maybe-uninitialized
 
 obj-m += $(DRIVER_NAME).o
 $(DRIVER_NAME)-objs := main.o

--- a/kernel/linux/efa/config/Makefile
+++ b/kernel/linux/efa/config/Makefile
@@ -2,12 +2,31 @@
 # Copyright 2020 Amazon.com, Inc. or its affiliates. All rights reserved.
 
 DRIVER_NAME = conftest
-ccflags-y += -Werror -Wno-unused-variable -Wno-uninitialized -Wno-maybe-uninitialized
+ccflags-y += -Werror -Wno-unused-variable -Wno-uninitialized
+ifdef CONFIG_CC_IS_CLANG
+ccflags-y += -Wno-unused-value
+else
+ccflags-y += -Wno-maybe-uninitialized
+endif
 
 obj-m += $(DRIVER_NAME).o
 $(DRIVER_NAME)-objs := main.o
 
 KERNEL_DIR ?= /lib/modules/$(shell uname -r)/build
 
+MAKE_OPTS :=
+# When LLVM is set, don't pass CC/LD to let the kernel build use LLVM tools
+ifeq ($(LLVM),)
+  ifneq ($(origin CC),default)
+    MAKE_OPTS += CC=$(CC)
+  endif
+  ifneq ($(origin LD),default)
+    MAKE_OPTS += LD=$(LD)
+  endif
+endif
+ifneq ($(LLVM),)
+MAKE_OPTS += LLVM=$(LLVM)
+endif
+
 modules:
-	$(MAKE) -C $(KERNEL_DIR) M=$(CURDIR) modules
+	$(MAKE) -C $(KERNEL_DIR) M=$(CURDIR) $(MAKE_OPTS) modules


### PR DESCRIPTION
*Issue #, if available:* #365

*Description of changes:*
- Use ccflags-y instead of KBUILD_CPPFLAGS in conftest Makefile
- Add Clang/LLVM toolchain support to conftest
  - Pass through make options
  - conditional compiler flags



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
