### PR TITLE
linux/ena: Add AF_XDP zero-copy multi-buffer support

### DIFF
--- a/kernel/linux/ena/config/test_defs.sh
+++ b/kernel/linux/ena/config/test_defs.sh
@@ -178,6 +178,21 @@ try_compile_async "#include <net/xdp.h>
                   ""                                                      \
                   "5.18 <= LINUX_VERSION_CODE"
 
+try_compile_async "#include <net/xdp_sock_drv.h>
+                   #include <linux/netdevice.h>"                          \
+                  "{
+                    struct xdp_buff xdp = {};
+                    struct xdp_desc desc = {};
+                    struct net_device dev = {};
+                    xsk_buff_set_size(&xdp, 0);
+                    xsk_buff_add_frag(&xdp);
+                    (void)xsk_is_eop_desc(&desc);
+                    dev.xdp_zc_max_segs = 1;
+                  }"                                                      \
+                  "ENA_HAVE_XSK_MULTI_BUFF"                               \
+                  ""                                                      \
+                  "6.6.0 <= LINUX_VERSION_CODE"
+
 try_compile_async "#include <linux/netdevice.h>"         \
                   "{
                     netif_enable_cpu_rmap(NULL, 0);

--- a/kernel/linux/ena/ena_netdev.c
+++ b/kernel/linux/ena/ena_netdev.c
@@ -5718,6 +5718,18 @@ static int ena_probe(struct pci_dev *pdev, const struct pci_device_id *ent)
 
 #ifdef ENA_HAVE_NETDEV_XDP_FEATURES
 	netdev->xdp_features = ENA_XDP_FEATURES;
+#ifdef ENA_XSK_MB_SUPPORT
+	/* Advertise only what we can actually place: the TX gather loop is
+	 * bounded by the TX SGL, and the RX assembler is bounded by both the
+	 * RX SGL and MAX_SKB_FRAGS (one head + MAX_SKB_FRAGS frags). Advertising
+	 * more would let the stack hand us frames the datapath has to truncate
+	 * (TX) or drop (RX).
+	 */
+	netdev->xdp_zc_max_segs = min_t(u32,
+					min_t(u16, adapter->max_tx_sgl_size,
+					      adapter->max_rx_sgl_size),
+					MAX_SKB_FRAGS + 1);
+#endif /* ENA_XSK_MB_SUPPORT */
 
 #endif
 	memcpy(adapter->netdev->perm_addr, adapter->mac_addr, netdev->addr_len);

