### PR TITLE
linux/ena: Support void page_pool_get_stats()

### DIFF
--- a/kernel/linux/ena/ena_ethtool.c
+++ b/kernel/linux/ena/ena_ethtool.c
@@ -383,8 +383,10 @@ void ena_fetch_page_pool_stats(struct ena_adapter *adapter)
 		memset(&stats, 0, sizeof(stats));
 		pool = rx_ring->page_pool;
 
-		if (!pool || !page_pool_get_stats(pool, &stats))
+		if (!pool)
 			continue;
+
+		page_pool_get_stats(pool, &stats);
 
 		u64_stats_update_begin(&rx_ring->syncp);
 		rx_ring->rx_stats.pp_alloc_fast = stats.alloc_stats.fast;


### PR DESCRIPTION
*Issue #, if available:*

https://github.com/amzn/amzn-drivers/issues/383

https://github.com/NixOS/nixpkgs/pull/554254

*Description of changes:*

Linux 7.2 changed page_pool_get_stats() to return void

see https://github.com/torvalds/linux/commit/81a4d039537a89e7619aa94c5b6db051ae0b180c

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
