### PR TITLE
userspace/dpdk/enav2-vfio: fix AL2023 support (dnf + Linux 6.12 patch)

### DIFF
--- a/userspace/dpdk/enav2-vfio-patch/get-vfio-with-wc.sh
+++ b/userspace/dpdk/enav2-vfio-patch/get-vfio-with-wc.sh
@@ -48,17 +48,17 @@ function get_kernel_version {
 	printf "%d%02d%04d" "${ver_major}" "${ver_minor}" "${ver_subminor}"
 }
 
-function download_kernel_src_yum {
-	echo "Use yum to get the kernel sources"
+function download_kernel_src_dnf {
+	echo "Use dnf to get the kernel sources"
 
 	bold "\nInstall required applications and kernel headers"
-	yum install -y gcc "kernel-$(uname -r)" "kernel-devel-$(uname -r)" \
-	    git make elfutils-libelf-devel patch yum-utils
+	dnf install -y gcc kernel6.12-devel kernel6.12-headers \
+		git make elfutils-libelf-devel patch dnf-plugins-core
 	green Done
 
 	# Download kernel source
 	bold "\nDownload kernel source with vfio"
-	yumdownloader --source "kernel-devel-$(uname -r)"
+	dnf download --source kernel6.12-devel
 	rpm2cpio kernel*.src.rpm | cpio -idmv
 	green Done
 
@@ -96,7 +96,7 @@ function download_kernel_src {
 	if apt-get -v >/dev/null 2>/dev/null; then
 		download_kernel_src_apt
 	else
-		download_kernel_src_yum
+		download_kernel_src_dnf
 	fi
 	cd linux-*
 }

--- a/userspace/dpdk/enav2-vfio-patch/get-vfio-with-wc.sh
+++ b/userspace/dpdk/enav2-vfio-patch/get-vfio-with-wc.sh
@@ -102,12 +102,15 @@ function download_kernel_src {
 }
 
 function apply_wc_patch {
-        if [ "${KERNEL_VERSION}" -ge 6080000 ]; then
-                echo "Using patch for kernel version 6.8"
-                local wc_patch="${BASE_PATH}/patches/linux-6.8-vfio-wc.patch"
-        elif [ "${KERNEL_VERSION}" -ge 5150000 ]; then
-                echo "Using patch for kernel version 5.15"
-                local wc_patch="${BASE_PATH}/patches/linux-5.15-vfio-wc.patch"
+	if [ "${KERNEL_VERSION}" -ge 6120000 ]; then
+			echo "Using patch for kernel version 6.12"
+			local wc_patch="${BASE_PATH}/patches/linux-6.12-vfio-wc.patch"
+	elif [ "${KERNEL_VERSION}" -ge 6080000 ]; then
+			echo "Using patch for kernel version 6.8"
+			local wc_patch="${BASE_PATH}/patches/linux-6.8-vfio-wc.patch"
+	elif [ "${KERNEL_VERSION}" -ge 5150000 ]; then
+			echo "Using patch for kernel version 5.15"
+			local wc_patch="${BASE_PATH}/patches/linux-5.15-vfio-wc.patch"
  	elif [ "${KERNEL_VERSION}" -ge 5080000 ]; then
 		echo "Using patch for kernel version 5.8"
 		local wc_patch="${BASE_PATH}/patches/linux-5.8-vfio-wc.patch"

--- a/userspace/dpdk/enav2-vfio-patch/patches/linux-6.12-vfio-wc.patch
+++ b/userspace/dpdk/enav2-vfio-patch/patches/linux-6.12-vfio-wc.patch
@@ -1,0 +1,30 @@
+diff --git a/drivers/vfio/pci/vfio_pci_core.c b/drivers/vfio/pci/vfio_pci_core.c
+index 1ab58da9f..1370b466a 100644
+--- a/drivers/vfio/pci/vfio_pci_core.c
++++ b/drivers/vfio/pci/vfio_pci_core.c
+@@ -1769,7 +1769,12 @@ int vfio_pci_core_mmap(struct vfio_device *core_vdev, struct vm_area_struct *vma
+ 		if (ret)
+ 			return ret;
+ 
+-		vdev->barmap[index] = pci_iomap(pdev, index, 0);
++		if (pci_resource_flags(pdev, index) & IORESOURCE_PREFETCH)
++			vdev->barmap[index] = ioremap_wc(
++				pci_resource_start(pdev, index),
++				pci_resource_len(pdev, index));
++		else
++			vdev->barmap[index] = pci_iomap(pdev, index, 0);
+ 		if (!vdev->barmap[index]) {
+ 			pci_release_selected_regions(pdev, 1 << index);
+ 			return -ENOMEM;
+@@ -1777,7 +1782,10 @@ int vfio_pci_core_mmap(struct vfio_device *core_vdev, struct vm_area_struct *vma
+ 	}
+ 
+ 	vma->vm_private_data = vdev;
+-	vma->vm_page_prot = pgprot_noncached(vma->vm_page_prot);
++	if (pci_resource_flags(pdev, index) & IORESOURCE_PREFETCH)
++		vma->vm_page_prot = pgprot_writecombine(vma->vm_page_prot);
++	else
++		vma->vm_page_prot = pgprot_noncached(vma->vm_page_prot);
+ 	vma->vm_page_prot = pgprot_decrypted(vma->vm_page_prot);
+ 
+ 	/*


### PR DESCRIPTION
## Why
Amazon Linux 2023 moved from yum to dnf and uses newer kernels (including 6.12).
The previous flow in get-vfio-with-wc.sh relied on yum/yumdownloader and did not include a Linux 6.12 patch path, so the old workflow no longer works on AL2023.

## What this PR changes
- switch kernel source install/download flow from yum + yumdownloader to dnf + dnf download
- add Linux 6.12 selection logic in apply_wc_patch
- add linux-6.12-vfio-wc.patch

## Impact
This restores the enav2-vfio patch workflow on AL2023 and supports the newer kernel line by selecting the correct patch.