--- a/kernel/linux/ena/ena_netdev.h
+++ b/kernel/linux/ena/ena_netdev.h
@@ -193,6 +193,10 @@ struct ena_tx_buffer {
 
 	/* used for ordering TX completions when needed (e.g. AF_XDP) */
 	u8 acked;
+#ifdef ENA_XSK_MB_SUPPORT
+	/* Number of XSK TX descriptors consumed for this packet (multi-buffer) */
+	u16 xsk_tx_nr_descs;
+#endif /* ENA_XSK_MB_SUPPORT */
 #ifdef ENA_HAVE_XSK_TX_METADATA
 
 	/* Contains pointer to xsk completion metadata, filled at completion */

--- a/kernel/linux/ena/ena_xdp.c
+++ b/kernel/linux/ena/ena_xdp.c
@@ -718,7 +718,12 @@ static bool ena_xdp_clean_tx_zc(struct ena_ring *tx_ring, u32 budget)
 		is_zc_pkt = !(skb || xdpf);
 
 		cleaned_pkts++;
+#ifdef ENA_XSK_MB_SUPPORT
+		if (is_zc_pkt)
+			zc_pkts += tx_info->xsk_tx_nr_descs;
+#else
 		zc_pkts += is_zc_pkt;
+#endif /* ENA_XSK_MB_SUPPORT */
 		total_done += tx_info->tx_descs;
 
 		if (xdpf) {
@@ -756,6 +761,177 @@ static bool ena_xdp_clean_tx_zc(struct ena_ring *tx_ring, u32 budget)
 	return acked_pkts < budget;
 }
 
+#ifdef ENA_XSK_MB_SUPPORT
+/* Multi-buffer (kernel >= 6.6) zero-copy Tx fast path.
+ *
+ * xsk_tx_peek_release_desc_batch() consumes whole frames atomically: it never
+ * exposes a partial multi-buffer frame and reserves a completion-queue slot for
+ * every descriptor it returns. That gives us three properties the legacy
+ * per-descriptor peek loop cannot:
+ *   - a frame is never truncated on the wire,
+ *   - the descriptor stream never desyncs (we never consume a non-EOP prefix),
+ *   - per-descriptor completions stay correctly ordered against in-flight
+ *     frames (completing dropped descriptors out-of-band via xsk_tx_completed()
+ *     would race the ordered cq and free in-flight UMEM addresses early).
+ *
+ * The batch is non-revocable (the descriptors are consumed and their cq slots
+ * reserved before we see them), so the whole returned batch must be submittable
+ * to the SQ. A frame uses at most (num_bufs + 2) SQ entries - the same bound the
+ * stack path reserves per packet - which is at most 3 entries per descriptor in
+ * the worst case of all single-descriptor frames. We therefore request at most
+ * sq_free / 3 descriptors so the result is guaranteed to fit.
+ *
+ * The function also releases the Tx ring internally, so the caller must not
+ * call xsk_tx_release(). It returns the number of frames submitted, and may
+ * return 0 when the batch peek is not usable (e.g. several sockets share the
+ * pool); the caller then falls back to the per-descriptor path.
+ */
+static int ena_xdp_xmit_zc_batch(struct ena_ring *tx_ring,
+				 struct xsk_buff_pool *xsk_pool, int budget,
+				 u64 *total_pkts, u64 *total_bytes)
+{
+	struct xdp_desc *descs = xsk_pool->tx_descs;
+	int work_done = 0;
+	int rc = 0;
+#ifdef ENA_HAVE_XSK_TX_METADATA
+	bool is_tx_metadata_enabled = xp_tx_metadata_enabled(xsk_pool);
+#endif /* ENA_HAVE_XSK_TX_METADATA */
+
+	while (likely(work_done < budget)) {
+		u32 sq_free = ena_com_free_q_entries(tx_ring->ena_com_io_sq);
+		u32 nb_descs, idx;
+
+		nb_descs = min_t(u32, budget - work_done, sq_free / 3);
+		if (unlikely(!nb_descs))
+			break;
+
+		nb_descs = xsk_tx_peek_release_desc_batch(xsk_pool, nb_descs);
+		if (!nb_descs)
+			break;
+
+		for (idx = 0; idx < nb_descs;) {
+			struct ena_com_tx_ctx ena_tx_ctx = {};
+			struct xdp_desc *first = &descs[idx];
+			struct ena_tx_buffer *tx_info;
+			struct ena_com_buf *ena_buf;
+			u32 frame_descs = 1;
+			int push_len = 0;
+			u16 next_to_use, req_id;
+			int size;
+
+			next_to_use = tx_ring->next_to_use;
+			req_id = tx_ring->free_ids[next_to_use];
+			tx_info = &tx_ring->tx_buffer_info[req_id];
+
+			size = first->len;
+
+			if (likely(tx_ring->tx_mem_queue_type ==
+				   ENA_ADMIN_PLACEMENT_POLICY_DEV)) {
+				/* Designate part of the packet for LLQ */
+				push_len = min_t(u32, size,
+						 tx_ring->tx_max_header_size);
+				ena_tx_ctx.push_header =
+					xsk_buff_raw_get_data(xsk_pool,
+							      first->addr);
+				ena_tx_ctx.header_len = push_len;
+				size -= push_len;
+			}
+
+			ena_buf = tx_info->bufs;
+			tx_info->num_of_bufs = 0;
+
+			if (size) {
+				dma_addr_t dma =
+					xsk_buff_raw_get_dma(xsk_pool,
+							     first->addr);
+
+				ena_buf->paddr = dma + push_len;
+				ena_buf->len = size;
+				ena_buf++;
+				tx_info->num_of_bufs = 1;
+			}
+
+			/* Gather this frame's continuation descriptors. The
+			 * batch guarantees a complete frame, so the EOP is
+			 * within [idx, nb_descs).
+			 */
+			while (!xsk_is_eop_desc(&descs[idx + frame_descs - 1]) &&
+			       idx + frame_descs < nb_descs) {
+				struct xdp_desc *frag = &descs[idx + frame_descs];
+
+				/* Bounded by the SGL. With xdp_zc_max_segs
+				 * clamped to the SGL this only fires for a
+				 * non-conformant frame larger than advertised:
+				 * drop the excess fragment bytes but keep
+				 * counting descriptors so the completion
+				 * accounting and stream framing stay correct.
+				 */
+				if (likely(tx_info->num_of_bufs <
+					   tx_ring->sgl_size)) {
+					ena_buf->paddr =
+						xsk_buff_raw_get_dma(xsk_pool,
+								     frag->addr);
+					ena_buf->len = frag->len;
+					ena_buf++;
+					tx_info->num_of_bufs++;
+					size += frag->len;
+				}
+
+				frame_descs++;
+			}
+
+			/* The batch peek must only hand back complete frames. If
+			 * the EOP is missing the kernel violated that contract;
+			 * warn so it is caught in testing instead of silently
+			 * desyncing the stream.
+			 */
+			if (unlikely(!xsk_is_eop_desc(&descs[idx + frame_descs - 1])))
+				netdev_err_once(tx_ring->netdev,
+						"xsk tx: batch returned a partial frame\n");
+
+			tx_info->xsk_tx_nr_descs = frame_descs;
+			ena_tx_ctx.ena_bufs = tx_info->bufs;
+			ena_tx_ctx.num_bufs = tx_info->num_of_bufs;
+
+#ifdef ENA_HAVE_XSK_TX_METADATA
+			if (unlikely(is_tx_metadata_enabled)) {
+				struct xsk_tx_metadata *meta =
+					xsk_buff_get_metadata(xsk_pool,
+							      first->addr);
+
+				/* Save a pointer to completion metadata to fill
+				 * it later upon completion
+				 */
+				xsk_tx_metadata_to_compl(meta,
+							 &tx_info->xsk_meta_compl);
+			}
+#endif /* ENA_HAVE_XSK_TX_METADATA */
+
+			ena_tx_ctx.req_id = req_id;
+
+			rc = ena_xmit_common(tx_ring->adapter, tx_ring, tx_info,
+					     &ena_tx_ctx, next_to_use,
+					     size + push_len);
+			if (unlikely(rc))
+				break;
+
+			(*total_pkts)++;
+			*total_bytes += size + push_len;
+			work_done++;
+			idx += frame_descs;
+		}
+
+		/* SQ sizing guarantees space, so any error here is fatal and
+		 * ena_xmit_common() already scheduled a device reset.
+		 */
+		if (unlikely(rc))
+			break;
+	}
+
+	return work_done;
+}
+#endif /* ENA_XSK_MB_SUPPORT */
+
 static bool ena_xdp_xmit_irq_zc(struct ena_ring *tx_ring,
 				struct napi_struct *napi,
 				int budget)
@@ -764,6 +940,7 @@ static bool ena_xdp_xmit_irq_zc(struct ena_ring *tx_ring,
 	int size, rc, push_len = 0, work_done = 0;
 	struct ena_tx_buffer *tx_info;
 	struct ena_com_buf *ena_buf;
+	bool tx_ring_released = false;
 	u64 total_pkts, total_bytes;
 #ifdef ENA_HAVE_XSK_TX_METADATA
 	bool is_tx_metadata_enabled;
@@ -784,79 +961,129 @@ static bool ena_xdp_xmit_irq_zc(struct ena_ring *tx_ring,
 	/* Avoid TX time out as we are sharing the queues */
 	txq_trans_cond_update(txq);
 
-	while (likely(work_done < budget)) {
-		struct ena_com_tx_ctx ena_tx_ctx = {};
+#ifdef ENA_XSK_MB_SUPPORT
+	/* Fast path: frame-atomic batch peek (releases the Tx ring itself). */
+	work_done = ena_xdp_xmit_zc_batch(tx_ring, xsk_pool, budget,
+					  &total_pkts, &total_bytes);
+	tx_ring_released = work_done > 0;
 
-		/* To align with the network stack path (.ndo_start_xmit) we
-		 * leave the same amount of empty space in the SQ.
-		 */
-		if (unlikely(!ena_com_sq_have_enough_space(
-			    tx_ring->ena_com_io_sq, tx_ring->sgl_size + 2)))
-			break;
+	/* Fall back to the per-descriptor path when the batch peek did nothing.
+	 * That covers both an empty ring (cheap no-op below) and the
+	 * multi-socket-shared-pool case the batch peek does not handle, so Tx
+	 * does not stall there.
+	 */
+	if (!work_done)
+#endif /* ENA_XSK_MB_SUPPORT */
+	{
+		while (likely(work_done < budget)) {
+			struct ena_com_tx_ctx ena_tx_ctx = {};
 
-		if (!xsk_tx_peek_desc(xsk_pool, &desc))
-			break;
-
-		next_to_use = tx_ring->next_to_use;
-		req_id = tx_ring->free_ids[next_to_use];
-		tx_info = &tx_ring->tx_buffer_info[req_id];
-
-		size = desc.len;
-
-		if (likely(tx_ring->tx_mem_queue_type == ENA_ADMIN_PLACEMENT_POLICY_DEV)) {
-			/* Designate part of the packet for LLQ */
-			push_len = min_t(u32, size, tx_ring->tx_max_header_size);
-			ena_tx_ctx.push_header = xsk_buff_raw_get_data(xsk_pool, desc.addr);
-			ena_tx_ctx.header_len = push_len;
-
-			size -= push_len;
-		}
-
-		if (size) {
-			/* Pass the rest of the descriptor as a DMA address. Assuming
-			 * single page descriptor.
+			/* To align with the network stack path (.ndo_start_xmit)
+			 * we leave the same amount of empty space in the SQ.
 			 */
-			dma  = xsk_buff_raw_get_dma(xsk_pool, desc.addr);
-			ena_buf = tx_info->bufs;
-			ena_buf->paddr = dma + push_len;
-			ena_buf->len = size;
+			if (unlikely(!ena_com_sq_have_enough_space(
+				    tx_ring->ena_com_io_sq,
+				    tx_ring->sgl_size + 2)))
+				break;
 
-			ena_tx_ctx.ena_bufs = ena_buf;
-			ena_tx_ctx.num_bufs = 1;
-		}
+			if (!xsk_tx_peek_desc(xsk_pool, &desc))
+				break;
+
+			next_to_use = tx_ring->next_to_use;
+			req_id = tx_ring->free_ids[next_to_use];
+			tx_info = &tx_ring->tx_buffer_info[req_id];
+
+			size = desc.len;
+
+			if (likely(tx_ring->tx_mem_queue_type == ENA_ADMIN_PLACEMENT_POLICY_DEV)) {
+				/* Designate part of the packet for LLQ */
+				push_len = min_t(u32, size, tx_ring->tx_max_header_size);
+				ena_tx_ctx.push_header = xsk_buff_raw_get_data(xsk_pool, desc.addr);
+				ena_tx_ctx.header_len = push_len;
+
+				size -= push_len;
+			}
+
+			ena_buf = tx_info->bufs;
+			tx_info->num_of_bufs = 0;
+
+			if (size) {
+				/* Pass the rest of the descriptor as a DMA address */
+				dma  = xsk_buff_raw_get_dma(xsk_pool, desc.addr);
+				ena_buf->paddr = dma + push_len;
+				ena_buf->len = size;
+				ena_buf++;
+				tx_info->num_of_bufs = 1;
+			}
+
+#ifdef ENA_XSK_MB_SUPPORT
+			/* Gather continuation descriptors for multi-buffer SG.
+			 * Only reached on the fallback (multi-socket) path; the
+			 * batch fast path keeps framing without this. A break
+			 * here before EOP (SGL bound or Tx-ring backpressure)
+			 * truncates the frame and can desync the stream - the
+			 * residual the batch path was added to avoid - but it is
+			 * confined to the uncommon shared-pool case.
+			 */
+			tx_info->xsk_tx_nr_descs = 1;
+			while (!xsk_is_eop_desc(&desc)) {
+				struct xdp_desc frag_desc;
+
+				if (!xsk_tx_peek_desc(xsk_pool, &frag_desc))
+					break;
+				if (tx_info->num_of_bufs >= tx_ring->sgl_size)
+					break;
+
+				ena_buf->paddr = xsk_buff_raw_get_dma(xsk_pool,
+								      frag_desc.addr);
+				ena_buf->len = frag_desc.len;
+				ena_buf++;
+				tx_info->num_of_bufs++;
+				size += frag_desc.len;
+				tx_info->xsk_tx_nr_descs++;
+				desc = frag_desc;
+			}
+#endif /* ENA_XSK_MB_SUPPORT */
+
+			ena_tx_ctx.ena_bufs = tx_info->bufs;
+			ena_tx_ctx.num_bufs = tx_info->num_of_bufs;
 
 #ifdef ENA_HAVE_XSK_TX_METADATA
-		if (unlikely(is_tx_metadata_enabled)) {
-			struct xsk_tx_metadata *meta =
-				xsk_buff_get_metadata(xsk_pool, desc.addr);
+			if (unlikely(is_tx_metadata_enabled)) {
+				struct xsk_tx_metadata *meta =
+					xsk_buff_get_metadata(xsk_pool, desc.addr);
 
-			/* Save a pointer to completion metadata to fill it
-			 * later upon completion
-			 */
-			xsk_tx_metadata_to_compl(meta,
-						 &tx_info->xsk_meta_compl);
-		}
+				/* Save a pointer to completion metadata to fill
+				 * it later upon completion
+				 */
+				xsk_tx_metadata_to_compl(meta,
+							 &tx_info->xsk_meta_compl);
+			}
 #endif /* ENA_HAVE_XSK_TX_METADATA */
 
-		ena_tx_ctx.req_id = req_id;
+			ena_tx_ctx.req_id = req_id;
 
-		netif_dbg(tx_ring->adapter, tx_queued, tx_ring->netdev,
-			  "Queueing zc packet on q %d, %s DMA part (req-id %d)\n",
-			  tx_ring->qid, ena_tx_ctx.num_bufs ? "with" : "without", req_id);
+			netif_dbg(tx_ring->adapter, tx_queued, tx_ring->netdev,
+				  "Queueing zc packet on q %d, %s DMA part (req-id %d)\n",
+				  tx_ring->qid, ena_tx_ctx.num_bufs ? "with" : "without", req_id);
 
-		rc = ena_xmit_common(tx_ring->adapter,
-				     tx_ring,
-				     tx_info,
-				     &ena_tx_ctx,
-				     next_to_use,
-				     desc.len);
-		if (rc)
-			break;
+			rc = ena_xmit_common(tx_ring->adapter,
+					     tx_ring,
+					     tx_info,
+					     &ena_tx_ctx,
+					     next_to_use,
+					     size + push_len);
+			if (rc)
+				break;
 
-		total_pkts++;
-		total_bytes += desc.len;
+			total_pkts++;
+			total_bytes += size + push_len;
 
-		work_done++;
+			work_done++;
+		}
+
+		if (work_done && !tx_ring_released)
+			xsk_tx_release(xsk_pool);
 	}
 
 	if (work_done) {
@@ -865,7 +1092,6 @@ static bool ena_xdp_xmit_irq_zc(struct ena_ring *tx_ring,
 		tx_ring->tx_stats.xsk_bytes += total_bytes;
 		u64_stats_update_end(&tx_ring->syncp);
 
-		xsk_tx_release(xsk_pool);
 		ena_ring_tx_doorbell(tx_ring);
 	}
 
@@ -876,18 +1102,30 @@ static bool ena_xdp_xmit_irq_zc(struct ena_ring *tx_ring,
 
 static struct sk_buff *ena_xdp_rx_skb_zc(struct ena_ring *rx_ring, struct xdp_buff *xdp)
 {
-	u32 headroom, data_len;
+	u32 headroom, data_len, total_len;
 	struct sk_buff *skb;
 	void *data_addr;
 
-	/* Assuming single-page packets for XDP */
 	headroom  = xdp->data - xdp->data_hard_start;
 	data_len  = xdp->data_end - xdp->data;
 	data_addr = xdp->data;
 
-	/* allocate a skb to store the frags */
+	/* The skb must hold the whole reassembled packet: the linear head plus
+	 * every fragment. Sizing it for the first descriptor only and then
+	 * __skb_put()'ing each frag (the unchecked put, no tailroom check)
+	 * overruns the linear area and corrupts the adjacent skb_shared_info,
+	 * which later panics in skb_release_data() when the frag array is
+	 * walked.
+	 */
+	total_len = data_len;
+#ifdef ENA_XSK_MB_SUPPORT
+	if (xdp_buff_has_frags(xdp))
+		total_len += xdp_get_shared_info_from_buff(xdp)->xdp_frags_size;
+#endif /* ENA_XSK_MB_SUPPORT */
+
+	/* allocate a skb to store the data */
 	skb = napi_alloc_skb(rx_ring->napi,
-			     headroom + data_len);
+			     headroom + total_len);
 	if (unlikely(!skb)) {
 		ena_increase_stat(&rx_ring->rx_stats.skb_alloc_fail, 1,
 				  &rx_ring->syncp);
@@ -899,8 +1137,49 @@ static struct sk_buff *ena_xdp_rx_skb_zc(struct ena_ring *rx_ring, struct xdp_bu
 	skb_reserve(skb, headroom);
 	memcpy(__skb_put(skb, data_len), data_addr, data_len);
 
+#ifdef ENA_XSK_MB_SUPPORT
+	/* Copy frag data for multi-buffer packets (XDP_PASS path). The skb was
+	 * sized for headroom + data_len + xdp_frags_size above, so these puts
+	 * stay within the linear area. The bytes are copied out of the XSK
+	 * (net_iov-backed) buffers; the resulting skb is fully linear and never
+	 * references XSK memory as page frags.
+	 */
+	if (xdp_buff_has_frags(xdp)) {
+		struct skb_shared_info *sinfo = xdp_get_shared_info_from_buff(xdp);
+		int i;
+
+		for (i = 0; i < sinfo->nr_frags; i++) {
+			skb_frag_t *frag = &sinfo->frags[i];
+			u32 frag_len = skb_frag_size(frag);
+			void *frag_addr = skb_frag_address(frag);
+
+			memcpy(__skb_put(skb, frag_len), frag_addr, frag_len);
+		}
+	}
+#endif /* ENA_XSK_MB_SUPPORT */
+
 	return skb;
 }
+
+#ifdef ENA_XSK_MB_SUPPORT
+/* Drop the driver's references to a multi-buffer packet's fragment buffers
+ * (the head is handled by the caller). This must be done whenever the
+ * buffers have been freed or handed to the XDP framework, so that neither
+ * ring teardown (ena_xdp_free_rx_bufs_zc) nor refill (ena_alloc_rx_buffer)
+ * touches a buffer the driver no longer owns.
+ */
+static void ena_xdp_zc_unref_frags(struct ena_ring *rx_ring,
+				   struct ena_com_rx_ctx *ena_rx_ctx)
+{
+	int i;
+
+	for (i = 1; i < ena_rx_ctx->descs; i++) {
+		u16 req_id = ena_rx_ctx->ena_bufs[i].req_id;
+
+		rx_ring->rx_buffer_info[req_id].xdp = NULL;
+	}
+}
+#endif /* ENA_XSK_MB_SUPPORT */
 
 static bool ena_xdp_clean_rx_irq_zc(struct ena_ring *rx_ring,
 				    struct napi_struct *napi, int budget)
@@ -959,17 +1238,65 @@ static bool ena_xdp_clean_rx_irq_zc(struct ena_ring *rx_ring,
 
 		/* XDP multi-buffer packets not supported */
 		if (unlikely(ena_rx_ctx.descs > 1)) {
+#ifdef ENA_XSK_MB_SUPPORT
+			struct skb_shared_info *sinfo;
+
+			if (unlikely(ena_rx_ctx.descs - 1 > MAX_SKB_FRAGS)) {
+				netdev_err_once(rx_ring->netdev,
+						"xdp: too many frags (%d)\n",
+						ena_rx_ctx.descs);
+				ena_increase_stat(&rx_ring->rx_stats.xdp_drop, 1,
+						  &rx_ring->syncp);
+				xdp_verdict = ENA_XDP_RECYCLE;
+				goto consume_descs;
+			}
+
+			xdp_buff_set_frags_flag(xdp);
+			sinfo = xdp_get_shared_info_from_buff(xdp);
+			sinfo->nr_frags = 0;
+			sinfo->xdp_frags_size = 0;
+
+			for (i = 1; i < ena_rx_ctx.descs; i++) {
+				struct ena_rx_buffer *frag_info;
+				struct xdp_buff *frag_xdp;
+				u32 frag_len;
+
+				frag_info = &rx_ring->rx_buffer_info[
+					ena_rx_ctx.ena_bufs[i].req_id];
+				frag_xdp = frag_info->xdp;
+				frag_len = ena_rx_ctx.ena_bufs[i].len;
+
+				xsk_buff_set_size(frag_xdp, frag_len);
+				xsk_buff_dma_sync_for_cpu(frag_xdp,
+							  rx_ring->xsk_pool);
+
+				__skb_fill_page_desc_noacc(sinfo,
+							   sinfo->nr_frags,
+							   virt_to_page(frag_xdp->data_hard_start),
+							   XDP_PACKET_HEADROOM,
+							   frag_len);
+				sinfo->nr_frags++;
+				sinfo->xdp_frags_size += frag_len;
+				xsk_buff_add_frag(frag_xdp);
+			}
+#else
 			netdev_err_once(rx_ring->netdev,
 					"xdp: dropped unsupported multi-buffer packets\n");
 			ena_increase_stat(&rx_ring->rx_stats.xdp_drop, 1, &rx_ring->syncp);
 			xdp_verdict = ENA_XDP_RECYCLE;
-		} else if (likely(!!xdp_prog)) {
+#endif /* ENA_XSK_MB_SUPPORT */
+		}
+
+		if (likely(xdp_verdict == ENA_XDP_PASS) && likely(!!xdp_prog)) {
 #ifdef ENA_HAVE_XDP_HINTS_DEPS
 			ena_xdp_buff_fill(xdp, &ena_rx_ctx);
 #endif /* ENA_HAVE_XDP_HINTS_DEPS */
 			xdp_verdict = ena_xdp_execute(rx_ring, xdp, xdp_prog);
 		}
 
+#ifdef ENA_XSK_MB_SUPPORT
+consume_descs:
+#endif /* ENA_XSK_MB_SUPPORT */
 		/* Note that there can be several descriptors, since device
 		 * might not honor MTU
 		 */
@@ -988,9 +1315,30 @@ static bool ena_xdp_clean_rx_irq_zc(struct ena_ring *rx_ring,
 			total_len += xdp_len;
 			xdp_flags |= xdp_verdict;
 
-			/* Mark buffer as consumed when it is redirected or freed */
-			if (likely(xdp_verdict & (ENA_XDP_FORWARDED | ENA_XDP_DROP)))
+			/* FORWARDED: the XDP framework now owns the buffer(s)
+			 * and drains the frag chain from pool->xskb_list.
+			 * DROP: ena_xdp_return_buff() already freed them.
+			 * Either way just drop our references so teardown/refill
+			 * won't double-free.
+			 */
+			if (likely(xdp_verdict & (ENA_XDP_FORWARDED | ENA_XDP_DROP))) {
 				rx_info->xdp = NULL;
+#ifdef ENA_XSK_MB_SUPPORT
+				ena_xdp_zc_unref_frags(rx_ring, &ena_rx_ctx);
+			} else if (xdp_buff_has_frags(xdp)) {
+				/* RECYCLE of an assembled multi-buffer packet:
+				 * the head still carries XDP_FLAGS_HAS_FRAGS and
+				 * the frags are still linked in pool->xskb_list,
+				 * so reusing the buffers in place would leak that
+				 * stale state into the next packet. Free the whole
+				 * chain (this drains xskb_list) and drop our
+				 * references so refill reallocates clean buffers.
+				 */
+				xsk_buff_free(xdp);
+				rx_info->xdp = NULL;
+				ena_xdp_zc_unref_frags(rx_ring, &ena_rx_ctx);
+#endif /* ENA_XSK_MB_SUPPORT */
+			}
 
 			continue;
 		}
@@ -998,9 +1346,38 @@ static bool ena_xdp_clean_rx_irq_zc(struct ena_ring *rx_ring,
 		/* XDP PASS */
 		skb = ena_xdp_rx_skb_zc(rx_ring, xdp);
 		if (unlikely(!skb)) {
+#ifdef ENA_XSK_MB_SUPPORT
+			/* skb alloc failed: the descriptors were already queued
+			 * for refill by the consume loop above. For an assembled
+			 * multi-buffer packet we must still free the chain and
+			 * drop our references here, otherwise refill reuses the
+			 * head with XDP_FLAGS_HAS_FRAGS set and the frags still
+			 * linked in pool->xskb_list, leading to a later
+			 * double-free/UAF. Mirror the success-path cleanup below.
+			 */
+			if (xdp_buff_has_frags(xdp)) {
+				xsk_buff_free(xdp);
+				rx_info->xdp = NULL;
+				ena_xdp_zc_unref_frags(rx_ring, &ena_rx_ctx);
+			}
+#endif /* ENA_XSK_MB_SUPPORT */
 			rc = -ENOMEM;
 			break;
 		}
+
+#ifdef ENA_XSK_MB_SUPPORT
+		/* For an assembled multi-buffer packet the payload has now been
+		 * copied into the linear skb. Free the chain (drains
+		 * pool->xskb_list and clears the head's HAS_FRAGS state) and
+		 * drop our references so refill reallocates clean buffers
+		 * instead of reusing stale frag state.
+		 */
+		if (xdp_buff_has_frags(xdp)) {
+			xsk_buff_free(xdp);
+			rx_info->xdp = NULL;
+			ena_xdp_zc_unref_frags(rx_ring, &ena_rx_ctx);
+		}
+#endif /* ENA_XSK_MB_SUPPORT */
 
 		pkt_copy++;
 		work_done++;

--- a/kernel/linux/ena/kcompat.h
+++ b/kernel/linux/ena/kcompat.h
@@ -751,6 +751,10 @@ static inline void eth_hw_addr_set(struct net_device *dev, const u8 *addr)
 #define ENA_AF_XDP_SUPPORT
 #endif
 
+#if defined(ENA_AF_XDP_SUPPORT) && defined(ENA_HAVE_XSK_MULTI_BUFF)
+#define ENA_XSK_MB_SUPPORT
+#endif
+
 #if LINUX_VERSION_CODE < KERNEL_VERSION(4, 10, 0)
 #define NAPIF_STATE_SCHED BIT(NAPI_STATE_SCHED)
 #endif


### PR DESCRIPTION
Add multi-buffer (scatter-gather) support for AF_XDP zero-copy mode on kernels >= 6.6 that expose the xsk_buff_add_frag() API.

Tx path:
- Add a frame-atomic batch fast path (xsk_tx_peek_release_desc_batch) that guarantees complete frames are never truncated on the wire.
- Fall back to per-descriptor peek for shared-pool configurations.
- Track per-packet descriptor count (xsk_tx_nr_descs) for correct completion accounting.

Rx path:
- Assemble multi-descriptor packets into xdp_buff frag chains.
- Size XDP_PASS skbs for the full reassembled packet to prevent skb_shared_info corruption on __skb_put().
- Properly free frag chains on FORWARD/DROP/RECYCLE/alloc-failure to prevent double-free and use-after-free.

Advertise xdp_zc_max_segs clamped to min(tx_sgl, rx_sgl, MAX_SKB_FRAGS+1) so the stack never hands frames the datapath cannot fit.

Guarded by ENA_XSK_MB_SUPPORT (ENA_AF_XDP_SUPPORT && ENA_HAVE_XSK_MULTI_BUFF).

*Issue #, if available:*

*Description of changes:*

This challenge allows receiving and sending of Jumbo frames using AF_XDP + Zero copy with the ENA driver


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
