### PR TITLE
linux/ena: report SOF_TIMESTAMPING_RAW_HARDWARE for RX timestamping capabilities

### DIFF
--- a/kernel/linux/ena/ena_ethtool.c
+++ b/kernel/linux/ena/ena_ethtool.c
@@ -586,7 +586,8 @@ static int ena_get_ts_info(struct net_device *netdev,
 
 		if (adapter->hw_ts_state.hw_rx_supported !=
 		    ENA_ADMIN_HW_TIMESTAMP_RX_SUPPORT_NONE) {
-			info->so_timestamping |= SOF_TIMESTAMPING_RX_HARDWARE;
+			info->so_timestamping |= SOF_TIMESTAMPING_RX_HARDWARE |
+						 SOF_TIMESTAMPING_RAW_HARDWARE;
 
 			info->rx_filters = BIT(HWTSTAMP_FILTER_NONE) |
 					   BIT(HWTSTAMP_FILTER_ALL);


### PR DESCRIPTION
The driver reports SOF_TIMESTAMPING_TX_HARDWARE together with SOF_TIMESTAMPING_RAW_HARDWARE for TX timestamping, but for RX it only advertises SOF_TIMESTAMPING_RX_HARDWARE.

According to the kernel timestamping documentation [1], SOF_TIMESTAMPING_*_HARDWARE flags control timestamp generation, while SOF_TIMESTAMPING_RAW_HARDWARE controls reporting of hardware timestamps to userspace. In practice, both are required to fully describe hardware timestamping capabilities: one to indicate that timestamps are generated in hardware, and the other to indicate that they are exposed to user space.

By omitting SOF_TIMESTAMPING_RAW_HARDWARE from RX capabilities, the reported feature set is inconsistent with TX and may cause userspace to incorrectly assume that RX hardware timestamps are not available.

This is not purely theoretical: some userspace components (e.g. libpcap [2]) check only for SOF_TIMESTAMPING_RAW_HARDWARE when deciding whether to enable adapter-level timestamping. As a result, RX hardware timestamping may be silently unused even when supported by the device.

Report SOF_TIMESTAMPING_RAW_HARDWARE for RX as well to accurately reflect the device capabilities and align RX reporting with TX.

[1] https://docs.kernel.org/networking/timestamping.html
[2] https://github.com/the-tcpdump-group/libpcap/blob/master/pcap-linux.c#L5097